### PR TITLE
feat(STONEINTG-180): migrate to pipelineRun TaskRun childReferences

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -137,3 +137,17 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns/status
+  verbs:
+  - get

--- a/controllers/pipeline/pipeline_adapter.go
+++ b/controllers/pipeline/pipeline_adapter.go
@@ -229,7 +229,7 @@ func (a *Adapter) EnsureStatusReported() (reconciler.OperationResult, error) {
 	}
 
 	for _, reporter := range reporters {
-		if err := reporter.ReportStatus(a.context, a.pipelineRun); err != nil {
+		if err := reporter.ReportStatus(a.client, a.context, a.pipelineRun); err != nil {
 			return reconciler.RequeueWithError(err)
 		}
 	}
@@ -327,7 +327,7 @@ func (a *Adapter) determineIfAllIntegrationPipelinesPassed(integrationPipelineRu
 	allIntegrationPipelineRunsPassed := true
 	for _, integrationPipelineRun := range *integrationPipelineRuns {
 		integrationPipelineRun := integrationPipelineRun // G601
-		pipelineRunOutcome, err := helpers.CalculateIntegrationPipelineRunOutcome(a.logger, &integrationPipelineRun)
+		pipelineRunOutcome, err := helpers.CalculateIntegrationPipelineRunOutcome(a.client, a.context, a.logger, &integrationPipelineRun)
 		if err != nil {
 			a.logger.Error(err, "Failed to get Integration PipelineRun outcome",
 				"PipelineRun.Name", integrationPipelineRun.Name, "PipelineRun.Namespace", integrationPipelineRun.Namespace)

--- a/controllers/pipeline/pipeline_adapter_test.go
+++ b/controllers/pipeline/pipeline_adapter_test.go
@@ -41,6 +41,7 @@ import (
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tonglil/buflogr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type MockStatusAdapter struct {
@@ -53,7 +54,7 @@ type MockStatusReporter struct {
 	ReportStatusError error
 }
 
-func (r *MockStatusReporter) ReportStatus(context.Context, *tektonv1beta1.PipelineRun) error {
+func (r *MockStatusReporter) ReportStatus(client.Client, context.Context, *tektonv1beta1.PipelineRun) error {
 	r.Called = true
 	return r.ReportStatusError
 }

--- a/controllers/pipeline/pipeline_adapter_test.go
+++ b/controllers/pipeline/pipeline_adapter_test.go
@@ -216,7 +216,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 											"result": "SUCCESS",
 											"timestamp": "1665405318",
 											"failures": 0,
-											"successes": 10
+											"successes": 10,
+											"warnings": 0
 										}`),
 					},
 				},

--- a/controllers/pipeline/pipeline_controller.go
+++ b/controllers/pipeline/pipeline_controller.go
@@ -52,6 +52,8 @@ func NewIntegrationReconciler(client client.Client, logger *logr.Logger, scheme 
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/finalizers,verbs=update
+//+kubebuilder:rbac:groups=tekton.dev,resources=taskruns,verbs=get;list;watch
+//+kubebuilder:rbac:groups=tekton.dev,resources=taskruns/status,verbs=get
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=pipelinesascode.tekton.dev,resources=repositories,verbs=get;list;watch

--- a/controllers/pipeline/pipeline_controller_test.go
+++ b/controllers/pipeline/pipeline_controller_test.go
@@ -115,7 +115,8 @@ var _ = Describe("PipelineController", func() {
 											"result": "SUCCESS",
 											"timestamp": "1665405318",
 											"failures": 0,
-											"successes": 10
+											"successes": 10,
+											"warnings": 0
 										}`),
 					},
 				},

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/redhat-appstudio/application-api v0.0.0-20230323195735-25c812747051
 	github.com/redhat-appstudio/operator-goodies v0.0.0-20221130140446-010c05bd7471
 	github.com/redhat-appstudio/release-service v0.0.0-20230314103738-21edb2dadc4e
-	github.com/tektoncd/pipeline v0.44.0
+	github.com/tektoncd/pipeline v0.45.0
 	github.com/tonglil/buflogr v1.0.1
 	golang.org/x/oauth2 v0.5.0
 	k8s.io/api v0.26.1
@@ -76,7 +76,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/crypto v0.5.0 // indirect
+	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
-github.com/tektoncd/pipeline v0.44.0 h1:gTiLCjTDDog3R9sRtQugiIZYqadmq5K6HArrtM1sHkU=
-github.com/tektoncd/pipeline v0.44.0/go.mod h1:z8D9m9nnG2JQGHTpRw/sie9tK37odai/iONmYaY7llA=
+github.com/tektoncd/pipeline v0.45.0 h1:Hv9kyutu5GWGXKtcMrM7PXdAULgeQc0F2HWDNg+jo5c=
+github.com/tektoncd/pipeline v0.45.0/go.mod h1:20Xs6qk3BTpsLHYWEtLNPM44XKqNH5jYwoomXHOGNs8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
 github.com/tonglil/buflogr v1.0.1/go.mod h1:yYWwvSpn/3uAaqjf6mJg/XMiAciaR0QcRJH2gJGDxNE=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -385,8 +385,8 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.5.0 h1:U/0M97KRkSFvyD/3FSmdP5W5swImpNgle/EHFhOsQPE=
-golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
+golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
+golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"k8s.io/apimachinery/pkg/types"
 	"reflect"
 	"sort"
@@ -37,9 +38,6 @@ const (
 
 	// HACBSTestOutputError is the result that's set when the HACBS test produces an error.
 	HACBSTestOutputError = "ERROR"
-
-	// AppStudioLabelSuffix is the suffix that's added to all HACBS label headings
-	AppStudioLabelSuffix = "appstudio.openshift.io"
 )
 
 // HACBSTestResult matches HACBS TaskRun result contract
@@ -185,7 +183,7 @@ func CalculateIntegrationPipelineRunOutcome(adapterClient client.Client, ctx con
 		// If the pipelineRun.Status contains the childReferences, parse them in the new way by querying for TaskRuns
 		results, err = GetHACBSTestResultsFromPipelineRunWithChildReferences(adapterClient, ctx, logger, pipelineRun)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("error while getting test results from pipelineRun %s: %w", pipelineRun.Name, err)
 		}
 	}
 
@@ -326,7 +324,7 @@ func GetAllChildTaskRunsForPipelineRun(adapterClient client.Client, ctx context.
 			Name:      childReference.Name,
 		}, pipelineTaskRun)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error while getting the child taskRun %s from pipelineRun: %w", childReference.Name, err)
 		}
 
 		integrationTaskRun := NewTaskRunFromTektonTaskRun(logger, childReference.PipelineTaskName, &pipelineTaskRun.Status)

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -105,7 +105,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 											"result": "SUCCESS",
 											"timestamp": "1665405318",
 											"failures": 0,
-											"successes": 10
+											"successes": 10,
+											"warnings": 0
 										}`),
 					},
 				},
@@ -139,7 +140,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 											"result": "FAILURE",
 											"timestamp": "1665405317",
 											"failures": 1,
-											"successes": 0
+											"successes": 0,
+											"warnings": 0
 										}`),
 					},
 				},
@@ -173,7 +175,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 											"result": "SKIPPED",
 											"timestamp": "1665405318",
 											"failures": 0,
-											"successes": 0
+											"successes": 0,
+											"warnings": 0
 										}`),
 					},
 				},

--- a/status/format_test.go
+++ b/status/format_test.go
@@ -26,7 +26,7 @@ const expectedSummary = `| Task | Duration | Test Suite | Status | Details |
 [^example-task-4]: example note 4`
 
 func newTaskRun(name string, startTime time.Time, completionTime time.Time) *helpers.TaskRun {
-	return helpers.NewTaskRun(logr.Discard(), &tektonv1beta1.PipelineRunTaskRunStatus{
+	return helpers.NewTaskRunFromPipelineRunStatus(logr.Discard(), &tektonv1beta1.PipelineRunTaskRunStatus{
 		PipelineTaskName: name,
 		Status: &tektonv1beta1.TaskRunStatus{
 			TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
@@ -39,7 +39,7 @@ func newTaskRun(name string, startTime time.Time, completionTime time.Time) *hel
 }
 
 func newTaskRunWithHACBSTestOutput(name string, startTime time.Time, completionTime time.Time, output string) *helpers.TaskRun {
-	return helpers.NewTaskRun(logr.Discard(), &tektonv1beta1.PipelineRunTaskRunStatus{
+	return helpers.NewTaskRunFromPipelineRunStatus(logr.Discard(), &tektonv1beta1.PipelineRunTaskRunStatus{
 		PipelineTaskName: name,
 		Status: &tektonv1beta1.TaskRunStatus{
 			TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{

--- a/status/format_test.go
+++ b/status/format_test.go
@@ -26,30 +26,24 @@ const expectedSummary = `| Task | Duration | Test Suite | Status | Details |
 [^example-task-4]: example note 4`
 
 func newTaskRun(name string, startTime time.Time, completionTime time.Time) *helpers.TaskRun {
-	return helpers.NewTaskRunFromPipelineRunStatus(logr.Discard(), &tektonv1beta1.PipelineRunTaskRunStatus{
-		PipelineTaskName: name,
-		Status: &tektonv1beta1.TaskRunStatus{
-			TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
-				StartTime:      &metav1.Time{Time: startTime},
-				CompletionTime: &metav1.Time{Time: completionTime},
-				TaskRunResults: []tektonv1beta1.TaskRunResult{},
-			},
+	return helpers.NewTaskRunFromTektonTaskRun(logr.Discard(), name, &tektonv1beta1.TaskRunStatus{
+		TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
+			StartTime:      &metav1.Time{Time: startTime},
+			CompletionTime: &metav1.Time{Time: completionTime},
+			TaskRunResults: []tektonv1beta1.TaskRunResult{},
 		},
 	})
 }
 
 func newTaskRunWithHACBSTestOutput(name string, startTime time.Time, completionTime time.Time, output string) *helpers.TaskRun {
-	return helpers.NewTaskRunFromPipelineRunStatus(logr.Discard(), &tektonv1beta1.PipelineRunTaskRunStatus{
-		PipelineTaskName: name,
-		Status: &tektonv1beta1.TaskRunStatus{
-			TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
-				StartTime:      &metav1.Time{Time: startTime},
-				CompletionTime: &metav1.Time{Time: completionTime},
-				TaskRunResults: []tektonv1beta1.TaskRunResult{
-					{
-						Name:  "HACBS_TEST_OUTPUT",
-						Value: *tektonv1beta1.NewArrayOrString(output),
-					},
+	return helpers.NewTaskRunFromTektonTaskRun(logr.Discard(), name, &tektonv1beta1.TaskRunStatus{
+		TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
+			StartTime:      &metav1.Time{Time: startTime},
+			CompletionTime: &metav1.Time{Time: completionTime},
+			TaskRunResults: []tektonv1beta1.TaskRunResult{
+				{
+					Name:  "HACBS_TEST_OUTPUT",
+					Value: *tektonv1beta1.NewArrayOrString(output),
 				},
 			},
 		},

--- a/status/reporters.go
+++ b/status/reporters.go
@@ -188,7 +188,7 @@ func (r *GitHubReporter) createCheckRunAdapter(k8sClient client.Client, ctx cont
 
 	taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(r.k8sClient, ctx, r.logger, pipelineRun)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error while getting all child taskRuns from pipelineRun %s: %w", pipelineRun.Name, err)
 	}
 	summary, err := FormatSummary(taskRuns)
 	if err != nil {
@@ -335,7 +335,7 @@ func (r *GitHubReporter) createComment(k8sClient client.Client, ctx context.Cont
 
 	taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(r.k8sClient, ctx, r.logger, pipelineRun)
 	if err != nil {
-		return err
+		return fmt.Errorf("error while getting all child taskRuns from pipelineRun %s: %w", pipelineRun.Name, err)
 	}
 	comment, err := FormatComment(title, taskRuns)
 	if err != nil {

--- a/status/status.go
+++ b/status/status.go
@@ -15,7 +15,7 @@ const NamePrefix = "HACBS Test"
 
 // Reporter is a generic interface all status implementations must follow.
 type Reporter interface {
-	ReportStatus(context.Context, *tektonv1beta1.PipelineRun) error
+	ReportStatus(client.Client, context.Context, *tektonv1beta1.PipelineRun) error
 }
 
 // Status is the interface of the main status Adapter.
@@ -41,7 +41,7 @@ func WithGitHubReporter(reporter Reporter) AdapterOption {
 }
 
 // NewAdapter constructs an Adapter with optional params, if specified.
-func NewAdapter(logger logr.Logger, k8sClient client.Reader, opts ...AdapterOption) *Adapter {
+func NewAdapter(logger logr.Logger, k8sClient client.Client, opts ...AdapterOption) *Adapter {
 	adapter := Adapter{
 		logger:         logger,
 		k8sClient:      k8sClient,

--- a/status/status_suite_test.go
+++ b/status/status_suite_test.go
@@ -1,102 +1,13 @@
 package status_test
 
-/*
-Copyright 2022.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 import (
-	"context"
-	goodies "github.com/redhat-appstudio/operator-goodies/test"
-	"go/build"
-	"path/filepath"
 	"testing"
-
-	"k8s.io/client-go/rest"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-
-	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	integrationalpha1 "github.com/redhat-appstudio/integration-service/api/v1alpha1"
-	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	ctx       context.Context
-	cancel    context.CancelFunc
-)
-
-func TestStatus(t *testing.T) {
+func TestHelpers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Status Suite")
 }
-
-var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	//adding required CRDs
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "config", "crd", "bases"),
-			filepath.Join(
-				build.Default.GOPATH,
-				"pkg", "mod", goodies.GetRelativeDependencyPath("tektoncd/pipeline"), "config",
-			),
-			filepath.Join(
-				build.Default.GOPATH,
-				"pkg", "mod", goodies.GetRelativeDependencyPath("application-api"), "config", "crd", "bases",
-			),
-		},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	var err error
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	Expect(applicationapiv1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
-	Expect(tektonv1beta1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
-	Expect(releasev1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
-	Expect(integrationalpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
-
-	k8sManager, _ := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             clientsetscheme.Scheme,
-		MetricsBindAddress: "0", // this disables metrics
-		LeaderElection:     false,
-	})
-
-	k8sClient = k8sManager.GetClient()
-	go func() {
-		defer GinkgoRecover()
-		Expect(k8sManager.Start(ctx)).To(Succeed())
-	}()
-})
-
-var _ = AfterSuite(func() {
-	cancel()
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
-})

--- a/status/status_suite_test.go
+++ b/status/status_suite_test.go
@@ -1,13 +1,102 @@
 package status_test
 
+/*
+Copyright 2022.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import (
+	"context"
+	goodies "github.com/redhat-appstudio/operator-goodies/test"
+	"go/build"
+	"path/filepath"
 	"testing"
+
+	"k8s.io/client-go/rest"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	integrationalpha1 "github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-func TestHelpers(t *testing.T) {
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestStatus(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Status Suite")
 }
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	//adding required CRDs
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "config", "crd", "bases"),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", goodies.GetRelativeDependencyPath("tektoncd/pipeline"), "config",
+			),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", goodies.GetRelativeDependencyPath("application-api"), "config", "crd", "bases",
+			),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	Expect(applicationapiv1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(tektonv1beta1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(releasev1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(integrationalpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+
+	k8sManager, _ := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             clientsetscheme.Scheme,
+		MetricsBindAddress: "0", // this disables metrics
+		LeaderElection:     false,
+	})
+
+	k8sClient = k8sManager.GetClient()
+	go func() {
+		defer GinkgoRecover()
+		Expect(k8sManager.Start(ctx)).To(Succeed())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/go-logr/logr"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type MockReporter struct{}
 
-func (r *MockReporter) ReportStatus(context.Context, *tektonv1beta1.PipelineRun) error {
+func (r *MockReporter) ReportStatus(client.Client, context.Context, *tektonv1beta1.PipelineRun) error {
 	return nil
 }
 

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -89,9 +89,9 @@ func GetTypeFromPipelineRun(object client.Object) (string, error) {
 // GetOutputImage returns a string containing the output-image parameter value from a given PipelineRun.
 func GetOutputImage(object client.Object) (string, error) {
 	if pipelineRun, ok := object.(*tektonv1beta1.PipelineRun); ok {
-		for _, param := range pipelineRun.Spec.Params {
-			if param.Name == "output-image" {
-				return param.Value.StringVal, nil
+		for _, pipelineResult := range pipelineRun.Status.PipelineResults {
+			if pipelineResult.Name == "IMAGE_URL" {
+				return pipelineResult.Value.StringVal, nil
 			}
 		}
 	}
@@ -101,13 +101,9 @@ func GetOutputImage(object client.Object) (string, error) {
 // GetOutputImageDigest returns a string containing the IMAGE_DIGEST result value from a given PipelineRun.
 func GetOutputImageDigest(object client.Object) (string, error) {
 	if pipelineRun, ok := object.(*tektonv1beta1.PipelineRun); ok {
-		for _, taskRun := range pipelineRun.Status.TaskRuns {
-			if taskRun.PipelineTaskName == "build-container" {
-				for _, taskRunResult := range taskRun.Status.TaskRunResults {
-					if taskRunResult.Name == "IMAGE_DIGEST" {
-						return taskRunResult.Value.StringVal, nil
-					}
-				}
+		for _, pipelineResult := range pipelineRun.Status.PipelineResults {
+			if pipelineResult.Name == "IMAGE_DIGEST" {
+				return pipelineResult.Value.StringVal, nil
 			}
 		}
 	}

--- a/tekton/utils_test.go
+++ b/tekton/utils_test.go
@@ -31,22 +31,15 @@ var _ = Describe("Utils", func() {
 			},
 			Status: tektonv1beta1.PipelineRunStatus{
 				PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
-					TaskRuns: map[string]*tektonv1beta1.PipelineRunTaskRunStatus{
-						"index1": {
-							PipelineTaskName: "build-container",
-							Status: &tektonv1beta1.TaskRunStatus{
-								TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
-									TaskRunResults: []tektonv1beta1.TaskRunResult{
-										{
-											Name:  "IMAGE_DIGEST",
-											Value: *tektonv1beta1.NewArrayOrString("image_digest_value"),
-										},
-									},
-								},
-							},
-						},
-					},
 					PipelineResults: []tektonv1beta1.PipelineRunResult{
+						{
+							Name:  "IMAGE_DIGEST",
+							Value: *tektonv1beta1.NewArrayOrString("image_digest_value"),
+						},
+						{
+							Name:  "IMAGE_URL",
+							Value: *tektonv1beta1.NewArrayOrString("test-image"),
+						},
 						{
 							Name:  "CHAINS-GIT_URL",
 							Value: *tektonv1beta1.NewArrayOrString("https://github.com/devfile-samples/devfile-sample-java-springboot-basic"),


### PR DESCRIPTION
* Upgrade tektoncd/pipeline to v0.45.0
* Stop supporting embedded TaskRun statuses in pipelineRuns
* Refactor GitHub reporter to utilize the new functions
* Refactor tekton utils to fetch PipelineRun results for output image URL and digest
* Update all unit tests to use the childReference TaskRuns