### PR TITLE
fix: set permissions to update Component.Status

### DIFF
--- a/config/rbac/component_editor_role.yaml
+++ b/config/rbac/component_editor_role.yaml
@@ -25,3 +25,5 @@ rules:
   - components/status
   verbs:
   - get
+  - patch
+  - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,24 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - components
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - components/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
   - environments
   verbs:
   - get

--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -53,6 +53,8 @@ func NewSnapshotReconciler(client client.Client, logger *logr.Logger, scheme *ru
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/finalizers,verbs=update
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components/status,verbs=get;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
### Need for this PR:

Previously merged PR: #141 deals with updating the `Status` field of the component, but currently our service doesn't have the required permissions to do this. So this PR adds those permissions and fixes the [failing e2e-test](https://github.com/redhat-appstudio/infra-deployments/pull/1638#issuecomment-1503315698).