### PR TITLE
fix(HACBS-1586): separate logic for getting existing pipelineRuns

### DIFF
--- a/controllers/pipeline/pipeline_adapter.go
+++ b/controllers/pipeline/pipeline_adapter.go
@@ -311,7 +311,7 @@ func (a *Adapter) getAllPipelineRunsForSnapshot(snapshot *applicationapiv1alpha1
 	for _, integrationTestScenario := range *integrationTestScenarios {
 		integrationTestScenario := integrationTestScenario // G601
 		if a.pipelineRun.Labels[tekton.ScenarioNameLabel] != integrationTestScenario.Name {
-			integrationPipelineRun, err := helpers.GetLatestPipelineRunForSnapshotAndScenario(a.client, a.context, a.application, snapshot, &integrationTestScenario)
+			integrationPipelineRun, err := helpers.GetLatestPipelineRunForSnapshotAndScenario(a.client, a.context, snapshot, &integrationTestScenario)
 			if err != nil {
 				return nil, err
 			}

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -79,16 +79,18 @@ func (a *Adapter) EnsureAllIntegrationTestPipelinesExist() (results.OperationRes
 			"IntegrationTestScenarios", len(*integrationTestScenarios))
 		for _, integrationTestScenario := range *integrationTestScenarios {
 			integrationTestScenario := integrationTestScenario //G601
-			integrationPipelineRun, err := helpers.GetLatestPipelineRunForSnapshotAndScenario(a.client, a.context, a.application, a.snapshot, &integrationTestScenario)
+			integrationPipelineRuns, err := helpers.GetAllPipelineRunsForSnapshotAndScenario(a.client, a.context, a.snapshot, &integrationTestScenario)
 			if err != nil {
-				a.logger.Error(err, "Failed to get latest pipelineRun for snapshot and scenario",
-					"integrationPipelineRun:", integrationPipelineRun)
+				a.logger.Error(err, "Failed to get pipelineRuns for snapshot and scenario",
+					"Snapshot.Name:", a.snapshot.Name,
+					"IntegrationTestScenario.Name", integrationTestScenario.Name)
 				return results.RequeueOnErrorOrStop(err)
 			}
-			if integrationPipelineRun != nil {
-				a.logger.Info("Found existing integrationPipelineRun",
+			if integrationPipelineRuns != nil && len(*integrationPipelineRuns) > 0 {
+				a.logger.Info("Found existing integrationPipelineRuns",
+					"Snapshot.Name", a.snapshot.Name,
 					"IntegrationTestScenario.Name", integrationTestScenario.Name,
-					"integrationPipelineRun.Name", integrationPipelineRun.Name)
+					"len(integrationPipelineRuns)", len(*integrationPipelineRuns))
 			} else {
 				a.logger.Info("Creating new pipelinerun for integrationTestscenario",
 					"IntegrationTestScenario.Name", integrationTestScenario.Name,

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -121,7 +121,9 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 		for _, integrationTestScenario := range *integrationTestScenarios {
 			integrationTestScenario := integrationTestScenario //G601
-			integrationPipelineRun, err := helpers.GetLatestPipelineRunForSnapshotAndScenario(k8sClient, ctx, hasApp, hasSnapshot, &integrationTestScenario)
+			integrationPipelineRuns, err := helpers.GetAllPipelineRunsForSnapshotAndScenario(k8sClient, ctx, hasSnapshot, &integrationTestScenario)
+			Expect(err != nil && integrationPipelineRuns == nil)
+			integrationPipelineRun, err := helpers.GetLatestPipelineRunForSnapshotAndScenario(k8sClient, ctx, hasSnapshot, &integrationTestScenario)
 			Expect(err != nil && integrationPipelineRun == nil)
 		}
 		pipelineRunOutcome, err := helpers.CalculateIntegrationPipelineRunOutcome(logger, testpipelineRun)
@@ -153,7 +155,10 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 					return len(integrationPipelineRuns.Items) > 0 && err == nil
 				}, time.Second*10).Should(BeTrue())
 
-				integrationPipelineRun, err := helpers.GetLatestPipelineRunForSnapshotAndScenario(k8sClient, ctx, hasApp, hasSnapshot, &requiredIntegrationTestScenario)
+				allFoundIntegrationPipelineRuns, err := helpers.GetAllPipelineRunsForSnapshotAndScenario(k8sClient, ctx, hasSnapshot, &requiredIntegrationTestScenario)
+				Expect(err != nil && integrationPipelineRuns != nil && len(*allFoundIntegrationPipelineRuns) > 0)
+
+				integrationPipelineRun, err := helpers.GetLatestPipelineRunForSnapshotAndScenario(k8sClient, ctx, hasSnapshot, &requiredIntegrationTestScenario)
 				Expect(err != nil && integrationPipelineRun == nil)
 
 				pipelineRunOutcome, err := helpers.CalculateIntegrationPipelineRunOutcome(logger, integrationPipelineRun)


### PR DESCRIPTION
The goal of this fix is for Integration service to correctly detect that an integration pipelineRun is already running when the snapshot controller is triggered before the existing pipelineRun finishes

* Add GetAllPipelineRunsForSnapshotAndScenario function
* Use the above function in EnsureAllIntegrationTestPipelinesExist
* Look for pipelineRuns in the snapshot's namespace
* Update unit tests accordingly

Signed-off-by: dirgim <kpavic@redhat.com>