### PR TITLE
feat(HACBS-1215): use the Red Hat go 1.18 image in the Integration service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
-
-WORKDIR /workspace
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18 as builder
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -24,11 +22,10 @@ COPY git/ git/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/manager .
+# Use ubi-minimal as minimal base image to package the manager binary
+# Refer to https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 for more details
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+COPY --from=builder /opt/app-root/src/manager /
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Signed-off-by: Hongwei Liu <hongliu@redhat.com>