### PR TITLE
feat(HACBS-1150): add namePrefix to kcp-rbac

### DIFF
--- a/config/kcp-rbac/kustomization.yaml
+++ b/config/kcp-rbac/kustomization.yaml
@@ -1,3 +1,5 @@
+namePrefix: integration-service-
+
 resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource


### PR DESCRIPTION
The integration-service has overlapping cluster roles with the release service. This commit adds a namePrefix to the cluster roles in this repo so that they do not conflict with the release service.

Signed-off-by: Hongwei Liu hongliu@redhat.com