### PR TITLE
fix(HACBS-1383): use go v1.18 in the codecov GitHub action

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run tests
         run: make test
       - name: Codecov


### PR DESCRIPTION
This should resolve codecov run failures like https://github.com/redhat-appstudio/integration-service/actions/runs/3416438020/jobs/5686581511

Signed-off-by: dirgim <kpavic@redhat.com>