### PR TITLE
feat(STONEINTG-291): Deny egress connections

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- network_policy.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Egress
+  egress:
+    - to:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            apiserver: "true"
+            app: openshift-kube-apiserver
+      ports:
+        - port: 6443
+          protocol: TCP
+    - to:
+      - ipBlock:
+          cidr: 172.20.0.1/32  # hypershift default
+      ports:
+        - port: 6443
+          protocol: TCP


### PR DESCRIPTION
This is for security hardening, integration-service is not supposed to be communicating with the internet, only kube-api should be allowed.

Note: this also blocks DNS resolving