### PR TITLE
fix(HACBS-1503): add rbac groups to SA

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,7 +42,7 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
-  - integrationTestScenarios
+  - integrationtestscenarios
   verbs:
   - create
   - delete
@@ -51,6 +51,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - integrationtestscenarios/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - appstudio.redhat.com
   resources:

--- a/controllers/scenario/scenario_controller.go
+++ b/controllers/scenario/scenario_controller.go
@@ -47,7 +47,8 @@ func NewScenarioReconciler(client client.Client, logger *logr.Logger, scheme *ru
 	}
 }
 
-//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=integrationTestScenarios,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=integrationtestscenarios,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=integrationtestscenarios/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments,verbs=get;list;watch;
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications,verbs=get;list;watch;create;update;patch;delete
 


### PR DESCRIPTION
Signed-off-by: Jiri Sztuka <jsztuka@redhat.com>

Changes are supposed to fix following:

```1.6759525873991888e+09
    ERROR    controllers.integrationTestScenario    Failed to update Scenario    
{"IntegrationTestScenario": 
"sbudhwar-1-tenant/component-integration-test-one", "Scenario.Name:": 
"component-integration-test-one", "error": 
"integrationtestscenarios.appstudio.redhat.com 
\"component-integration-test-one\" is forbidden: User 
\"system:serviceaccount:integration-service:integration-service-controller-manager\"
 cannot patch resource \"integrationtestscenarios/status\" in API group 
\"appstudio.redhat.com\" in the namespace \"sbudhwar-1-tenant\""}```