### PR TITLE
feat(HACBS-1084): set ownerRef on ApplicationSnapshots and ASEBs

### DIFF
--- a/controllers/pipeline/pipeline_adapter.go
+++ b/controllers/pipeline/pipeline_adapter.go
@@ -19,6 +19,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -328,6 +329,11 @@ func (a *Adapter) prepareApplicationSnapshot(application *hasv1alpha1.Applicatio
 	}
 
 	applicationSnapshot := gitops.CreateApplicationSnapshot(application, &snapshotComponents)
+
+	err = ctrl.SetControllerReference(application, applicationSnapshot, a.client.Scheme())
+	if err != nil {
+		return nil, err
+	}
 
 	return applicationSnapshot, nil
 }


### PR DESCRIPTION
* Extract the ASEB handing functions from Ensure block
* Add `SetControllerReference` calls when creating new CRs
* Wrap snapshot adapter tests with additional `Eventually` calls
  * The `SetControllerReference` causes delays in tests
  * The added `Eventually` calls ensure that we wait for CRs to show up

Running the `SetControllerReference` function adds the application to the `ownerReferences` for a given CR, e.g.:
```
  ownerReferences:
    - apiVersion: appstudio.redhat.com/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: Application
      name: application-sample
      uid: 87b43fc8-e48b-4b92-8bd8-d61404f82c1f
```
