### PR TITLE
feat(HACBS-1536): add dependabot to detect dependencies update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      # Prefix all commit messages with "chore(Dockerfile): "
+      prefix: "chore(Dockerfile): "
+    # Add reviewers
+    reviewers:
+      - "dirgim"
+      - "hongweiliu17"
+      - "jsztuka"
+      - "jinqi7"
+      - "Josh-Everett"
+      - "MartinBasti"
+      - "dheerajodha"


### PR DESCRIPTION
This dependabot can detect dependencies version update and create pr for them automatically, more details can be found in https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

This is the first PR to use dependabot, we just make it detect the docker image version update.

[Here](https://github.com/hongweiliu17/dependabot-test/blob/main/.github/dependabot.yml) is the merged dependatbot in my personal repo and it generates [two PRs](https://github.com/hongweiliu17/dependabot-test/pulls) to update docker image in my repo.

Signed-off-by: Hongwei Liu hongliu@redhat.com