### PR TITLE
feat[HACBS-463]-adding unit tests

### DIFF
--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -86,30 +86,6 @@ func NewIntegrationPipelineRun(prefix, namespace string, integrationTestScenario
 	return &IntegrationPipelineRun{pipelineRun}
 }
 
-// WithSpecialParams adds Pipeline reference, params to the PipelineRun.
-func (r *IntegrationPipelineRun) WithSpecialParams(integration *v1alpha1.IntegrationTestScenario) *IntegrationPipelineRun {
-	r.Spec.PipelineRef = &tektonv1beta1.PipelineRef{
-		Name:   integration.Spec.Pipeline,
-		Bundle: integration.Spec.Bundle,
-	}
-
-	valueType := tektonv1beta1.ParamTypeString
-
-	for _, param := range integration.Spec.Params {
-		if len(param.Value) > 0 {
-			valueType = tektonv1beta1.ParamTypeArray
-		}
-
-		r.WithExtraParam(param.Name, tektonv1beta1.ArrayOrString{
-			Type:      valueType,
-			StringVal: param.Value,
-			ArrayVal:  param.Values,
-		})
-	}
-
-	return r
-}
-
 // WithExtraParam adds an extra param to the Integration PipelineRun. If the parameter is not part of the Pipeline
 // definition, it will be silently ignored.
 func (r *IntegrationPipelineRun) WithExtraParam(name string, value tektonv1beta1.ArrayOrString) *IntegrationPipelineRun {

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -1,0 +1,177 @@
+package tekton_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hasv1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/gitops"
+	tekton "github.com/redhat-appstudio/integration-service/tekton"
+	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ExtraParams struct {
+	Name  string
+	Value tektonv1beta1.ArrayOrString
+}
+
+var _ = Describe("Integration pipeline", func() {
+
+	const (
+		prefix                  = "testpipeline"
+		namespace               = "default"
+		PipelineTypeIntegration = "integration"
+		applicationName         = "application-sample"
+		SampleRepoLink          = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+	)
+	var (
+		hasApp                    *hasv1alpha1.Application
+		hasSnapshot               *appstudioshared.ApplicationSnapshot
+		hasComp                   *hasv1alpha1.Component
+		newIntegrationPipelineRun *tekton.IntegrationPipelineRun
+		integrationTestScenario   *v1alpha1.IntegrationTestScenario
+		extraParams               *ExtraParams
+	)
+
+	BeforeEach(func() {
+
+		extraParams = &ExtraParams{
+			Name: "extraConfigPath",
+			Value: tektonv1beta1.ArrayOrString{
+				Type:      tektonv1beta1.ParamTypeString,
+				StringVal: "path/to/extra/config.yaml",
+			},
+		}
+
+		integrationTestScenario = &v1alpha1.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-pass",
+				Namespace: "default",
+
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/optional": "false",
+				},
+			},
+			Spec: v1alpha1.IntegrationTestScenarioSpec{
+				Application: "application-sample",
+				Bundle:      "quay.io/kpavic/test-bundle:component-pipeline-pass",
+				Pipeline:    "component-pipeline-pass",
+				Environment: v1alpha1.TestEnvironment{
+					Name:   "envname",
+					Type:   "POC",
+					Params: []string{},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, integrationTestScenario)).Should(Succeed())
+
+		//create new integration pipeline run from integration test scenario
+		newIntegrationPipelineRun = tekton.NewIntegrationPipelineRun(prefix, namespace, *integrationTestScenario)
+		Expect(k8sClient.Create(ctx, newIntegrationPipelineRun.AsPipelineRun())).Should(Succeed())
+
+		hasApp = &hasv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      applicationName,
+				Namespace: namespace,
+			},
+			Spec: hasv1alpha1.ApplicationSpec{
+				DisplayName: "application-sample",
+				Description: "This is an example application",
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
+
+		hasSnapshot = &appstudioshared.ApplicationSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.ApplicationSnapshotTypeLabel:      "component",
+					gitops.ApplicationSnapshotComponentLabel: "component-sample",
+				},
+			},
+			Spec: appstudioshared.ApplicationSnapshotSpec{
+				Application: hasApp.Name,
+				Components: []appstudioshared.ApplicationSnapshotComponent{
+					{
+						Name:           "component-sample",
+						ContainerImage: "testimage",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasSnapshot)).Should(Succeed())
+
+		hasComp = &hasv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "component-sample",
+				Namespace: "default",
+			},
+			Spec: hasv1alpha1.ComponentSpec{
+				ComponentName:  "component-sample",
+				Application:    "application-sample",
+				ContainerImage: "",
+				Source: hasv1alpha1.ComponentSource{
+					ComponentSourceUnion: hasv1alpha1.ComponentSourceUnion{
+						GitSource: &hasv1alpha1.GitSource{
+							URL: SampleRepoLink,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, integrationTestScenario)
+		_ = k8sClient.Delete(ctx, hasApp)
+		_ = k8sClient.Delete(ctx, hasSnapshot)
+		_ = k8sClient.Delete(ctx, hasComp)
+		_ = k8sClient.Delete(ctx, newIntegrationPipelineRun.AsPipelineRun())
+	})
+
+	Context("When managing a new IntegrationPipelineRun", func() {
+		It("can create a IntegrationPipelineRun and the returned object name is prefixed with the provided GenerateName", func() {
+			Expect(newIntegrationPipelineRun.ObjectMeta.Name).
+				Should(HavePrefix(prefix))
+			Expect(newIntegrationPipelineRun.ObjectMeta.Namespace).To(Equal(namespace))
+		})
+
+		It("can append extra params to IntegrationPipelineRun and these parameters are present in the object Specs", func() {
+			newIntegrationPipelineRun.WithExtraParam(extraParams.Name, extraParams.Value)
+			Expect(newIntegrationPipelineRun.Spec.Params[0].Name).To(Equal(extraParams.Name))
+			Expect(newIntegrationPipelineRun.Spec.Params[0].Value.StringVal).
+				To(Equal(extraParams.Value.StringVal))
+		})
+
+		It("can append the scenario Name and Namespace to a IntegrationPipelineRun object and that these label key names match the correct label format", func() {
+			newIntegrationPipelineRun.WithIntegrationLabels(integrationTestScenario)
+			Expect(newIntegrationPipelineRun.Labels["test.appstudio.openshift.io/scenario"]).
+				To(Equal(integrationTestScenario.Name))
+			Expect(newIntegrationPipelineRun.Labels["pipelines.appstudio.openshift.io/type"]).
+				To(Equal("test"))
+			Expect(newIntegrationPipelineRun.Namespace).
+				To(Equal(integrationTestScenario.Namespace))
+		})
+
+		It("can append labels that comes from ApplicationSnapshot to IntegrationPipelineRun and make sure that label value matches the snapshot name", func() {
+			newIntegrationPipelineRun.WithApplicationSnapshot(hasSnapshot)
+			Expect(newIntegrationPipelineRun.Labels["test.appstudio.openshift.io/snapshot"]).
+				To(Equal(hasSnapshot.Name))
+		})
+
+		It("can append labels comming from Application and Component to IntegrationPipelineRun and making sure that label values matches application and component names", func() {
+			newIntegrationPipelineRun.WithApplicationAndComponent(hasApp, hasComp)
+			Expect(newIntegrationPipelineRun.Labels["test.appstudio.openshift.io/component"]).
+				To(Equal(hasComp.Name))
+			Expect(newIntegrationPipelineRun.Labels["test.appstudio.openshift.io/application"]).
+				To(Equal(hasApp.Name))
+		})
+
+	})
+
+})

--- a/tekton/tekton_suite_test.go
+++ b/tekton/tekton_suite_test.go
@@ -1,13 +1,109 @@
 package tekton_test
 
+/*
+Copyright 2022.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import (
+	"context"
+	"go/build"
+	"path/filepath"
 	"testing"
+
+	"k8s.io/client-go/rest"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	integrationalpha1 "github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
+	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	appstudiotest "github.com/redhat-appstudio/release-service/test"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-func TestTekton(t *testing.T) {
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestControllerSnapshot(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Tekton Suite")
+	RunSpecs(t, "Tekton Test Suite")
 }
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	//adding required CRDs
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "config", "crd", "bases"),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", "github.com", "tektoncd",
+				"pipeline@v0.35.0", "config",
+			),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", appstudiotest.GetRelativeDependencyPath("application-service"), "config", "crd", "bases",
+			),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", appstudiotest.GetRelativeDependencyPath("managed-gitops"), "config", "crd", "bases",
+			),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	Expect(appstudiov1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(tektonv1beta1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(appstudioshared.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(releasev1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(integrationalpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+
+	k8sManager, _ := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             clientsetscheme.Scheme,
+		MetricsBindAddress: "0", // this disables metrics
+		LeaderElection:     false,
+	})
+
+	k8sClient = k8sManager.GetClient()
+	go func() {
+		defer GinkgoRecover()
+		Expect(k8sManager.Start(ctx)).To(Succeed())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
Adding unit tests covering new functionality added in HACBS-463
Output after running `make test`

```
KUBEBUILDER_ASSETS="/home/jsztuka/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64" go test ./... -coverprofile cover.out
?       github.com/redhat-appstudio/integration-service [no test files]
?       github.com/redhat-appstudio/integration-service/api/v1alpha1    [no test files]
ok      github.com/redhat-appstudio/integration-service/controllers     5.292s  coverage: 0.0% of statements
?       github.com/redhat-appstudio/integration-service/controllers/pipeline    [no test files]
?       github.com/redhat-appstudio/integration-service/controllers/results     [no test files]
ok      github.com/redhat-appstudio/integration-service/controllers/snapshot    9.487s  coverage: 69.6% of statements
ok      github.com/redhat-appstudio/integration-service/gitops  7.895s  coverage: 62.1% of statements
ok      github.com/redhat-appstudio/integration-service/helpers 0.026s  coverage: 18.5% of statements
?       github.com/redhat-appstudio/integration-service/release [no test files]
ok      github.com/redhat-appstudio/integration-service/tekton  8.010s  coverage: 72.4% of statements
```