### PR TITLE
fix(HACBS-1779): update the GCL promotion logic 

### DIFF
--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -88,7 +88,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	return reconciler.ReconcileHandler([]reconciler.ReconcileOperation{
 		adapter.EnsureAllReleasesExist,
-		adapter.EnsureGlobalComponentImageUpdated,
+		adapter.EnsureGlobalCandidateImageUpdated,
 		adapter.EnsureSnapshotEnvironmentBindingExist,
 		adapter.EnsureAllIntegrationTestPipelinesExist,
 	})
@@ -134,7 +134,7 @@ func (r *Reconciler) getComponentFromSnapshot(context context.Context, snapshot 
 type AdapterInterface interface {
 	EnsureAllReleasesExist() (reconciler.OperationResult, error)
 	EnsureAllIntegrationTestPipelinesExist() (reconciler.OperationResult, error)
-	EnsureGlobalComponentImageUpdated() (reconciler.OperationResult, error)
+	EnsureGlobalCandidateImageUpdated() (reconciler.OperationResult, error)
 	EnsureSnapshotEnvironmentBindingExist() (reconciler.OperationResult, error)
 }
 

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -327,3 +327,14 @@ func CompareSnapshots(expectedSnapshot *applicationapiv1alpha1.Snapshot, foundSn
 func IsSnapshotCreatedByPACPullRequestEvent(snapshot *applicationapiv1alpha1.Snapshot) bool {
 	return helpers.HasLabelWithValue(snapshot, PipelineAsCodeEventTypeLabel, PipelineAsCodePullRequestType)
 }
+
+// HasSnapshotTestingChangedToFinished returns a boolean indicating whether the Snapshot testing status has
+// changed to finished. If the objects passed to this function are not Snapshots, the function will return false.
+func HasSnapshotTestingChangedToFinished(objectOld, objectNew client.Object) bool {
+	if oldSnapshot, ok := objectOld.(*applicationapiv1alpha1.Snapshot); ok {
+		if newSnapshot, ok := objectNew.(*applicationapiv1alpha1.Snapshot); ok {
+			return !HaveHACBSTestsFinished(oldSnapshot) && HaveHACBSTestsFinished(newSnapshot)
+		}
+	}
+	return false
+}

--- a/gitops/snapshot_predicate.go
+++ b/gitops/snapshot_predicate.go
@@ -6,7 +6,7 @@ import (
 )
 
 // IntegrationSnapshotChangePredicate returns a predicate which filters out all objects except
-// snapshot is deleted.
+// snapshot is deleted and requires HasSnapshotTestingChangedToFinished for update events.
 func IntegrationSnapshotChangePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
@@ -19,7 +19,7 @@ func IntegrationSnapshotChangePredicate() predicate.Predicate {
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return true
+			return HasSnapshotTestingChangedToFinished(e.ObjectOld, e.ObjectNew)
 		},
 	}
 }

--- a/gitops/snapshot_predicate_test.go
+++ b/gitops/snapshot_predicate_test.go
@@ -123,6 +123,13 @@ var _ = Describe("Predicates", Ordered, func() {
 			}
 			Expect(instance.Update(contextEvent)).To(BeTrue())
 		})
+		It("returns false when the old Snapshot has true status and the new one has true status", func() {
+			contextEvent := event.UpdateEvent{
+				ObjectOld: hasSnapshotTrueStatus,
+				ObjectNew: hasSnapshotTrueStatus,
+			}
+			Expect(instance.Update(contextEvent)).To(BeFalse())
+		})
 		It("returns false when the Snapshot is deleted", func() {
 			contextEvent := event.DeleteEvent{
 				Object: hasSnapshotUnknownStatus,


### PR DESCRIPTION
Change the logic for updating the GCL (Global Candidate List).

* Move setting integration status to pipeline adapter
* Mark the Snapshot as invalid if superseded
* Add IsSnapshotValid and CanSnapshotBePromoted functions
* Check CanSnapshotBePromoted in snapshot adapter
* Add HasSnapshotTestingChangedToFinished function
* Use the function for snapshot update events