### PR TITLE
feat(HACBS-1629): Dockerfile linter

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,15 @@ on:
 
 jobs:
 
+  Dockerfile-linter:
+    name: Check Dockerfiles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
   go:
     name: Check sources
     runs-on: ubuntu-20.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build the manager binary
 FROM registry.access.redhat.com/ubi8/go-toolset:1.18.9-13 as builder
 
+WORKDIR /opt/app-root/src
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum


### PR DESCRIPTION
Fixes: [HACBS-1629](https://issues.redhat.com/browse/HACBS-1629)

Hadolint is a Dockerfile linter that helps you build best practice Docker images.