### PR TITLE
fix: pass scenario parameters to the pipeline

### DIFF
--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -18,6 +18,7 @@ package snapshot
 
 import (
 	"context"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/go-logr/logr"
@@ -378,6 +379,7 @@ func (a *Adapter) createIntegrationPipelineRun(application *applicationapiv1alph
 		WithSnapshot(snapshot).
 		WithIntegrationLabels(integrationTestScenario).
 		WithApplicationAndComponent(a.application, a.component).
+		WithExtraParams(integrationTestScenario.Spec.Params).
 		AsPipelineRun()
 	// copy PipelineRun PAC annotations/labels from snapshot to integration test PipelineRuns
 	helpers.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.PipelinesAsCodePrefix, gitops.PipelinesAsCodePrefix)

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -103,6 +103,26 @@ func (r *IntegrationPipelineRun) WithExtraParam(name string, value tektonv1beta1
 	return r
 }
 
+// WithExtraParams adds all provided parameters to the Integration PipelineRun.
+func (r *IntegrationPipelineRun) WithExtraParams(params []v1alpha1.PipelineParameter) *IntegrationPipelineRun {
+	for _, param := range params {
+		var value tektonv1beta1.ArrayOrString
+		switch {
+		case param.Value != "":
+			value.StringVal = param.Value
+			value.Type = tektonv1beta1.ParamTypeString
+		case len(param.Values) > 0:
+			value.ArrayVal = param.Values
+			value.Type = tektonv1beta1.ParamTypeArray
+		default:
+			value.Type = tektonv1beta1.ParamTypeObject
+		}
+		r.WithExtraParam(param.Name, value)
+	}
+
+	return r
+}
+
 // WithSnapshot adds a param containing the Snapshot as a json string
 // to the integration PipelineRun.
 func (r *IntegrationPipelineRun) WithSnapshot(snapshot *applicationapiv1alpha1.Snapshot) *IntegrationPipelineRun {

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -176,6 +176,25 @@ var _ = Describe("Integration pipeline", func() {
 				To(Equal(hasApp.Name))
 		})
 
+		It("provides parameters from IntegrationTestScenario to the PipelineRun", func() {
+			scenarioParams := []v1alpha1.PipelineParameter{
+				{
+					Name:  "ADDITIONAL_PARAMETER",
+					Value: "custom value",
+				},
+				{
+					Name:   "MULTIVALUE_PARAMETER",
+					Values: []string{"value1", "value2"},
+				},
+			}
+
+			newIntegrationPipelineRun.WithExtraParams(scenarioParams)
+			Expect(newIntegrationPipelineRun.Spec.Params[0].Name).To(Equal(scenarioParams[0].Name))
+			Expect(newIntegrationPipelineRun.Spec.Params[0].Value.StringVal).To(Equal(scenarioParams[0].Value))
+			Expect(newIntegrationPipelineRun.Spec.Params[1].Name).To(Equal(scenarioParams[1].Name))
+			Expect(newIntegrationPipelineRun.Spec.Params[1].Value.ArrayVal).To(Equal(scenarioParams[1].Values))
+		})
+
 	})
 
 })


### PR DESCRIPTION
This makes sure that the parameters provided via the `params` field of IntegrationTestScenarioSpec are passed to the derived PipelineRun.