### PR TITLE
fix(HACBS-1636): update dependabot to include go packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
       - "jsztuka"
       - "jinqi7"
       - "Josh-Everett"
+      - "sonam1412"
       - "MartinBasti"
       - "dheerajodha"
   - package-ecosystem: "github-actions"
@@ -33,5 +34,21 @@ updates:
       - "jsztuka"
       - "jinqi7"
       - "Josh-Everett"
+      - "sonam1412"
+      - "MartinBasti"
+      - "dheerajodha"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(go): "
+    reviewers:
+      - "dirgim"
+      - "hongweiliu17"
+      - "jsztuka"
+      - "jinqi7"
+      - "Josh-Everett"
+      - "sonam1412"
       - "MartinBasti"
       - "dheerajodha"


### PR DESCRIPTION
* Use dependabot to detect go package update and create PR

Signed-off-by: Hongwei Liu  hongliu@redhat.com