### PR TITLE
Prevent out-of-order deployments

### DIFF
--- a/controllers/pipeline/pipeline_adapter.go
+++ b/controllers/pipeline/pipeline_adapter.go
@@ -65,7 +65,7 @@ func NewAdapter(pipelineRun *tektonv1beta1.PipelineRun, component *applicationap
 // EnsureSnapshotExists is an operation that will ensure that a pipeline Snapshot associated
 // to the PipelineRun being processed exists. Otherwise, it will create a new pipeline Snapshot.
 func (a *Adapter) EnsureSnapshotExists() (reconciler.OperationResult, error) {
-	if !tekton.IsBuildPipelineRun(a.pipelineRun) || !tekton.HasPipelineRunSucceeded(a.pipelineRun) {
+	if !tekton.IsBuildPipelineRun(a.pipelineRun) || !helpers.HasPipelineRunSucceeded(a.pipelineRun) {
 		return reconciler.ContinueProcessing()
 	}
 
@@ -109,7 +109,7 @@ func (a *Adapter) EnsureSnapshotExists() (reconciler.OperationResult, error) {
 // EnsureSnapshotPassedAllTests is an operation that will ensure that a pipeline Snapshot
 // to the PipelineRun being processed passed all tests for all defined non-optional IntegrationTestScenarios.
 func (a *Adapter) EnsureSnapshotPassedAllTests() (reconciler.OperationResult, error) {
-	if !tekton.IsIntegrationPipelineRun(a.pipelineRun) || !tekton.HasPipelineRunSucceeded(a.pipelineRun) {
+	if !tekton.IsIntegrationPipelineRun(a.pipelineRun) || !helpers.HasPipelineRunSucceeded(a.pipelineRun) {
 		return reconciler.ContinueProcessing()
 	}
 

--- a/controllers/pipeline/pipeline_adapter_test.go
+++ b/controllers/pipeline/pipeline_adapter_test.go
@@ -568,4 +568,125 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			return result.RequeueRequest && err != nil && err.Error() == "ReportStatusError"
 		}, time.Second*10).Should(BeTrue())
 	})
+
+	When("multiple succesfull build pipeline runs exists for the same component", func() {
+
+		var (
+			testpipelineRunBuild2 *tektonv1beta1.PipelineRun
+		)
+
+		BeforeAll(func() {
+			testpipelineRunBuild2 = &tektonv1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pipelinerun-build-sample-2",
+					Namespace: "default",
+					Labels: map[string]string{
+						"pipelines.appstudio.openshift.io/type": "build",
+						"pipelines.openshift.io/used-by":        "build-cloud",
+						"pipelines.openshift.io/runtime":        "nodejs",
+						"pipelines.openshift.io/strategy":       "s2i",
+						"appstudio.openshift.io/component":      "component-sample",
+						"pipelinesascode.tekton.dev/event-type": "pull_request",
+					},
+					Annotations: map[string]string{
+						"appstudio.redhat.com/updateComponentOnSuccess": "false",
+						"pipelinesascode.tekton.dev/on-target-branch":   "[main,master]",
+						"foo": "bar",
+					},
+				},
+				Spec: tektonv1beta1.PipelineRunSpec{
+					PipelineRef: &tektonv1beta1.PipelineRef{
+						Name:   "build-pipeline-pass",
+						Bundle: "quay.io/kpavic/test-bundle:build-pipeline-pass",
+					},
+					Params: []tektonv1beta1.Param{
+						{
+							Name: "output-image",
+							Value: tektonv1beta1.ArrayOrString{
+								Type:      "string",
+								StringVal: "quay.io/redhat-appstudio/sample-image",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, testpipelineRunBuild2)).Should(Succeed())
+
+			testpipelineRunBuild2.Status = tektonv1beta1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
+					TaskRuns: map[string]*tektonv1beta1.PipelineRunTaskRunStatus{
+						"index1": {
+							PipelineTaskName: "build-container",
+							Status: &tektonv1beta1.TaskRunStatus{
+								TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
+									TaskRunResults: []tektonv1beta1.TaskRunResult{
+										{
+											Name:  "IMAGE_DIGEST",
+											Value: *tektonv1beta1.NewArrayOrString("image_digest_value"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: v1beta1.Status{
+					Conditions: v1beta1.Conditions{
+						apis.Condition{
+							Reason: "Completed",
+							Status: "True",
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, testpipelineRunBuild2)).Should(Succeed())
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      testpipelineRunBuild2.Name,
+					Namespace: "default",
+				}, testpipelineRunBuild2)
+				if err != nil {
+					return err
+				}
+				if !helpers.HasPipelineRunSucceeded(testpipelineRunBuild2) {
+					return fmt.Errorf("Pipeline is not marked as succeeded yet")
+				}
+				return err
+			}, time.Second*10).ShouldNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			err := k8sClient.Delete(ctx, testpipelineRunBuild2)
+			Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("isLatestSucceededPipelineRun reports second pipeline as the latest pipeline", func() {
+			// make sure the seocnd pipeline started as second
+			testpipelineRunBuild2.CreationTimestamp.Time = testpipelineRunBuild2.CreationTimestamp.Add(2 * time.Hour)
+			adapter = NewAdapter(testpipelineRunBuild2, hasComp, hasApp, ctrl.Log, k8sClient, ctx)
+			isLatest, err := adapter.isLatestSucceededPipelineRun()
+			Expect(err).To(BeNil())
+			Expect(isLatest).To(BeTrue())
+		})
+
+		It("isLatestSucceededPipelineRun doesn't report first pipeline as the latest pipeline", func() {
+			// make sure the first pipeline started as first
+			testpipelineRunBuild.CreationTimestamp.Time = testpipelineRunBuild.CreationTimestamp.Add(-2 * time.Hour)
+			adapter = NewAdapter(testpipelineRunBuild, hasComp, hasApp, ctrl.Log, k8sClient, ctx)
+			isLatest, err := adapter.isLatestSucceededPipelineRun()
+			Expect(err).To(BeNil())
+			Expect(isLatest).To(BeFalse())
+		})
+
+		It("ensure that EnsureSnapshotExists doesn't create snapshot for previous pipeline run", func() {
+			// make sure the first pipeline started as first
+			testpipelineRunBuild.CreationTimestamp.Time = testpipelineRunBuild.CreationTimestamp.Add(-2 * time.Hour)
+			adapter = NewAdapter(testpipelineRunBuild, hasComp, hasApp, ctrl.Log, k8sClient, ctx)
+			Eventually(func() bool {
+				result, err := adapter.EnsureSnapshotExists()
+				return !result.CancelRequest && err == nil
+			}, time.Second*10).Should(BeTrue())
+		})
+	})
 })

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/redhat-appstudio/operator-goodies v0.0.0-20221130140446-010c05bd7471
 	github.com/redhat-appstudio/release-service v0.0.0-20221116195308-308d82e909fa
 	github.com/tektoncd/pipeline v0.41.0
+	github.com/tonglil/buflogr v1.0.1
 	golang.org/x/oauth2 v0.1.0
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
 github.com/tektoncd/pipeline v0.41.0 h1:FksQuX83ZRasZygQPNmaR6hKBh6gy822XxRuoKBqPUE=
 github.com/tektoncd/pipeline v0.41.0/go.mod h1:YY4+PGfdsd6Qxn3PZXmCpKeS3heK8pIIcnUt37vRJ2Q=
+github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
+github.com/tonglil/buflogr v1.0.1/go.mod h1:yYWwvSpn/3uAaqjf6mJg/XMiAciaR0QcRJH2gJGDxNE=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -76,16 +76,6 @@ func hasPipelineRunStateChangedToStarted(objectOld, objectNew client.Object) boo
 	return false
 }
 
-// HasPipelineRunSucceeded returns a boolean indicating whether the PipelineRun succeeded or not.
-// If the object passed to this function is not a PipelineRun, the function will return false.
-func HasPipelineRunSucceeded(object client.Object) bool {
-	if pr, ok := object.(*tektonv1beta1.PipelineRun); ok {
-		return pr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
-	}
-
-	return false
-}
-
 // GetTypeFromPipelineRun extracts the pipeline type from the pipelineRun labels.
 func GetTypeFromPipelineRun(object client.Object) (string, error) {
 	if pipelineRun, ok := object.(*tektonv1beta1.PipelineRun); ok {

--- a/tekton/utils_test.go
+++ b/tekton/utils_test.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/integration-service/tekton"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klog "k8s.io/klog/v2"
-	"knative.dev/pkg/apis"
 )
 
 var _ = Describe("Utils", func() {
@@ -66,16 +64,6 @@ var _ = Describe("Utils", func() {
 			Fail(fmt.Sprintf("Expected image_digest is image_digest_value, but got %s", image_digest))
 		}
 		klog.Infoln("Got expected image_digest")
-	})
-
-	It("can detect if a PipelineRun has succeeded", func() {
-		Expect(tekton.HasPipelineRunSucceeded(pipelineRun)).To(BeFalse())
-		pipelineRun.Status.SetCondition(&apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: "True",
-		})
-		Expect(tekton.HasPipelineRunSucceeded(pipelineRun)).To(BeTrue())
-		Expect(tekton.HasPipelineRunSucceeded(&tektonv1beta1.TaskRun{})).To(BeFalse())
 	})
 
 })


### PR DESCRIPTION
    Fixing race condition where older pipeline could replace newer
    deployment with image from older pipeline, if older pipeline was running
    longer than latest one.
