### PR TITLE
feat(HACBS-712) Generate apiresourceschema

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download fedora environment dependencies # Would be nice to cache this somehow
-        run: sudo dnf -y install diffutils findutils gcc wget
+        run: sudo dnf -y install diffutils findutils gcc wget which jq
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
         uses: actions/cache@v2
         id: cache-operator-sdk
@@ -42,6 +42,16 @@ jobs:
           mkdir -p ~/bin
           cp ~/cache/operator-sdk-${OPERATOR_SDK_VERSION} ~/bin/operator-sdk
           echo "$HOME/bin" >> $GITHUB_PATH
+      - name: Regenerate executables with current environment packages
+        run: |
+          rm -f bin/kustomize bin/controller-gen
+          make kustomize controller-gen
+      - name: Install kcp tooling
+        run: |
+          sudo dnf -y install git
+          git clone https://github.com/kcp-dev/kcp ~/kcp
+          cd ~/kcp
+          WHAT=./cmd/kubectl-kcp make install
       - name: Cache go modules
         id: cache-mod
         uses: actions/cache@v2
@@ -86,6 +96,24 @@ jobs:
           then
             echo "generated sources are not up to date:"
             diff -r ../integration-service /tmp/integration-service
+            exit 1
+          fi
+      - name: Check kcp manifests
+        run: |
+          CONTROL_PLANE=kcp make generate manifests
+          if [[ ! -z $(git status ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen' -s) ]]
+          then
+            echo "generated kcp sources are not up to date:"
+            git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
+            exit 1
+          fi
+      - name: Check kubernetes manifests
+        run: |
+          CONTROL_PLANE=kubernetes make generate manifests
+          if [[ ! -z $(git status ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen' -s) ]]
+          then
+            echo "generated k8s sources are not up to date:"
+            git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
             exit 1
           fi
       - name: Run Go Tests

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 endif
 
+# CONTROL_PLANE defines the type of cluster that will be used. Possible values are kubernetes (default) and kcp.
+CONTROL_PLANE ?= kubernetes
+
 # DEFAULT_CHANNEL defines the default channel used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
@@ -92,6 +95,9 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+ifeq ($(CONTROL_PLANE), kcp)
+	hack/generate-kcp-api.sh ## Generate KCP APIResourceSchema from CRDs
+endif
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/config/kcp/apiexport_integration.yaml
+++ b/config/kcp/apiexport_integration.yaml
@@ -1,0 +1,9 @@
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: inetegration
+spec:
+  latestResourceSchemas:
+    - v202207220324.integrationtestscenarios.appstudio.redhat.com

--- a/config/kcp/apiresourceschema_integration.yaml
+++ b/config/kcp/apiresourceschema_integration.yaml
@@ -1,0 +1,112 @@
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v202207220324.integrationtestscenarios.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: IntegrationTestScenario
+    listKind: IntegrationTestScenarioList
+    plural: integrationtestscenarios
+    singular: integrationtestscenario
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.application
+      name: Application
+      type: string
+    name: v1alpha1
+    schema:
+      description: IntegrationTestScenario is the Schema for the integrationtestscenarios
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IntegrationTestScenarioSpec defines the desired state of IntegrationScenario
+          properties:
+            application:
+              description: Application that's associated with the IntegrationTestScenario
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+            bundle:
+              description: Tekton Bundle where to find the pipeline
+              type: string
+            contexts:
+              description: Contexts where this IntegrationTestScenario can be applied
+              items:
+                description: TestContext contains the name and values of a Test context
+                properties:
+                  description:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            environment:
+              description: Environment that will be utilized by the test pipeline
+              properties:
+                name:
+                  type: string
+                params:
+                  items:
+                    type: string
+                  type: array
+                type:
+                  type: string
+              required:
+              - name
+              - params
+              - type
+              type: object
+            params:
+              description: Params to pass to the pipeline
+              items:
+                description: PipelineParameter contains the name and values of a Tekton
+                  Pipeline parameter
+                properties:
+                  name:
+                    type: string
+                  value:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - name
+                - value
+                type: object
+              type: array
+            pipeline:
+              description: Release Tekton Pipeline to execute
+              type: string
+          required:
+          - application
+          - bundle
+          - pipeline
+          type: object
+        status:
+          description: IntegrationTestScenarioStatus defines the observed state of
+            IntegrationTestScenario
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---

--- a/config/kcp/kustomization.yaml
+++ b/config/kcp/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - apiexport_integration.yaml
+  - apiresourceschema_integration.yaml

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+if ! which kubectl-kcp; then
+  echo "kubectl-kcp required on path"
+  echo "you can install it with running:"
+  echo "    $ git clone https://github.com/kcp-dev/kcp && cd kcp && make install"
+  exit 1
+fi
+
+THIS_DIR="$(dirname "$(realpath "$0")")"
+CRD_DIR="$( realpath ${THIS_DIR}/../config/crd/bases)"
+KCP_API_DIR="$( realpath ${THIS_DIR}/../config/kcp)"
+
+KCP_API_SCHEMA_FILE_CURRENT="${KCP_API_DIR}/apiresourceschema_integration.yaml"
+KCP_API_SCHEMA_FILE_NEW="${KCP_API_DIR}/apiresourceschema_integration.yaml_new"
+cat << EOF > ${KCP_API_SCHEMA_FILE_NEW}
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+EOF
+
+# APIResourceSchema is immutable so when we want to update something, we actually have to create new version.
+# Version is defined by this prefix, which is taken from date. This will allow us to do new version each minute, which
+# should be hopefully enough granularity :)
+PREFIX=$( TZ="Etc/UTC" date +%Y%m%d%H%M )
+
+I=0
+for CRD in $( ls ${CRD_DIR} ); do
+  kubectl-kcp crd snapshot -f "${CRD_DIR}/${CRD}" --prefix v${PREFIX} >> ${KCP_API_SCHEMA_FILE_NEW}
+done
+
+# If there are some changes in new generated file, we replace old one. Otherwise just remove new file.
+# The regex is there to ignore name change, because we're updating date there so it is expected to change.
+# Ignored line looks like this:
+# '  name: v202207220324.integrationtestscenarios.appstudio.redhat.com'
+if ! diff -I '^  name: v[0-9]\{12\}\..*\.appstudio\.redhat\.com$' ${KCP_API_SCHEMA_FILE_CURRENT} ${KCP_API_SCHEMA_FILE_NEW} > /dev/null; then
+  mv ${KCP_API_SCHEMA_FILE_NEW} ${KCP_API_SCHEMA_FILE_CURRENT}
+  echo "updated KCP APIResourceSchema for interation service saved at '${KCP_API_SCHEMA_FILE_CURRENT}'"
+else
+  echo "no changes in KCP API"
+  rm ${KCP_API_SCHEMA_FILE_NEW}
+fi
+
+
+# now create APIExport and link all created APIResourceSchemas there
+KCP_API_EXPORT_FILE="${KCP_API_DIR}/apiexport_integration.yaml"
+cat << EOF > ${KCP_API_EXPORT_FILE}
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: inetegration
+spec:
+  latestResourceSchemas:
+EOF
+
+# match APIResourceSchema name pattern with date prefix
+for SCHEMA in $( cat ${KCP_API_SCHEMA_FILE_CURRENT} | grep -o "v[0-9]\{12\}\..*\.appstudio\.redhat\.com" ); do
+  echo "    - ${SCHEMA}" >> ${KCP_API_EXPORT_FILE}
+done
+
+cat << EOF > ${KCP_API_EXPORT_FILE}
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+$( cat ${KCP_API_EXPORT_FILE} )
+EOF


### PR DESCRIPTION
This commit adds the APIResourceSchema for the integration service. This
is needed for KCP integration. The generate-kcp-api.sh script is copied
from the has and spi repos.