### PR TITLE
feat(HACBS-1232): create ephemeral Env/Binding

### DIFF
--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -280,6 +280,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		Expect(requiredIntegrationTestScenarios != nil && err == nil).To(BeTrue())
 		if requiredIntegrationTestScenarios != nil {
 			for _, requiredIntegrationTestScenario := range *requiredIntegrationTestScenarios {
+				if !reflect.ValueOf(requiredIntegrationTestScenario.Spec.Environment).IsZero() {
+					continue
+				}
 				requiredIntegrationTestScenario := requiredIntegrationTestScenario
 
 				integrationPipelineRuns := &tektonv1beta1.PipelineRunList{}

--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -127,6 +127,7 @@ func (r *Reconciler) getComponentFromSnapshot(context context.Context, snapshot 
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
 	EnsureAllReleasesExist() (results.OperationResult, error)
+	EnsureCreationOfEnvironment() (results.OperationResult, error)
 	EnsureAllIntegrationTestPipelinesExist() (results.OperationResult, error)
 	EnsureGlobalComponentImageUpdated() (results.OperationResult, error)
 	EnsureSnapshotEnvironmentBindingExist() (results.OperationResult, error)
@@ -142,6 +143,7 @@ func (r *Reconciler) ReconcileHandler(adapter AdapterInterface) (ctrl.Result, er
 		adapter.EnsureAllReleasesExist,
 		adapter.EnsureGlobalComponentImageUpdated,
 		adapter.EnsureSnapshotEnvironmentBindingExist,
+		adapter.EnsureCreationOfEnvironment,
 		adapter.EnsureAllIntegrationTestPipelinesExist,
 	}
 

--- a/gitops/environment.go
+++ b/gitops/environment.go
@@ -1,0 +1,93 @@
+package gitops
+
+import (
+	"github.com/google/uuid"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type CopiedEnvironment struct {
+	applicationapiv1alpha1.Environment
+}
+
+// AsEnvironment casts the IntegrationPipelineRun to PipelineRun, so it can be used in the Kubernetes client.
+func (r *CopiedEnvironment) AsEnvironment() *applicationapiv1alpha1.Environment {
+	return &r.Environment
+}
+
+// NewCopyOfExistingEnvironment gets the existing environment from current namespace and makes copy of it
+// new name is generated consisting of existing environment name and integrationTestScenario name
+// targetNamespace gets name of integrationTestScenario and uuid
+func NewCopyOfExistingEnvironment(existingEnvironment *applicationapiv1alpha1.Environment, namespace string, integrationTestScenario *v1alpha1.IntegrationTestScenario) *CopiedEnvironment {
+	id := uuid.New()
+	existingApiURL := existingEnvironment.Spec.UnstableConfigurationFields.KubernetesClusterCredentials.APIURL
+	existingClusterCreds := existingEnvironment.Spec.UnstableConfigurationFields.KubernetesClusterCredentials.ClusterCredentialsSecret
+
+	copiedEnvConfiguration := applicationapiv1alpha1.EnvironmentConfiguration{}
+	copiedEnvConfiguration = *existingEnvironment.Spec.Configuration.DeepCopy()
+	copiedIntTestScenario := *integrationTestScenario.Spec.Environment.Configuration.DeepCopy()
+	// if existing environment does not contain EnvVars, copy ones from IntegrationTestScenario
+	if existingEnvironment.Spec.Configuration.Env == nil {
+		copiedEnvConfiguration.Env = copiedIntTestScenario.Env
+	} else if len(copiedIntTestScenario.Env) != 0 {
+		for intEnvVars := range copiedIntTestScenario.Env {
+			envVarFound := false
+			for existingEnvVar := range copiedEnvConfiguration.Env {
+				// envVar names are matching? overwrite existing environment with one from ITS
+				if copiedIntTestScenario.Env[intEnvVars].Name == copiedEnvConfiguration.Env[existingEnvVar].Name {
+					copiedEnvConfiguration.Env[existingEnvVar].Value = copiedIntTestScenario.Env[intEnvVars].Value
+					envVarFound = true
+				}
+			}
+			if !envVarFound {
+				// in case that EnvVar from IntegrationTestScenario is not matching any EnvVar from existingEnv, add this ITS EnvVar to copied Environment
+				copiedEnvConfiguration.Env = append(copiedEnvConfiguration.Env, applicationapiv1alpha1.EnvVarPair{Name: copiedIntTestScenario.Env[intEnvVars].Name, Value: copiedIntTestScenario.Env[intEnvVars].Value})
+			}
+		}
+	}
+
+	copyOfEnvironment := applicationapiv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: existingEnvironment.Name + "-" + integrationTestScenario.Name + "-",
+			Namespace:    namespace,
+		},
+		Spec: applicationapiv1alpha1.EnvironmentSpec{
+			Type:               applicationapiv1alpha1.EnvironmentType_POC,
+			DisplayName:        existingEnvironment.Name + "-" + integrationTestScenario.Name,
+			Tags:               []string{"ephemeral"},
+			DeploymentStrategy: applicationapiv1alpha1.DeploymentStrategy_Manual,
+			Configuration:      copiedEnvConfiguration,
+			UnstableConfigurationFields: &applicationapiv1alpha1.UnstableEnvironmentConfiguration{
+				KubernetesClusterCredentials: applicationapiv1alpha1.KubernetesClusterCredentials{
+					TargetNamespace:          integrationTestScenario.Name + "-" + id.String(),
+					APIURL:                   existingApiURL,
+					ClusterCredentialsSecret: existingClusterCreds,
+				},
+			},
+		},
+	}
+	return &CopiedEnvironment{copyOfEnvironment}
+}
+
+// WithIntegrationLabels adds IntegrationTestScenario name as label to the copied environment.
+func (e *CopiedEnvironment) WithIntegrationLabels(integrationTestScenario *v1alpha1.IntegrationTestScenario) *CopiedEnvironment {
+	if e.ObjectMeta.Labels == nil {
+		e.ObjectMeta.Labels = map[string]string{}
+	}
+	e.ObjectMeta.Labels[SnapshotTestScenarioLabel] = integrationTestScenario.Name
+
+	return e
+
+}
+
+// WithSnapshot adds the name of snapshot as label to the copied environment.
+func (e *CopiedEnvironment) WithSnapshot(snapshot *applicationapiv1alpha1.Snapshot) *CopiedEnvironment {
+
+	if e.ObjectMeta.Labels == nil {
+		e.ObjectMeta.Labels = map[string]string{}
+	}
+	e.ObjectMeta.Labels[SnapshotLabel] = snapshot.Name
+
+	return e
+}

--- a/gitops/environment_test.go
+++ b/gitops/environment_test.go
@@ -1,0 +1,279 @@
+package gitops_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/gitops"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
+
+	var (
+		hasApp                   *applicationapiv1alpha1.Application
+		hasSnapshot              *applicationapiv1alpha1.Snapshot
+		envWithEnvVars           *applicationapiv1alpha1.Environment
+		copiedEnvWithEnvVars     *gitops.CopiedEnvironment
+		copiedEnvWithEnvVarsITS  *gitops.CopiedEnvironment
+		copiedEnvWithEnvVarsDiff *gitops.CopiedEnvironment
+		expectEnv                *applicationapiv1alpha1.Environment
+		hasIntTestSc             *v1alpha1.IntegrationTestScenario
+		hasIntTestScWithNoEnv    *v1alpha1.IntegrationTestScenario
+		hasIntTestScDiff         *v1alpha1.IntegrationTestScenario
+		sampleImage              string
+	)
+	const (
+		namespace       = "default"
+		applicationName = "application-sample"
+		componentName   = "component-sample"
+		snapshotName    = "snapshot-sample"
+	)
+
+	BeforeAll(func() {
+
+		expectEnv = &applicationapiv1alpha1.Environment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "expect-envname",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.EnvironmentSpec{
+				Configuration: applicationapiv1alpha1.EnvironmentConfiguration{
+					Env: []applicationapiv1alpha1.EnvVarPair{
+						{
+							Name:  "VAR_NAME",
+							Value: "VAR_VALUE_ENV",
+						},
+						{
+							Name:  "VAR_NAME_INT",
+							Value: "VAR_VALUE_INT",
+						},
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, expectEnv)).Should(Succeed())
+
+		hasApp = &applicationapiv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      applicationName,
+				Namespace: namespace,
+			},
+			Spec: applicationapiv1alpha1.ApplicationSpec{
+				DisplayName: "application-sample",
+				Description: "This is an example application",
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
+
+		envWithEnvVars = &applicationapiv1alpha1.Environment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "envname-with-env-vars",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.EnvironmentSpec{
+				Type:               "POC",
+				DisplayName:        "my-environment",
+				DeploymentStrategy: applicationapiv1alpha1.DeploymentStrategy_Manual,
+				Tags:               []string{},
+				Configuration: applicationapiv1alpha1.EnvironmentConfiguration{
+					Env: []applicationapiv1alpha1.EnvVarPair{
+						{
+							Name:  "VAR_NAME",
+							Value: "VAR_VALUE_ENV",
+						},
+					},
+				},
+				UnstableConfigurationFields: &applicationapiv1alpha1.UnstableEnvironmentConfiguration{
+					KubernetesClusterCredentials: applicationapiv1alpha1.KubernetesClusterCredentials{
+						TargetNamespace:          "example-pass-9664d7b0-54f5-409d-9abf-de9a8bbde59f",
+						APIURL:                   "https://api.sample.lab.upshift.rdu2.redhat.com:6443",
+						ClusterCredentialsSecret: "example-managed-environment-secret",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, envWithEnvVars)).Should(Succeed())
+
+		hasIntTestSc = &v1alpha1.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-pass",
+				Namespace: "default",
+
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/optional": "false",
+				},
+			},
+			Spec: v1alpha1.IntegrationTestScenarioSpec{
+				Application: "application-sample",
+				Bundle:      "quay.io/kpavic/test-bundle:component-pipeline-pass",
+				Pipeline:    "component-pipeline-pass",
+				Environment: v1alpha1.TestEnvironment{
+					Name: "envname",
+					Type: "POC",
+					Configuration: applicationapiv1alpha1.EnvironmentConfiguration{
+						Env: []applicationapiv1alpha1.EnvVarPair{
+							{
+								Name:  "VAR_NAME",
+								Value: "VAR_VALUE_INT",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasIntTestSc)).Should(Succeed())
+
+		hasIntTestScWithNoEnv = &v1alpha1.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-pass-no-env",
+				Namespace: "default",
+
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/optional": "false",
+				},
+			},
+			Spec: v1alpha1.IntegrationTestScenarioSpec{
+				Application: "application-sample",
+				Bundle:      "quay.io/kpavic/test-bundle:component-pipeline-pass",
+				Pipeline:    "component-pipeline-pass",
+				Environment: v1alpha1.TestEnvironment{
+					Name: "envname",
+					Type: "POC",
+					Configuration: applicationapiv1alpha1.EnvironmentConfiguration{
+						Env: []applicationapiv1alpha1.EnvVarPair{},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasIntTestScWithNoEnv)).Should(Succeed())
+
+		hasIntTestScDiff = &v1alpha1.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-pass-diff",
+				Namespace: "default",
+
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/optional": "false",
+				},
+			},
+			Spec: v1alpha1.IntegrationTestScenarioSpec{
+				Application: "application-sample",
+				Bundle:      "quay.io/kpavic/test-bundle:component-pipeline-pass",
+				Pipeline:    "component-pipeline-pass",
+				Environment: v1alpha1.TestEnvironment{
+					Name: "envname",
+					Type: "POC",
+					Configuration: applicationapiv1alpha1.EnvironmentConfiguration{
+						Env: []applicationapiv1alpha1.EnvVarPair{
+							{
+								Name:  "VAR_NAME_INT",
+								Value: "VAR_VALUE_INT",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasIntTestScDiff)).Should(Succeed())
+
+	})
+
+	BeforeEach(func() {
+		sampleImage = "quay.io/redhat-appstudio/sample-image:latest"
+
+		hasSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      snapshotName,
+				Namespace: namespace,
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:      gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel: componentName,
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           componentName,
+						ContainerImage: sampleImage,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasSnapshot)).Should(Succeed())
+
+		//create copy of environment with env Vars from ITS
+		copiedEnvWithEnvVars = gitops.NewCopyOfExistingEnvironment(envWithEnvVars, namespace, hasIntTestSc)
+		Expect(k8sClient.Create(ctx, copiedEnvWithEnvVars.AsEnvironment())).Should(Succeed())
+		//create copy of environment with env Vars from existing env
+		copiedEnvWithEnvVarsITS = gitops.NewCopyOfExistingEnvironment(envWithEnvVars, namespace, hasIntTestScWithNoEnv)
+		Expect(k8sClient.Create(ctx, copiedEnvWithEnvVarsITS.AsEnvironment())).Should(Succeed())
+		//create copy of environment with env Vars from both existing env and ITS
+		copiedEnvWithEnvVarsDiff = gitops.NewCopyOfExistingEnvironment(envWithEnvVars, namespace, hasIntTestScDiff)
+		Expect(k8sClient.Create(ctx, copiedEnvWithEnvVarsDiff.AsEnvironment())).Should(Succeed())
+
+		Eventually(func() error {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      hasSnapshot.Name,
+				Namespace: namespace,
+			}, hasSnapshot)
+			return err
+		}, time.Second*10).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := k8sClient.Delete(ctx, hasSnapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	AfterAll(func() {
+		err := k8sClient.Delete(ctx, hasApp)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasIntTestSc)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasIntTestScWithNoEnv)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasIntTestScDiff)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, envWithEnvVars)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+
+	})
+	Context("When copying an existing environment", func() {
+		It("can create a IntegrationPipelineRun and the returned object name is prefixed with the provided GenerateName", func() {
+			Expect(copiedEnvWithEnvVars.ObjectMeta.Name).
+				Should(HavePrefix(envWithEnvVars.Name + "-" + hasIntTestSc.Name + "-"))
+			Expect(copiedEnvWithEnvVars.ObjectMeta.Namespace).To(Equal(hasApp.ObjectMeta.Namespace))
+		})
+		It("existing env has envVars defined, ITS(integrationTestScenario) has the same envVar but different value, copied env should have envVar from ITS", func() {
+			Expect(copiedEnvWithEnvVars.Spec.Configuration.Env).To(Equal(hasIntTestSc.Spec.Environment.Configuration.Env))
+		})
+		It("existing env has envVars defined, ITS has NO envVar defined, copied env should have envVar exisitng env", func() {
+			Expect(copiedEnvWithEnvVarsITS.Spec.Configuration.Env).To(Equal(envWithEnvVars.Spec.Configuration.Env))
+		})
+		It("existing env has envVars defines, ITS has envVars defined, copied env should have updated envVars from existing evironment and new ones from ITS", func() {
+			Expect(copiedEnvWithEnvVarsDiff.Spec.Configuration.Env).To(Equal(expectEnv.Spec.Configuration.Env))
+		})
+
+		It("can append labels that comes from Snapshot to Environment and make sure that label value matches the snapshot name", func() {
+			copiedEnvWithEnvVarsDiff.WithSnapshot(hasSnapshot)
+			Expect(copiedEnvWithEnvVarsDiff.Labels["appstudio.openshift.io/snapshot"]).
+				To(Equal(hasSnapshot.Name))
+		})
+
+		It("can append labels that comes from IntegrationTestScenario to Environment and make sure that label value matches the snapshot name", func() {
+			copiedEnvWithEnvVarsDiff.WithIntegrationLabels(hasIntTestSc)
+			Expect(copiedEnvWithEnvVarsDiff.Labels["test.appstudio.openshift.io/scenario"]).
+				To(Equal(hasIntTestSc.Name))
+		})
+	})
+
+})

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -17,6 +17,9 @@ const (
 	// SnapshotTypeLabel contains the type of the Snapshot.
 	SnapshotTypeLabel = "test.appstudio.openshift.io/type"
 
+	// SnapshotLabel contains the name of the Snapshot within appstudio
+	SnapshotLabel = "appstudio.openshift.io/snapshot"
+
 	// SnapshotComponentLabel contains the name of the updated Snapshot component.
 	SnapshotComponentLabel = "test.appstudio.openshift.io/component"
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.1.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-github/v45 v45.2.0
+	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.5.0
 	github.com/onsi/gomega v1.24.1
@@ -56,7 +57,6 @@ require (
 	github.com/google/go-containerregistry v0.12.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect


### PR DESCRIPTION
Signed-off-by: jsztuka <jsztuka@redhat.com>

Adding a logic for creation of ephemeral environments.
Order of logic:

Integration service checks `integrationTestScenario` for presence of env attribute.
When the attribute exists - it check if the environment exist.
In case it does - create copy of this environment with updated envVars from IntegrationTestScenario.
Envs are created by this pattern: `IntegrationTestScenario x snapshot`
Corresponding labels are attached to newly created environment - snapshot, integrationTestScenario
For each snapshot the environmentbinding is created also.

Example targetNamespace that was created by process: `example-its-example-b81eabe8-6e53-425c-970c-0eb0baa0214b`
