### PR TITLE
fix(Dockerfile): bump ubi-minimal version to 8.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 # Use ubi-minimal as minimal base image to package the manager binary
 # Refer to https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 COPY --from=builder /opt/app-root/src/manager /
 USER 65532:65532
 


### PR DESCRIPTION
ubi-minimal:8.6 is deprecated and doesn't receive vulnerability fixes anymore. Bump to 8.7

Signed-off-by: Martin Basti <mbasti@redhat.com>