### PR TITLE
feat(HACBS-1562): Remove HACBS keyword from integration-service codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# HACBS Integration Service
-The HACBS Integration Service is a Kubernetes operator to control the integration and testing of HACBS-managed 
+# Stonesoup Integration Service
+The Stonesoup Integration Service is a Kubernetes operator to control the integration and testing of Stonesoup-managed 
 Application Component builds in Red Hat AppStudio.
 
 ## Running, building and testing the operator

--- a/controllers/pipeline/pipeline_adapter.go
+++ b/controllers/pipeline/pipeline_adapter.go
@@ -165,7 +165,7 @@ func (a *Adapter) EnsureSnapshotPassedAllTests() (results.OperationResult, error
 			existingSnapshot, err := gitops.MarkSnapshotAsFailed(a.client, a.context, existingSnapshot,
 				"The global component list has changed in the meantime, superseding with a composite snapshot")
 			if err != nil {
-				a.logger.Error(err, "Failed to Update Snapshot HACBSTestSucceeded status")
+				a.logger.Error(err, "Failed to Update Snapshot StonesoupTestSucceeded status")
 				return results.RequeueWithError(err)
 			}
 			a.logger.Info("The global component list has changed in the meantime, marking snapshot as failed",
@@ -179,7 +179,7 @@ func (a *Adapter) EnsureSnapshotPassedAllTests() (results.OperationResult, error
 	if allIntegrationPipelineRunsPassed {
 		existingSnapshot, err = gitops.MarkSnapshotAsPassed(a.client, a.context, existingSnapshot, "All Integration Pipeline tests passed")
 		if err != nil {
-			a.logger.Error(err, "Failed to Update Snapshot HACBSTestSucceeded status")
+			a.logger.Error(err, "Failed to Update Snapshot StonesoupTestSucceeded status")
 			return results.RequeueWithError(err)
 		}
 		a.logger.Info("All Integration PipelineRuns succeeded, marking Snapshot as succeeded",
@@ -188,7 +188,7 @@ func (a *Adapter) EnsureSnapshotPassedAllTests() (results.OperationResult, error
 	} else {
 		existingSnapshot, err = gitops.MarkSnapshotAsFailed(a.client, a.context, existingSnapshot, "Some Integration pipeline tests failed")
 		if err != nil {
-			a.logger.Error(err, "Failed to Update Snapshot HACBSTestSucceeded status")
+			a.logger.Error(err, "Failed to Update Snapshot StonesoupTestSucceeded status")
 			return results.RequeueWithError(err)
 		}
 		a.logger.Info("Some tests within Integration PipelineRuns failed, marking Snapshot as failed",

--- a/controllers/pipeline/pipeline_adapter_test.go
+++ b/controllers/pipeline/pipeline_adapter_test.go
@@ -271,7 +271,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 							TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
 								TaskRunResults: []tektonv1beta1.TaskRunResult{
 									{
-										Name:  "HACBS_TEST_OUTPUT",
+										Name:  "Stonesoup_TEST_OUTPUT",
 										Value: *tektonv1beta1.NewArrayOrString("{\"result\":\"SUCCESS\",\"timestamp\":\"1665405317\",\"failures\":0,\"successes\":1}"),
 									},
 								},

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -59,7 +59,7 @@ func NewAdapter(snapshot *applicationapiv1alpha1.Snapshot, application *applicat
 // associated with the Snapshot and the Application's IntegrationTestScenarios exist.
 // Otherwise, it will create new Releases for each ReleasePlan.
 func (a *Adapter) EnsureAllIntegrationTestPipelinesExist() (results.OperationResult, error) {
-	if gitops.HaveHACBSTestsFinished(a.snapshot) {
+	if gitops.HaveStonesoupTestsFinished(a.snapshot) {
 		a.logger.Info("The Snapshot has finished testing.")
 		return results.ContinueProcessing()
 	}
@@ -144,7 +144,7 @@ func (a *Adapter) EnsureAllIntegrationTestPipelinesExist() (results.OperationRes
 // EnsureGlobalComponentImageUpdated is an operation that ensure the ContainerImage in the Global Candidate List
 // being updated when the Snapshot passed all the integration tests
 func (a *Adapter) EnsureGlobalComponentImageUpdated() (results.OperationResult, error) {
-	if (a.component != nil) && gitops.HaveHACBSTestsSucceeded(a.snapshot) && !gitops.IsSnapshotCreatedByPACPullRequestEvent(a.snapshot) {
+	if (a.component != nil) && gitops.HaveStonesoupTestsSucceeded(a.snapshot) && !gitops.IsSnapshotCreatedByPACPullRequestEvent(a.snapshot) {
 		patch := client.MergeFrom(a.component.DeepCopy())
 		for _, component := range a.snapshot.Spec.Components {
 			if component.Name == a.component.Name {
@@ -165,8 +165,8 @@ func (a *Adapter) EnsureGlobalComponentImageUpdated() (results.OperationResult, 
 // to the Snapshot and the Application's ReleasePlans exist.
 // Otherwise, it will create new Releases for each ReleasePlan.
 func (a *Adapter) EnsureAllReleasesExist() (results.OperationResult, error) {
-	if !gitops.HaveHACBSTestsSucceeded(a.snapshot) {
-		a.logger.Info("The Snapshot hasn't been marked as HACBSTestSucceeded, holding off on releasing.")
+	if !gitops.HaveStonesoupTestsSucceeded(a.snapshot) {
+		a.logger.Info("The Snapshot hasn't been marked as StonesoupTestSucceeded, holding off on releasing.")
 		return results.ContinueProcessing()
 	}
 
@@ -202,8 +202,8 @@ func (a *Adapter) EnsureAllReleasesExist() (results.OperationResult, error) {
 // SnapshotEnvironmentBindings for non-ephemeral root environments point to the newly constructed snapshot.
 // If the bindings don't already exist, it will create new ones for each of the environments.
 func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (results.OperationResult, error) {
-	if !gitops.HaveHACBSTestsSucceeded(a.snapshot) {
-		a.logger.Info("The Snapshot hasn't been marked as HACBSTestSucceeded, holding off on deploying.")
+	if !gitops.HaveStonesoupTestsSucceeded(a.snapshot) {
+		a.logger.Info("The Snapshot hasn't been marked as StonesoupTestSucceeded, holding off on deploying.")
 		return results.ContinueProcessing()
 	}
 

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -300,9 +300,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		}
 	})
 
-	It("ensures all Releases exists when HACBSTests succeeded", func() {
+	It("ensures all Releases exists when StonesoupTests succeeded", func() {
 		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
-		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshot)).To(BeTrue())
+		Expect(gitops.HaveStonesoupTestsSucceeded(hasSnapshot)).To(BeTrue())
 
 		Eventually(func() bool {
 			result, err := adapter.EnsureAllReleasesExist()
@@ -320,7 +320,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 	It("ensures global Component Image will not be updated in the PR context", func() {
 
 		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshotPR, "test passed")
-		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshotPR)).To(BeTrue())
+		Expect(gitops.HaveStonesoupTestsSucceeded(hasSnapshotPR)).To(BeTrue())
 
 		Eventually(func() bool {
 			result, err := adapter.EnsureGlobalComponentImageUpdated()
@@ -330,9 +330,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		Expect(hasComp.Spec.ContainerImage).To(Equal(""))
 	})
 
-	It("ensures global Component Image updated when HACBSTests succeeded", func() {
+	It("ensures global Component Image updated when StonesoupTests succeeded", func() {
 		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
-		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshot)).To(BeTrue())
+		Expect(gitops.HaveStonesoupTestsSucceeded(hasSnapshot)).To(BeTrue())
 
 		Eventually(func() bool {
 			result, err := adapter.EnsureGlobalComponentImageUpdated()
@@ -343,17 +343,17 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 	})
 
-	It("no error from ensuring global Component Image updated when HACBSTests failed", func() {
+	It("no error from ensuring global Component Image updated when StonesoupTests failed", func() {
 		gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
-		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshot)).To(BeFalse())
+		Expect(gitops.HaveStonesoupTestsSucceeded(hasSnapshot)).To(BeFalse())
 		result, err := adapter.EnsureGlobalComponentImageUpdated()
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(result.CancelRequest).To(BeFalse())
 	})
 
-	It("no error from ensuring all Releases exists function when HACBSTests failed", func() {
+	It("no error from ensuring all Releases exists function when StonesoupTests failed", func() {
 		gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
-		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshot)).To(BeFalse())
+		Expect(gitops.HaveStonesoupTestsSucceeded(hasSnapshot)).To(BeFalse())
 		Eventually(func() bool {
 			result, err := adapter.EnsureAllReleasesExist()
 			return !result.CancelRequest && err == nil
@@ -362,7 +362,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 	It("ensures snapshot environmentBinding exist", func() {
 		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
-		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshot)).To(BeTrue())
+		Expect(gitops.HaveStonesoupTestsSucceeded(hasSnapshot)).To(BeTrue())
 		Eventually(func() bool {
 			result, err := adapter.EnsureSnapshotEnvironmentBindingExist()
 			return !result.CancelRequest && err == nil

--- a/gitops/gitops_test.go
+++ b/gitops/gitops_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 	It("ensures Snapshot Environment Binding doesn't exist", func() {
 		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
-		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshot)).To(BeTrue())
+		Expect(gitops.HaveStonesoupTestsSucceeded(hasSnapshot)).To(BeTrue())
 
 		Eventually(func() bool {
 			snapshotEnvironmentBinding, err := gitops.FindExistingSnapshotEnvironmentBinding(k8sClient, ctx, hasApp, &env)
@@ -152,7 +152,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 	It("ensures Binding Component is created", func() {
 		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
-		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshot)).To(BeTrue())
+		Expect(gitops.HaveStonesoupTestsSucceeded(hasSnapshot)).To(BeTrue())
 		bindingComponents := gitops.NewBindingComponents([]applicationapiv1alpha1.Component{*hasComp})
 		Expect(bindingComponents != nil).To(BeTrue())
 	})

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -59,26 +59,26 @@ const (
 	// PipelineAsCodeGitHubProviderType is the git provider type for a GitHub event which triggered the pipelinerun in build service.
 	PipelineAsCodeGitHubProviderType = "github"
 
-	//HACBSTestSuceededCondition is the condition for marking if the HACBS Tests succeeded for the Snapshot.
-	HACBSTestSuceededCondition = "HACBSTestSucceeded"
+	//StonesoupTestSuceededCondition is the condition for marking if the Stonesoup Tests succeeded for the Snapshot.
+	StonesoupTestSuceededCondition = "StonesoupTestSucceeded"
 
-	// HACBSIntegrationStatusCondition is the condition for marking the HACBS integration status of the Snapshot.
-	HACBSIntegrationStatusCondition = "HACBSIntegrationStatus"
+	// StonesoupIntegrationStatusCondition is the condition for marking the Stonesoup integration status of the Snapshot.
+	StonesoupIntegrationStatusCondition = "StonesoupIntegrationStatus"
 
-	// HACBSTestSuceededConditionPassed is the reason that's set when the HACBS tests succeed.
-	HACBSTestSuceededConditionPassed = "Passed"
+	// StonesoupTestSuceededConditionPassed is the reason that's set when the Stonesoup tests succeed.
+	StonesoupTestSuceededConditionPassed = "Passed"
 
-	// HACBSTestSuceededConditionFailed is the reason that's set when the HACBS tests fail.
-	HACBSTestSuceededConditionFailed = "Failed"
+	// StonesoupTestSuceededConditionFailed is the reason that's set when the Stonesoup tests fail.
+	StonesoupTestSuceededConditionFailed = "Failed"
 
-	// HACBSIntegrationStatusInvalid is the reason that's set when the HACBS integration gets into an invalid state.
-	HACBSIntegrationStatusInvalid = "Invalid"
+	// StonesoupIntegrationStatusInvalid is the reason that's set when the Stonesoup integration gets into an invalid state.
+	StonesoupIntegrationStatusInvalid = "Invalid"
 
-	//HACBSIntegrationStatusInProgress is the reason that's set when the HACBS tests gets into an in progress state.
-	HACBSIntegrationStatusInProgress = "InProgress"
+	//StonesoupIntegrationStatusInProgress is the reason that's set when the Stonesoup tests gets into an in progress state.
+	StonesoupIntegrationStatusInProgress = "InProgress"
 
-	//HACBSIntegrationStatusFinished is the reason that's set when the HACBS tests finish.
-	HACBSIntegrationStatusFinished = "Finished"
+	//StonesoupIntegrationStatusFinished is the reason that's set when the Stonesoup tests finish.
+	StonesoupIntegrationStatusFinished = "Finished"
 )
 
 var (
@@ -86,14 +86,14 @@ var (
 	SnapshotComponentLabel = tekton.ComponentNameLabel
 )
 
-// MarkSnapshotAsPassed updates the HACBS Test succeeded condition for the Snapshot to passed.
+// MarkSnapshotAsPassed updates the Stonesoup Test succeeded condition for the Snapshot to passed.
 // If the patch command fails, an error will be returned.
 func MarkSnapshotAsPassed(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	meta.SetStatusCondition(&snapshot.Status.Conditions, metav1.Condition{
-		Type:    HACBSTestSuceededCondition,
+		Type:    StonesoupTestSuceededCondition,
 		Status:  metav1.ConditionTrue,
-		Reason:  HACBSTestSuceededConditionPassed,
+		Reason:  StonesoupTestSuceededConditionPassed,
 		Message: message,
 	})
 	SetSnapshotIntegrationStatusAsFinished(snapshot, "Marking snapshot integration status condition as finished since the testing is passed")
@@ -104,14 +104,14 @@ func MarkSnapshotAsPassed(adapterClient client.Client, ctx context.Context, snap
 	return snapshot, nil
 }
 
-// MarkSnapshotAsFailed updates the HACBS Test succeeded condition for the Snapshot to failed.
+// MarkSnapshotAsFailed updates the Stonesoup Test succeeded condition for the Snapshot to failed.
 // If the patch command fails, an error will be returned.
 func MarkSnapshotAsFailed(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	meta.SetStatusCondition(&snapshot.Status.Conditions, metav1.Condition{
-		Type:    HACBSTestSuceededCondition,
+		Type:    StonesoupTestSuceededCondition,
 		Status:  metav1.ConditionFalse,
-		Reason:  HACBSTestSuceededConditionFailed,
+		Reason:  StonesoupTestSuceededConditionFailed,
 		Message: message,
 	})
 	SetSnapshotIntegrationStatusAsFinished(snapshot, "Marking snapshot integration status condition as finished since the testing fails")
@@ -122,23 +122,23 @@ func MarkSnapshotAsFailed(adapterClient client.Client, ctx context.Context, snap
 	return snapshot, nil
 }
 
-// SetSnapshotIntegrationStatusAsInvalid sets the HACBS integration status condition for the Snapshot to invalid.
+// SetSnapshotIntegrationStatusAsInvalid sets the Stonesoup integration status condition for the Snapshot to invalid.
 func SetSnapshotIntegrationStatusAsInvalid(snapshot *applicationapiv1alpha1.Snapshot, message string) {
 	meta.SetStatusCondition(&snapshot.Status.Conditions, metav1.Condition{
-		Type:    HACBSIntegrationStatusCondition,
+		Type:    StonesoupIntegrationStatusCondition,
 		Status:  metav1.ConditionFalse,
-		Reason:  HACBSIntegrationStatusInvalid,
+		Reason:  StonesoupIntegrationStatusInvalid,
 		Message: message,
 	})
 }
 
-// MarkSnapshotIntegrationStatusAsInProgress sets the HACBS integration status condition for the Snapshot to In Progress.
+// MarkSnapshotIntegrationStatusAsInProgress sets the Stonesoup integration status condition for the Snapshot to In Progress.
 func MarkSnapshotIntegrationStatusAsInProgress(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	meta.SetStatusCondition(&snapshot.Status.Conditions, metav1.Condition{
-		Type:    HACBSIntegrationStatusCondition,
+		Type:    StonesoupIntegrationStatusCondition,
 		Status:  metav1.ConditionUnknown,
-		Reason:  HACBSIntegrationStatusInProgress,
+		Reason:  StonesoupIntegrationStatusInProgress,
 		Message: message,
 	})
 	err := adapterClient.Status().Patch(ctx, snapshot, patch)
@@ -148,24 +148,24 @@ func MarkSnapshotIntegrationStatusAsInProgress(adapterClient client.Client, ctx 
 	return snapshot, nil
 }
 
-// SetSnapshotIntegrationStatusAsFinished sets the HACBS integration status condition for the Snapshot to Finished.
+// SetSnapshotIntegrationStatusAsFinished sets the Stonesoup integration status condition for the Snapshot to Finished.
 func SetSnapshotIntegrationStatusAsFinished(snapshot *applicationapiv1alpha1.Snapshot, message string) {
 	meta.SetStatusCondition(&snapshot.Status.Conditions, metav1.Condition{
-		Type:    HACBSIntegrationStatusCondition,
+		Type:    StonesoupIntegrationStatusCondition,
 		Status:  metav1.ConditionTrue,
-		Reason:  HACBSIntegrationStatusFinished,
+		Reason:  StonesoupIntegrationStatusFinished,
 		Message: message,
 	})
 }
 
-// HaveHACBSTestsFinished checks if the HACBS tests have finished by checking if the HACBS Test Succeeded condition is set.
-func HaveHACBSTestsFinished(snapshot *applicationapiv1alpha1.Snapshot) bool {
-	return meta.FindStatusCondition(snapshot.Status.Conditions, HACBSTestSuceededCondition) != nil
+// HaveStonesoupTestsFinished checks if the Stonesoup tests have finished by checking if the Stonesoup Test Succeeded condition is set.
+func HaveStonesoupTestsFinished(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	return meta.FindStatusCondition(snapshot.Status.Conditions, StonesoupTestSuceededCondition) != nil
 }
 
-// HaveHACBSTestsSucceeded checks if the HACBS tests have finished by checking if the HACBS Test Succeeded condition is set.
-func HaveHACBSTestsSucceeded(snapshot *applicationapiv1alpha1.Snapshot) bool {
-	return meta.IsStatusConditionTrue(snapshot.Status.Conditions, HACBSTestSuceededCondition)
+// HaveStonesoupTestsSucceeded checks if the Stonesoup tests have finished by checking if the Stonesoup Test Succeeded condition is set.
+func HaveStonesoupTestsSucceeded(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	return meta.IsStatusConditionTrue(snapshot.Status.Conditions, StonesoupTestSuceededCondition)
 }
 
 // NewSnapshot creates a new snapshot based on the supplied application and components

--- a/gitops/snapshot_predicate_test.go
+++ b/gitops/snapshot_predicate_test.go
@@ -94,13 +94,13 @@ var _ = Describe("Predicates", Ordered, func() {
 		// Set the binding statuses after they are created
 		hasSnapshotUnknownStatus.Status.Conditions = []metav1.Condition{
 			{
-				Type:   gitops.HACBSTestSuceededCondition,
+				Type:   gitops.StonesoupTestSuceededCondition,
 				Status: metav1.ConditionUnknown,
 			},
 		}
 		hasSnapshotTrueStatus.Status.Conditions = []metav1.Condition{
 			{
-				Type:   gitops.HACBSTestSuceededCondition,
+				Type:   gitops.StonesoupTestSuceededCondition,
 				Status: metav1.ConditionTrue,
 			},
 		}

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(err == nil).To(BeTrue())
 		Expect(updatedSnapshot != nil).To(BeTrue())
 		Expect(updatedSnapshot.Status.Conditions != nil).To(BeTrue())
-		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.HACBSTestSuceededCondition)).To(BeTrue())
+		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.StonesoupTestSuceededCondition)).To(BeTrue())
 	})
 
 	It("ensures the Snapshots status can be marked as failed", func() {
@@ -122,22 +122,22 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(err == nil).To(BeTrue())
 		Expect(updatedSnapshot != nil).To(BeTrue())
 		Expect(updatedSnapshot.Status.Conditions != nil).To(BeTrue())
-		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.HACBSTestSuceededCondition)).To(BeFalse())
+		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.StonesoupTestSuceededCondition)).To(BeFalse())
 	})
 
 	It("ensures the Snapshots status can be marked as invalid", func() {
 		gitops.SetSnapshotIntegrationStatusAsInvalid(hasSnapshot, "Test message")
 		Expect(hasSnapshot != nil).To(BeTrue())
 		Expect(hasSnapshot.Status.Conditions != nil).To(BeTrue())
-		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.HACBSIntegrationStatusCondition)).To(BeFalse())
+		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.StonesoupIntegrationStatusCondition)).To(BeFalse())
 	})
 
 	It("ensures the Snapshots status can be marked as finished", func() {
 		gitops.SetSnapshotIntegrationStatusAsFinished(hasSnapshot, "Test message")
 		Expect(hasSnapshot.Status.Conditions != nil).To(BeTrue())
-		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.HACBSIntegrationStatusCondition)).To(BeTrue())
-		foundStatusCondition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.HACBSIntegrationStatusCondition)
-		Expect(foundStatusCondition.Reason == gitops.HACBSIntegrationStatusFinished).To(BeTrue())
+		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.StonesoupIntegrationStatusCondition)).To(BeTrue())
+		foundStatusCondition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.StonesoupIntegrationStatusCondition)
+		Expect(foundStatusCondition.Reason == gitops.StonesoupIntegrationStatusFinished).To(BeTrue())
 	})
 
 	It("ensures the Snapshots status can be marked as in progress", func() {
@@ -145,17 +145,17 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(err == nil).To(BeTrue())
 		Expect(updatedSnapshot != nil).To(BeTrue())
 		Expect(updatedSnapshot.Status.Conditions != nil).To(BeTrue())
-		foundStatusCondition := meta.FindStatusCondition(updatedSnapshot.Status.Conditions, gitops.HACBSIntegrationStatusCondition)
-		Expect(foundStatusCondition.Reason == gitops.HACBSIntegrationStatusInProgress).To(BeTrue())
+		foundStatusCondition := meta.FindStatusCondition(updatedSnapshot.Status.Conditions, gitops.StonesoupIntegrationStatusCondition)
+		Expect(foundStatusCondition.Reason == gitops.StonesoupIntegrationStatusInProgress).To(BeTrue())
 	})
 
-	It("ensures the Snapshots can be checked for the HACBSTestSuceededCondition", func() {
-		checkResult := gitops.HaveHACBSTestsFinished(hasSnapshot)
+	It("ensures the Snapshots can be checked for the StonesoupTestSuceededCondition", func() {
+		checkResult := gitops.HaveStonesoupTestsFinished(hasSnapshot)
 		Expect(checkResult).To(BeFalse())
 	})
 
-	It("ensures the Snapshots can be checked for the HACBSTestSuceededCondition", func() {
-		checkResult := gitops.HaveHACBSTestsSucceeded(hasSnapshot)
+	It("ensures the Snapshots can be checked for the StonesoupTestSuceededCondition", func() {
+		checkResult := gitops.HaveStonesoupTestsSucceeded(hasSnapshot)
 		Expect(checkResult).To(BeFalse())
 	})
 

--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -18,30 +18,32 @@ import (
 )
 
 const (
-	//HACBSTestOutputName is the name of the standardized HACBS Test output Tekton task result
-	HACBSTestOutputName = "HACBS_TEST_OUTPUT"
+	// TODO check effects of modifying output name
+	//StonesoupTestOutputName is the name of the standardized Stonesoup Test output Tekton task result
+	StonesoupTestOutputName = "STONESOUP_TEST_OUTPUT"
 
-	// HACBSTestOutputSuccess is the result that's set when the HACBS test succeeds.
-	HACBSTestOutputSuccess = "SUCCESS"
+	// StonesoupTestOutputSuccess is the result that's set when the Stonesoup test succeeds.
+	StonesoupTestOutputSuccess = "SUCCESS"
 
-	// HACBSTestOutputFailure is the result that's set when the HACBS test fails.
-	HACBSTestOutputFailure = "FAILURE"
+	// StonesoupTestOutputFailure is the result that's set when the Stonesoup test fails.
+	StonesoupTestOutputFailure = "FAILURE"
 
-	// HACBSTestOutputWarning is the result that's set when the HACBS test passes with a warning.
-	HACBSTestOutputWarning = "WARNING"
+	// StonesoupTestOutputWarning is the result that's set when the Stonesoup test passes with a warning.
+	StonesoupTestOutputWarning = "WARNING"
 
-	// HACBSTestOutputSkipped is the result that's set when the HACBS test gets skipped.
-	HACBSTestOutputSkipped = "SKIPPED"
+	// StonesoupTestOutputSkipped is the result that's set when the Stonesoup test gets skipped.
+	StonesoupTestOutputSkipped = "SKIPPED"
 
-	// HACBSTestOutputError is the result that's set when the HACBS test produces an error.
-	HACBSTestOutputError = "ERROR"
+	// StonesoupTestOutputError is the result that's set when the Stonesoup test produces an error.
+	StonesoupTestOutputError = "ERROR"
 
-	// AppStudioLabelSuffix is the suffix that's added to all HACBS label headings
+	// AppStudioLabelSuffix is the suffix that's added to all Stonesoup label headings
 	AppStudioLabelSuffix = "appstudio.openshift.io"
 )
 
-// HACBSTestResult matches HACBS TaskRun result contract
-type HACBSTestResult struct {
+// TODO understand the TaskRun result contract and implications of making the following changes
+// StonesoupTestResult matches Stonesoup TaskRun result contract
+type StonesoupTestResult struct {
 	Result    string `json:"result"`
 	Namespace string `json:"namespace"`
 	Timestamp string `json:"timestamp"`
@@ -55,7 +57,7 @@ type HACBSTestResult struct {
 type TaskRun struct {
 	logger     logr.Logger
 	trStatus   *tektonv1beta1.PipelineRunTaskRunStatus
-	testResult *HACBSTestResult
+	testResult *StonesoupTestResult
 }
 
 // NewTaskRun creates and returns am integration TaskRun.
@@ -90,21 +92,21 @@ func (t *TaskRun) GetDuration() time.Duration {
 	return end.Sub(start)
 }
 
-// GetTestResult returns a HACBSTestResult if the TaskRun produced the result. It will return nil otherwise.
-func (t *TaskRun) GetTestResult() (*HACBSTestResult, error) {
+// GetTestResult returns a StonesoupTestResult if the TaskRun produced the result. It will return nil otherwise.
+func (t *TaskRun) GetTestResult() (*StonesoupTestResult, error) {
 	// Check for an already parsed result.
 	if t.testResult != nil {
 		return t.testResult, nil
 	}
 
 	for _, taskRunResult := range t.trStatus.Status.TaskRunResults {
-		if taskRunResult.Name == HACBSTestOutputName {
-			var result HACBSTestResult
+		if taskRunResult.Name == StonesoupTestOutputName {
+			var result StonesoupTestResult
 			err := json.Unmarshal([]byte(taskRunResult.Value.StringVal), &result)
 			if err != nil {
 				return nil, err
 			}
-			t.logger.Info("Found a HACBS test result", "Result", result)
+			t.logger.Info("Found a Stonesoup test result", "Result", result)
 			t.testResult = &result
 			return &result, nil
 		}
@@ -173,14 +175,14 @@ func GetAllIntegrationTestScenariosForApplication(adapterClient client.Client, c
 }
 
 // CalculateIntegrationPipelineRunOutcome checks the Tekton results for a given PipelineRun and calculates the overall outcome.
-// If any of the tasks with the HACBS_TEST_OUTPUT result don't have the `result` field set to SUCCESS or SKIPPED, it returns false.
+// If any of the tasks with the STONESOUP_TEST_OUTPUT result don't have the `result` field set to SUCCESS or SKIPPED, it returns false.
 func CalculateIntegrationPipelineRunOutcome(logger logr.Logger, pipelineRun *tektonv1beta1.PipelineRun) (bool, error) {
-	results, err := GetHACBSTestResultsFromPipelineRun(logger, pipelineRun)
+	results, err := GetStonesoupTestResultsFromPipelineRun(logger, pipelineRun)
 	if err != nil {
 		return false, err
 	}
 	for _, result := range results {
-		if result.Result != HACBSTestOutputSuccess && result.Result != HACBSTestOutputSkipped {
+		if result.Result != StonesoupTestOutputSuccess && result.Result != StonesoupTestOutputSkipped {
 			return false, nil
 		}
 	}
@@ -238,10 +240,10 @@ func GetLatestPipelineRunForSnapshotAndScenario(adapterClient client.Client, ctx
 	return nil, err
 }
 
-// GetHACBSTestResultsFromPipelineRun finds all TaskRuns with a HACBS_TEST_OUTPUT result and returns the parsed data
-func GetHACBSTestResultsFromPipelineRun(logger logr.Logger, pipelineRun *tektonv1beta1.PipelineRun) ([]*HACBSTestResult, error) {
+// GetStonesoupTestResultsFromPipelineRun finds all TaskRuns with a STONESOUP_TEST_OUTPUT result and returns the parsed data
+func GetStonesoupTestResultsFromPipelineRun(logger logr.Logger, pipelineRun *tektonv1beta1.PipelineRun) ([]*StonesoupTestResult, error) {
 	taskRuns := GetTaskRunsFromPipelineRun(logger, pipelineRun)
-	results := []*HACBSTestResult{}
+	results := []*StonesoupTestResult{}
 	for _, tr := range taskRuns {
 		r, err := tr.GetTestResult()
 		if err != nil {

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 	It("should return all IntegrationTestScenarios used by the application", func() {
 		updatedSnapshot, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 		Expect(err == nil && updatedSnapshot != nil).To(BeTrue())
-		Expect(gitops.HaveHACBSTestsFinished(hasSnapshot)).To(BeTrue())
+		Expect(gitops.HaveStonesoupTestsFinished(hasSnapshot)).To(BeTrue())
 
 		integrationTestScenarios, err := helpers.GetAllIntegrationTestScenariosForApplication(k8sClient, ctx, hasApp)
 		Expect(err == nil && integrationTestScenarios != nil).To(BeTrue())
@@ -133,7 +133,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 	It("should return all the required IntegrationTestScenarios used by the application", func() {
 		updatedSnapshot, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 		Expect(err == nil && updatedSnapshot != nil).To(BeTrue())
-		Expect(gitops.HaveHACBSTestsFinished(hasSnapshot)).To(BeTrue())
+		Expect(gitops.HaveStonesoupTestsFinished(hasSnapshot)).To(BeTrue())
 
 		requiredIntegrationTestScenarios, err := helpers.GetRequiredIntegrationTestScenariosForApplication(k8sClient, ctx, hasApp)
 		Expect(err == nil && requiredIntegrationTestScenarios != nil).To(BeTrue())
@@ -169,7 +169,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		}
 	})
 
-	It("ensures multiple task pipelinerun outcome when HACBSTests succeeded", func() {
+	It("ensures multiple task pipelinerun outcome when StonesoupTests succeeded", func() {
 		testpipelineRun.Status = tektonv1beta1.PipelineRunStatus{
 			PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
 				TaskRuns: map[string]*tektonv1beta1.PipelineRunTaskRunStatus{
@@ -179,7 +179,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 							TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
 								TaskRunResults: []tektonv1beta1.TaskRunResult{
 									{
-										Name: "HACBS_TEST_OUTPUT",
+										Name: "STONESOUP_TEST_OUTPUT",
 										Value: *tektonv1beta1.NewArrayOrString(`{
 											"result": "SKIPPED",
 											"timestamp": "1665405318",
@@ -197,7 +197,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 							TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
 								TaskRunResults: []tektonv1beta1.TaskRunResult{
 									{
-										Name: "HACBS_TEST_OUTPUT",
+										Name: "STONESOUP_TEST_OUTPUT",
 										Value: *tektonv1beta1.NewArrayOrString(`{
 											"result": "SUCCESS",
 											"timestamp": "1665405318",
@@ -215,7 +215,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 							TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
 								TaskRunResults: []tektonv1beta1.TaskRunResult{
 									{
-										Name: "HACBS_TEST_OUTPUT",
+										Name: "STONESOUP_TEST_OUTPUT",
 										Value: *tektonv1beta1.NewArrayOrString(`{
 											"result": "SUCCESS",
 											"timestamp": "1665405318",
@@ -236,10 +236,10 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(err == nil && pipelineRunOutcome).To(BeTrue())
 
 		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
-		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshot)).To(BeTrue())
+		Expect(gitops.HaveStonesoupTestsSucceeded(hasSnapshot)).To(BeTrue())
 	})
 
-	It("no error from pipelinrun when HACBSTests failed", func() {
+	It("no error from pipelinrun when StonesoupTests failed", func() {
 		testpipelineRun.Status = tektonv1beta1.PipelineRunStatus{
 			PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
 				TaskRuns: map[string]*tektonv1beta1.PipelineRunTaskRunStatus{
@@ -249,7 +249,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 							TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
 								TaskRunResults: []tektonv1beta1.TaskRunResult{
 									{
-										Name: "HACBS_TEST_OUTPUT",
+										Name: "STONESOUP_TEST_OUTPUT",
 										Value: *tektonv1beta1.NewArrayOrString(`{
 											"result": "FAILURE",
 											"timestamp": "1665405317",
@@ -271,10 +271,10 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome).To(BeFalse())
 
 		gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
-		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshot)).To(BeFalse())
+		Expect(gitops.HaveStonesoupTestsSucceeded(hasSnapshot)).To(BeFalse())
 	})
 
-	It("ensure No Task pipelinerun passed when HACBSTests passed", func() {
+	It("ensure No Task pipelinerun passed when StonesoupTests passed", func() {
 
 		testpipelineRun.Status = tektonv1beta1.PipelineRunStatus{
 			PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
@@ -310,10 +310,10 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome).To(BeTrue())
 
 		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
-		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshot)).To(BeTrue())
+		Expect(gitops.HaveStonesoupTestsSucceeded(hasSnapshot)).To(BeTrue())
 	})
 
-	It("can handle malformed HACBS_TEST_OUTPUT result", func() {
+	It("can handle malformed STONESOUP_TEST_OUTPUT result", func() {
 		testpipelineRun.Status = tektonv1beta1.PipelineRunStatus{
 			PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
 				TaskRuns: map[string]*tektonv1beta1.PipelineRunTaskRunStatus{
@@ -323,7 +323,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 							TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
 								TaskRunResults: []tektonv1beta1.TaskRunResult{
 									{
-										Name:  "HACBS_TEST_OUTPUT",
+										Name:  "STONESOUP_TEST_OUTPUT",
 										Value: *tektonv1beta1.NewArrayOrString("invalid json"),
 									},
 								},
@@ -353,7 +353,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 								CompletionTime: &metav1.Time{Time: now.Add(5 * time.Minute)},
 								TaskRunResults: []tektonv1beta1.TaskRunResult{
 									{
-										Name: "HACBS_TEST_OUTPUT",
+										Name: "STONESOUP_TEST_OUTPUT",
 										Value: *tektonv1beta1.NewArrayOrString(`{
 											"result": "SUCCESS",
 											"successes": 1

--- a/status/format.go
+++ b/status/format.go
@@ -79,15 +79,15 @@ func FormatStatus(taskRun *helpers.TaskRun) (string, error) {
 
 	var emoji string
 	switch result.Result {
-	case helpers.HACBSTestOutputSuccess:
+	case helpers.StonesoupTestOutputSuccess:
 		emoji = ":heavy_check_mark:"
-	case helpers.HACBSTestOutputFailure:
+	case helpers.StonesoupTestOutputFailure:
 		emoji = ":x:"
-	case helpers.HACBSTestOutputWarning:
+	case helpers.StonesoupTestOutputWarning:
 		emoji = ":warning:"
-	case helpers.HACBSTestOutputSkipped:
+	case helpers.StonesoupTestOutputSkipped:
 		emoji = ":white_check_mark:"
-	case helpers.HACBSTestOutputError:
+	case helpers.StonesoupTestOutputError:
 		emoji = ":heavy_exclamation_mark:"
 	default:
 		emoji = ":question:"

--- a/status/format_test.go
+++ b/status/format_test.go
@@ -38,7 +38,7 @@ func newTaskRun(name string, startTime time.Time, completionTime time.Time) *hel
 	})
 }
 
-func newTaskRunWithHACBSTestOutput(name string, startTime time.Time, completionTime time.Time, output string) *helpers.TaskRun {
+func newTaskRunWithStonesoupTestOutput(name string, startTime time.Time, completionTime time.Time, output string) *helpers.TaskRun {
 	return helpers.NewTaskRun(logr.Discard(), &tektonv1beta1.PipelineRunTaskRunStatus{
 		PipelineTaskName: name,
 		Status: &tektonv1beta1.TaskRunStatus{
@@ -47,7 +47,7 @@ func newTaskRunWithHACBSTestOutput(name string, startTime time.Time, completionT
 				CompletionTime: &metav1.Time{Time: completionTime},
 				TaskRunResults: []tektonv1beta1.TaskRunResult{
 					{
-						Name:  "HACBS_TEST_OUTPUT",
+						Name:  "STONESOUP_TEST_OUTPUT",
 						Value: *tektonv1beta1.NewArrayOrString(output),
 					},
 				},
@@ -63,7 +63,7 @@ var _ = Describe("Formatters", func() {
 	BeforeEach(func() {
 		now := time.Now()
 		taskRuns = []*helpers.TaskRun{
-			newTaskRunWithHACBSTestOutput(
+			newTaskRunWithStonesoupTestOutput(
 				"example-task-1",
 				now,
 				now.Add(time.Minute*5).Add(time.Second*30),
@@ -80,7 +80,7 @@ var _ = Describe("Formatters", func() {
 				now.Add(time.Minute*-2),
 				now,
 			),
-			newTaskRunWithHACBSTestOutput(
+			newTaskRunWithStonesoupTestOutput(
 				"example-task-3",
 				now.Add(time.Second*3),
 				now.Add(time.Second*4),
@@ -92,7 +92,7 @@ var _ = Describe("Formatters", func() {
 					"note": "example note 3"
 				}`,
 			),
-			newTaskRunWithHACBSTestOutput(
+			newTaskRunWithStonesoupTestOutput(
 				"example-task-4",
 				now.Add(time.Second*4),
 				now.Add(time.Second*5),
@@ -103,7 +103,7 @@ var _ = Describe("Formatters", func() {
 					"note": "example note 4"
 				}`,
 			),
-			newTaskRunWithHACBSTestOutput(
+			newTaskRunWithStonesoupTestOutput(
 				"example-task-5",
 				now.Add(time.Minute*-5),
 				now,
@@ -112,7 +112,7 @@ var _ = Describe("Formatters", func() {
 					"namespace": "example-namespace-5"
 				}`,
 			),
-			newTaskRunWithHACBSTestOutput(
+			newTaskRunWithStonesoupTestOutput(
 				"example-task-6",
 				now.Add(time.Second*6),
 				now.Add(time.Second*7),
@@ -121,7 +121,7 @@ var _ = Describe("Formatters", func() {
 					"namespace": "example-namespace-6"
 				}`,
 			),
-			newTaskRunWithHACBSTestOutput(
+			newTaskRunWithStonesoupTestOutput(
 				"example-task-7",
 				now.Add(time.Second*7),
 				now.Add(time.Second*7),

--- a/status/reporters_test.go
+++ b/status/reporters_test.go
@@ -130,7 +130,7 @@ func setFailureStatus(pipelineRun *tektonv1beta1.PipelineRun) {
 							CompletionTime: &metav1.Time{Time: time.Now()},
 							TaskRunResults: []tektonv1beta1.TaskRunResult{
 								{
-									Name:  "HACBS_TEST_OUTPUT",
+									Name:  "STONESOUP_TEST_OUTPUT",
 									Value: *tektonv1beta1.NewArrayOrString("{\"result\":\"FAILURE\"}"),
 								},
 							},
@@ -239,7 +239,7 @@ var _ = Describe("GitHubReporter", func() {
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.Owner).To(Equal("devfile-sample"))
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.Repository).To(Equal("devfile-sample-go-basic"))
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.SHA).To(Equal("12a4a35ccd08194595179815e4646c3a6c08bb77"))
-			Expect(mockGitHubClient.CreateCheckRunResult.cra.Name).To(Equal("HACBS Test / devfile-sample-go-basic / example-pass"))
+			Expect(mockGitHubClient.CreateCheckRunResult.cra.Name).To(Equal("Stonesoup Test / devfile-sample-go-basic / example-pass"))
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.StartTime.IsZero()).To(BeFalse())
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.CompletionTime.IsZero()).To(BeTrue())
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.Text).To(Equal(""))
@@ -257,7 +257,7 @@ var _ = Describe("GitHubReporter", func() {
 									CompletionTime: &metav1.Time{Time: time.Now()},
 									TaskRunResults: []tektonv1beta1.TaskRunResult{
 										{
-											Name:  "HACBS_TEST_OUTPUT",
+											Name:  "STONESOUP_TEST_OUTPUT",
 											Value: *tektonv1beta1.NewArrayOrString("{\"result\":\"SUCCESS\"}"),
 										},
 									},
@@ -272,7 +272,7 @@ var _ = Describe("GitHubReporter", func() {
 									CompletionTime: &metav1.Time{Time: time.Now()},
 									TaskRunResults: []tektonv1beta1.TaskRunResult{
 										{
-											Name:  "HACBS_TEST_OUTPUT",
+											Name:  "STONESOUP_TEST_OUTPUT",
 											Value: *tektonv1beta1.NewArrayOrString("{\"result\":\"SKIPPED\"}"),
 										},
 									},
@@ -379,7 +379,7 @@ var _ = Describe("GitHubReporter", func() {
 			Expect(reporter.ReportStatus(context.TODO(), pipelineRun)).To(BeNil())
 			Expect(mockGitHubClient.CreateCommitStatusResult.state).To(Equal("pending"))
 			Expect(mockGitHubClient.CreateCommitStatusResult.description).To(Equal("example-pass has started"))
-			Expect(mockGitHubClient.CreateCommitStatusResult.statusContext).To(Equal("HACBS Test / devfile-sample-go-basic / example-pass"))
+			Expect(mockGitHubClient.CreateCommitStatusResult.statusContext).To(Equal("Stonesoup Test / devfile-sample-go-basic / example-pass"))
 
 			// Success
 			pipelineRun.Status.SetCondition(&apis.Condition{
@@ -389,14 +389,14 @@ var _ = Describe("GitHubReporter", func() {
 			Expect(reporter.ReportStatus(context.TODO(), pipelineRun)).To(BeNil())
 			Expect(mockGitHubClient.CreateCommitStatusResult.state).To(Equal("success"))
 			Expect(mockGitHubClient.CreateCommitStatusResult.description).To(Equal("example-pass has succeeded"))
-			Expect(mockGitHubClient.CreateCommitStatusResult.statusContext).To(Equal("HACBS Test / devfile-sample-go-basic / example-pass"))
+			Expect(mockGitHubClient.CreateCommitStatusResult.statusContext).To(Equal("Stonesoup Test / devfile-sample-go-basic / example-pass"))
 
 			// Failure
 			setFailureStatus(pipelineRun)
 			Expect(reporter.ReportStatus(context.TODO(), pipelineRun)).To(BeNil())
 			Expect(mockGitHubClient.CreateCommitStatusResult.state).To(Equal("failure"))
 			Expect(mockGitHubClient.CreateCommitStatusResult.description).To(Equal("example-pass has failed"))
-			Expect(mockGitHubClient.CreateCommitStatusResult.statusContext).To(Equal("HACBS Test / devfile-sample-go-basic / example-pass"))
+			Expect(mockGitHubClient.CreateCommitStatusResult.statusContext).To(Equal("Stonesoup Test / devfile-sample-go-basic / example-pass"))
 		})
 	})
 

--- a/status/status.go
+++ b/status/status.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NamePrefix is a common name prefix for this service.
-const NamePrefix = "HACBS Test"
+const NamePrefix = "Stonesoup Test"
 
 // Reporter is a generic interface all status implementations must follow.
 type Reporter interface {


### PR DESCRIPTION
Update all occurrences of HACBs naming convention in favor of Stonesoup.

Signed-off-by: Josh Everett <jeverett@redhat.com>