### PR TITLE
chore(gitlint): ignore dependabot

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -12,3 +12,6 @@ line-length=72
 [body-first-line-empty]
 
 [contrib-title-conventional-commits]
+
+[ignore-by-author-name]
+regex=(.*)dependabot(.*)


### PR DESCRIPTION
Splitting dependabot commit message into shored lines wouldn't bring any benefits in readability, let's ignore it