### PR TITLE
fix(HACBS-1576): fix composite snapshot checking

### DIFF
--- a/controllers/pipeline/pipeline_adapter.go
+++ b/controllers/pipeline/pipeline_adapter.go
@@ -153,8 +153,8 @@ func (a *Adapter) EnsureSnapshotPassedAllTests() (results.OperationResult, error
 	}
 
 	// If the snapshot is a component type, check if the global component list changed in the meantime and
-	// create a composite snapshot if it did.
-	if existingSnapshot.Labels != nil && existingSnapshot.Labels[gitops.SnapshotTypeLabel] == gitops.SnapshotComponentType && !gitops.IsSnapshotCreatedByPACPullRequestEvent(existingSnapshot) {
+	// create a composite snapshot if it did. Does not apply for PAC pull request events.
+	if a.component != nil && helpers.HasLabelWithValue(existingSnapshot, gitops.SnapshotTypeLabel, gitops.SnapshotComponentType) && !gitops.IsSnapshotCreatedByPACPullRequestEvent(existingSnapshot) {
 		compositeSnapshot, err := a.createCompositeSnapshotsIfConflictExists(a.application, a.component, existingSnapshot)
 		if err != nil {
 			a.logger.Error(err, "Failed to determine if a composite snapshot needs to be created because of a conflict",


### PR DESCRIPTION
Follow-on fix for a edge case error that happens if the component can't be found (because of a label mismatch caused by HACBS-1576 or an issue with manual/e2e testing) when the pipeline controller runs the composite snapshot check.

* Check for component existence before running composite logic
* Use the HasLabelWithValue to check Snapshot type

Signed-off-by: dirgim <kpavic@redhat.com>