### PR TITLE
tekton-ci: Use volumeClaimTemplate instead of static PVC

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -18,9 +18,12 @@ spec:
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
-  serviceAccountName: pipeline
   workspaces:
     - name: workspace
-      persistentVolumeClaim:
-        claimName: app-studio-default-workspace
-      subPath: integration-service-check-{{ revision }}
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -25,8 +25,12 @@ spec:
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
-  workspaces: 
-   - name: workspace 
-     persistentVolumeClaim: 
-        claimName: app-studio-default-workspace 
-     subPath: integration-service-push-{{ revision }}
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi


### PR DESCRIPTION
volumeClaimTemplate provides PVC cleanup out-of-box.