### PR TITLE
test(STONEINTG-385): update unit tests to be more clear about errors

### DIFF
--- a/controllers/pipeline/pipeline_adapter_test.go
+++ b/controllers/pipeline/pipeline_adapter_test.go
@@ -370,41 +370,41 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 	It("ensures the Application Components can be found ", func() {
 		applicationComponents, err := adapter.getAllApplicationComponents(hasApp)
-		Expect(err == nil).To(BeTrue())
-		Expect(applicationComponents != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(applicationComponents).NotTo(BeNil())
 	})
 
 	It("ensures the Imagepullspec and ComponentSource from pipelinerun and prepare snapshot can be created", func() {
 		imagePullSpec, err := adapter.getImagePullSpecFromPipelineRun(testpipelineRunBuild)
-		Expect(err == nil).To(BeTrue())
-		Expect(imagePullSpec != "").To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(imagePullSpec).NotTo(BeEmpty())
 
 		componentSource, err := adapter.getComponentSourceFromPipelineRun(testpipelineRunBuild)
-		Expect(err == nil).To(BeTrue())
+		Expect(err).To(BeNil())
 
 		snapshot, err := adapter.prepareSnapshot(hasApp, hasComp, imagePullSpec, componentSource)
-		Expect(snapshot != nil).To(BeTrue())
-		Expect(err == nil).To(BeTrue())
-		Expect(snapshot != nil).To(BeTrue())
+		Expect(snapshot).NotTo(BeNil())
+		Expect(err).To(BeNil())
+		Expect(snapshot).NotTo(BeNil())
 		Expect(snapshot.Spec.Components).To(HaveLen(1), "One component should have been added to snapshot.  Other component should have been omited due to empty ContainerImage field")
 		Expect(snapshot.Spec.Components[0].Name).To(Equal(hasComp.Name), "The built component should have been added to the snapshot")
 
 		fetchedPullSpec, err := adapter.getImagePullSpecFromSnapshotComponent(snapshot, hasComp)
-		Expect(err == nil).To(BeTrue())
-		Expect(fetchedPullSpec != "").To(BeTrue())
-		Expect(fetchedPullSpec == imagePullSpec).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(fetchedPullSpec).NotTo(BeEmpty())
+		Expect(fetchedPullSpec).To(Equal(imagePullSpec))
 
 		fetchedComponentSource, err := adapter.getComponentSourceFromSnapshotComponent(snapshot, hasComp)
-		Expect(err == nil).To(BeTrue())
-		Expect(fetchedComponentSource != nil).To(BeTrue())
-		Expect(componentSource.ComponentSourceUnion.GitSource.URL == fetchedComponentSource.ComponentSourceUnion.GitSource.URL).To(BeTrue())
-		Expect(componentSource.ComponentSourceUnion.GitSource.Revision == fetchedComponentSource.ComponentSourceUnion.GitSource.Revision).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(fetchedComponentSource).NotTo(BeNil())
+		Expect(componentSource.ComponentSourceUnion.GitSource.URL).To(Equal(fetchedComponentSource.ComponentSourceUnion.GitSource.URL))
+		Expect(componentSource.ComponentSourceUnion.GitSource.Revision).To(Equal(fetchedComponentSource.ComponentSourceUnion.GitSource.Revision))
 	})
 
 	It("ensures that snapshot has label pointing to build pipelinerun", func() {
 		expectedSnapshot, err := adapter.prepareSnapshotForPipelineRun(testpipelineRunBuild, hasComp, hasApp)
-		Expect(err == nil).To(BeTrue())
-		Expect(expectedSnapshot != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(expectedSnapshot).NotTo(BeNil())
 
 		Expect(expectedSnapshot.Labels).NotTo(BeNil())
 		Expect(expectedSnapshot.Labels).Should(HaveKeyWithValue(Equal(gitops.BuildPipelineRunNameLabel), Equal(testpipelineRunBuild.Name)))
@@ -412,13 +412,13 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 	It("ensures the global component list unchanged and compositeSnapshot shouldn't be created ", func() {
 		expectedSnapshot, err := adapter.prepareSnapshotForPipelineRun(testpipelineRunBuild, hasComp, hasApp)
-		Expect(err == nil).To(BeTrue())
-		Expect(expectedSnapshot != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(expectedSnapshot).NotTo(BeNil())
 
 		// Check if the global component list changed in the meantime and create a composite snapshot if it did.
 		compositeSnapshot, err := adapter.createCompositeSnapshotsIfConflictExists(hasApp, hasComp, expectedSnapshot)
-		Expect(err == nil).To(BeTrue())
-		Expect(compositeSnapshot == nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(compositeSnapshot).To(BeNil())
 	})
 
 	It("ensures the global component list is changed and compositeSnapshot should be created", func() {
@@ -461,8 +461,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		compositeSnapshot, err := adapter.createCompositeSnapshotsIfConflictExists(hasApp, hasComp, createdSnapshot)
 		fmt.Fprintf(GinkgoWriter, "compositeSnapshot.Name: %v\n", compositeSnapshot.Name)
 
-		Expect(err == nil).To(BeTrue())
-		Expect(compositeSnapshot != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(compositeSnapshot).NotTo(BeNil())
 
 		Eventually(func() error {
 			err := k8sClient.Get(ctx, types.NamespacedName{
@@ -474,26 +474,26 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 		// Check if the composite snapshot that was already created above was correctly detected and returned.
 		existingCompositeSnapshot, err := adapter.createCompositeSnapshotsIfConflictExists(hasApp, hasComp, createdSnapshot)
-		Expect(err == nil).To(BeTrue())
-		Expect(existingCompositeSnapshot != nil).To(BeTrue())
-		Expect(existingCompositeSnapshot.Name == compositeSnapshot.Name).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(existingCompositeSnapshot).NotTo(BeNil())
+		Expect(existingCompositeSnapshot.Name).To(Equal(compositeSnapshot.Name))
 
 		componentSource, _ := adapter.getComponentSourceFromSnapshotComponent(existingCompositeSnapshot, hasCompNew)
-		Expect(componentSource.GitSource.Revision == "lastbuildcommit").To(BeTrue())
+		Expect(componentSource.GitSource.Revision).To(Equal("lastbuildcommit"))
 		err = k8sClient.Delete(ctx, hasCompNew)
 		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
 	})
 
 	It("ensure ComponentSource can returned when component have Status.LastBuiltCommit defined or not", func() {
 		componentSource := adapter.getComponentSourceFromComponent(hasComp)
-		Expect(componentSource.GitSource.Revision == "a2ba645d50e471d5f084b").To(BeTrue())
+		Expect(componentSource.GitSource.Revision).To(Equal("a2ba645d50e471d5f084b"))
 
 		hasComp.Status = applicationapiv1alpha1.ComponentStatus{
 			LastBuiltCommit: "lastbuildcommit",
 		}
 		Expect(k8sClient.Status().Update(ctx, hasComp)).Should(Succeed())
 		componentSource = adapter.getComponentSourceFromComponent(hasComp)
-		Expect(componentSource.GitSource.Revision == "lastbuildcommit").To(BeTrue())
+		Expect(componentSource.GitSource.Revision).To(Equal("lastbuildcommit"))
 	})
 
 	It("ensure err is returned when pipelinerun doesn't have Result for ", func() {
@@ -617,15 +617,15 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		}, time.Second*10).Should(BeTrue())
 
 		integrationTestScenarios, err := helpers.GetRequiredIntegrationTestScenariosForApplication(k8sClient, ctx, hasApp)
-		Expect(err == nil).To(BeTrue())
+		Expect(err).To(BeNil())
 		Expect(len(*integrationTestScenarios) > 0).To(BeTrue())
 
 		integrationPipelineRuns, err := adapter.getAllPipelineRunsForSnapshot(hasSnapshot, integrationTestScenarios)
-		Expect(err == nil).To(BeTrue())
+		Expect(err).To(BeNil())
 		Expect(len(*integrationPipelineRuns) > 0).To(BeTrue())
 
 		allIntegrationPipelineRunsPassed, err := adapter.determineIfAllIntegrationPipelinesPassed(integrationPipelineRuns)
-		Expect(err == nil).To(BeTrue())
+		Expect(err).To(BeNil())
 		Expect(allIntegrationPipelineRunsPassed).To(BeTrue())
 	})
 

--- a/controllers/scenario/scenario_adapter_test.go
+++ b/controllers/scenario/scenario_adapter_test.go
@@ -203,15 +203,15 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 
 	It("ensures the Scenario status can be marked as invalid", func() {
 		SetScenarioIntegrationStatusAsInvalid(invalidScenario, "Test message")
-		Expect(invalidScenario != nil).To(BeTrue())
-		Expect(invalidScenario.Status.Conditions != nil).To(BeTrue())
+		Expect(invalidScenario).NotTo(BeNil())
+		Expect(invalidScenario.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionFalse(invalidScenario.Status.Conditions, gitops.IntegrationTestScenarioValid)).To(BeTrue())
 	})
 
 	It("ensures the Scenario status can be marked as valid", func() {
 		SetScenarioIntegrationStatusAsValid(integrationTestScenario, "Test message")
-		Expect(integrationTestScenario != nil).To(BeTrue())
-		Expect(integrationTestScenario.Status.Conditions != nil).To(BeTrue())
+		Expect(integrationTestScenario).NotTo(BeNil())
+		Expect(integrationTestScenario.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(integrationTestScenario.Status.Conditions, gitops.IntegrationTestScenarioValid)).To(BeTrue())
 	})
 

--- a/controllers/scenario/scenario_controller_test.go
+++ b/controllers/scenario/scenario_controller_test.go
@@ -154,8 +154,8 @@ var _ = Describe("ScenarioController", func() {
 
 	It("Run reconciler for scenario", func() {
 		hasApp, err := scenarioReconciler.getApplicationFromScenario(ctx, failScenario)
-		Expect(err != nil).To(BeTrue())
-		Expect(hasApp == nil).To(BeTrue())
+		Expect(err).NotTo(BeNil())
+		Expect(hasApp).To(BeNil())
 		Expect(err).To(HaveOccurred())
 	})
 

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -284,8 +284,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 	It("ensures the Applicationcomponents can be found ", func() {
 		applicationComponents, err := adapter.getAllApplicationComponents(hasApp)
-		Expect(err == nil).To(BeTrue())
-		Expect(applicationComponents != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(applicationComponents).NotTo(BeNil())
 	})
 
 	It("ensures the integrationTestPipelines are created", func() {
@@ -295,7 +295,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		}, time.Second*20).Should(BeTrue())
 
 		requiredIntegrationTestScenarios, err := helpers.GetRequiredIntegrationTestScenariosForApplication(k8sClient, ctx, hasApp)
-		Expect(requiredIntegrationTestScenarios != nil && err == nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(requiredIntegrationTestScenarios).NotTo(BeNil())
 		if requiredIntegrationTestScenarios != nil {
 			for _, requiredIntegrationTestScenario := range *requiredIntegrationTestScenarios {
 				requiredIntegrationTestScenario := requiredIntegrationTestScenario
@@ -329,8 +330,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		}, time.Second*10).Should(BeTrue())
 
 		releases, err := adapter.getReleasesWithSnapshot(hasSnapshot)
-		Expect(err == nil).To(BeTrue())
-		Expect(releases != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(releases).NotTo(BeNil())
 		for _, release := range *releases {
 			Expect(k8sClient.Delete(ctx, &release)).Should(Succeed())
 		}

--- a/gitops/gitops_test.go
+++ b/gitops/gitops_test.go
@@ -154,7 +154,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 		Expect(gitops.HaveHACBSTestsSucceeded(hasSnapshot)).To(BeTrue())
 		bindingComponents := gitops.NewBindingComponents([]applicationapiv1alpha1.Component{*hasComp})
-		Expect(bindingComponents != nil).To(BeTrue())
+		Expect(bindingComponents).NotTo(BeNil())
 	})
 
 	It("ensures Snapshot Environment Binding is created and exists", func() {
@@ -162,7 +162,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		snapshotEnvironmentBinding := gitops.NewSnapshotEnvironmentBinding(
 			bindingName, hasApp.Namespace, hasApp.Name,
 			env.Name, hasSnapshot, []applicationapiv1alpha1.Component{*hasComp})
-		Expect(snapshotEnvironmentBinding != nil).To(BeTrue())
+		Expect(snapshotEnvironmentBinding).NotTo(BeNil())
 		Expect(k8sClient.Create(ctx, snapshotEnvironmentBinding)).Should(Succeed())
 		Eventually(func() bool {
 			snapshotEnvironmentBinding, err := gitops.FindExistingSnapshotEnvironmentBinding(k8sClient, ctx, hasApp, &env)

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -112,42 +112,42 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 	It("ensures the Snapshots status can be marked as passed", func() {
 		updatedSnapshot, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "Test message")
-		Expect(err == nil).To(BeTrue())
-		Expect(updatedSnapshot != nil).To(BeTrue())
-		Expect(updatedSnapshot.Status.Conditions != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(updatedSnapshot).NotTo(BeNil())
+		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.HACBSTestSuceededCondition)).To(BeTrue())
 	})
 
 	It("ensures the Snapshots status can be marked as failed", func() {
 		updatedSnapshot, err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "Test message")
-		Expect(err == nil).To(BeTrue())
-		Expect(updatedSnapshot != nil).To(BeTrue())
-		Expect(updatedSnapshot.Status.Conditions != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(updatedSnapshot).NotTo(BeNil())
+		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.HACBSTestSuceededCondition)).To(BeFalse())
 	})
 
 	It("ensures the Snapshots status can be marked as invalid", func() {
 		gitops.SetSnapshotIntegrationStatusAsInvalid(hasSnapshot, "Test message")
-		Expect(hasSnapshot != nil).To(BeTrue())
-		Expect(hasSnapshot.Status.Conditions != nil).To(BeTrue())
+		Expect(hasSnapshot).NotTo(BeNil())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.HACBSIntegrationStatusCondition)).To(BeFalse())
 	})
 
 	It("ensures the Snapshots status can be marked as finished", func() {
 		gitops.SetSnapshotIntegrationStatusAsFinished(hasSnapshot, "Test message")
-		Expect(hasSnapshot.Status.Conditions != nil).To(BeTrue())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.HACBSIntegrationStatusCondition)).To(BeTrue())
 		foundStatusCondition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.HACBSIntegrationStatusCondition)
-		Expect(foundStatusCondition.Reason == gitops.HACBSIntegrationStatusFinished).To(BeTrue())
+		Expect(foundStatusCondition.Reason).To(Equal(gitops.HACBSIntegrationStatusFinished))
 	})
 
 	It("ensures the Snapshots status can be marked as in progress", func() {
 		updatedSnapshot, err := gitops.MarkSnapshotIntegrationStatusAsInProgress(k8sClient, ctx, hasSnapshot, "Test message")
-		Expect(err == nil).To(BeTrue())
-		Expect(updatedSnapshot != nil).To(BeTrue())
-		Expect(updatedSnapshot.Status.Conditions != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(updatedSnapshot).NotTo(BeNil())
+		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
 		foundStatusCondition := meta.FindStatusCondition(updatedSnapshot.Status.Conditions, gitops.HACBSIntegrationStatusCondition)
-		Expect(foundStatusCondition.Reason == gitops.HACBSIntegrationStatusInProgress).To(BeTrue())
+		Expect(foundStatusCondition.Reason).To(Equal(gitops.HACBSIntegrationStatusInProgress))
 	})
 
 	It("ensures the Snapshots can be checked for the HACBSTestSuceededCondition", func() {
@@ -163,21 +163,21 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	It("ensures that a new Snapshots can be successfully created", func() {
 		snapshotComponents := []applicationapiv1alpha1.SnapshotComponent{}
 		createdSnapshot := gitops.NewSnapshot(hasApp, &snapshotComponents)
-		Expect(createdSnapshot != nil).To(BeTrue())
+		Expect(createdSnapshot).NotTo(BeNil())
 	})
 
 	It("ensures a matching Snapshot can be found", func() {
 		expectedSnapshot := hasSnapshot.DeepCopy()
 		foundSnapshot, err := gitops.FindMatchingSnapshot(k8sClient, ctx, hasApp, expectedSnapshot)
-		Expect(err == nil).To(BeTrue())
-		Expect(foundSnapshot != nil).To(BeTrue())
-		Expect(foundSnapshot.Name == hasSnapshot.Name).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(foundSnapshot).NotTo(BeNil())
+		Expect(foundSnapshot.Name).To(Equal(hasSnapshot.Name))
 	})
 
 	It("ensures that all Snapshots for a given application can be found", func() {
 		snapshots, err := gitops.GetAllSnapshots(k8sClient, ctx, hasApp)
-		Expect(err == nil).To(BeTrue())
-		Expect(snapshots != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(snapshots).NotTo(BeNil())
 	})
 
 	It("ensures the same Snapshots can be successfully compared", func() {
@@ -199,56 +199,56 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 	It("ensures the Snapshots status can be detected to be invalid", func() {
 		gitops.SetSnapshotIntegrationStatusAsInvalid(hasSnapshot, "Test message")
-		Expect(hasSnapshot != nil).To(BeTrue())
-		Expect(hasSnapshot.Status.Conditions != nil).To(BeTrue())
+		Expect(hasSnapshot).NotTo(BeNil())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(gitops.IsSnapshotValid(hasSnapshot)).To(BeFalse())
 	})
 
 	It("ensures the Snapshots status can be detected to be valid", func() {
 		gitops.SetSnapshotIntegrationStatusAsFinished(hasSnapshot, "Test message")
-		Expect(hasSnapshot != nil).To(BeTrue())
-		Expect(hasSnapshot.Status.Conditions != nil).To(BeTrue())
+		Expect(hasSnapshot).NotTo(BeNil())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(gitops.IsSnapshotValid(hasSnapshot)).To(BeTrue())
 	})
 
 	It("ensures the a decision can be made to promote the Snapshot based on its status", func() {
 		gitops.SetSnapshotIntegrationStatusAsFinished(hasSnapshot, "Test message")
-		Expect(hasSnapshot != nil).To(BeTrue())
-		Expect(hasSnapshot.Status.Conditions != nil).To(BeTrue())
+		Expect(hasSnapshot).NotTo(BeNil())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 
 		updatedSnapshot, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "Test message")
-		Expect(err == nil).To(BeTrue())
-		Expect(updatedSnapshot != nil).To(BeTrue())
-		Expect(updatedSnapshot.Status.Conditions != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(updatedSnapshot).NotTo(BeNil())
+		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
 
 		canBePromoted, reasons := gitops.CanSnapshotBePromoted(updatedSnapshot)
 		Expect(canBePromoted).To(BeTrue())
-		Expect(len(reasons) == 0).To(BeTrue())
+		Expect(reasons).To(BeEmpty())
 	})
 
 	It("ensures the a decision can be made to NOT promote the Snapshot based on its status", func() {
 		gitops.SetSnapshotIntegrationStatusAsFinished(hasSnapshot, "Test message")
-		Expect(hasSnapshot != nil).To(BeTrue())
-		Expect(hasSnapshot.Status.Conditions != nil).To(BeTrue())
+		Expect(hasSnapshot).NotTo(BeNil())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 
 		updatedSnapshot, err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "Test message")
-		Expect(err == nil).To(BeTrue())
-		Expect(updatedSnapshot != nil).To(BeTrue())
-		Expect(updatedSnapshot.Status.Conditions != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(updatedSnapshot).NotTo(BeNil())
+		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
 
 		canBePromoted, reasons := gitops.CanSnapshotBePromoted(updatedSnapshot)
 		Expect(canBePromoted).To(BeFalse())
-		Expect(len(reasons) == 1).To(BeTrue())
+		Expect(reasons).To(HaveLen(1))
 
 		updatedSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePullRequestType
 		canBePromoted, reasons = gitops.CanSnapshotBePromoted(updatedSnapshot)
 		Expect(canBePromoted).To(BeFalse())
-		Expect(len(reasons) == 2).To(BeTrue())
+		Expect(reasons).To(HaveLen(2))
 
 		gitops.SetSnapshotIntegrationStatusAsInvalid(updatedSnapshot, "Test message")
 		canBePromoted, reasons = gitops.CanSnapshotBePromoted(updatedSnapshot)
 		Expect(canBePromoted).To(BeFalse())
-		Expect(len(reasons) == 3).To(BeTrue())
+		Expect(reasons).To(HaveLen(3))
 	})
 
 })

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -222,11 +222,13 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 	It("should return all IntegrationTestScenarios used by the application", func() {
 		updatedSnapshot, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
-		Expect(err == nil && updatedSnapshot != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(updatedSnapshot).NotTo(BeNil())
 		Expect(gitops.HaveHACBSTestsFinished(hasSnapshot)).To(BeTrue())
 
 		integrationTestScenarios, err := helpers.GetAllIntegrationTestScenariosForApplication(k8sClient, ctx, hasApp)
-		Expect(err == nil && integrationTestScenarios != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(integrationTestScenarios).NotTo(BeNil())
 
 		for _, integrationTestScenario := range *integrationTestScenarios {
 			integrationTestScenario := integrationTestScenario //G601
@@ -236,16 +238,19 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(err != nil && integrationPipelineRun == nil)
 		}
 		pipelineRunOutcome, err := helpers.CalculateIntegrationPipelineRunOutcome(logger, testpipelineRun)
-		Expect(err == nil && pipelineRunOutcome).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(pipelineRunOutcome).To(BeTrue())
 	})
 
 	It("should return all the required IntegrationTestScenarios used by the application", func() {
 		updatedSnapshot, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
-		Expect(err == nil && updatedSnapshot != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(updatedSnapshot).NotTo(BeNil())
 		Expect(gitops.HaveHACBSTestsFinished(hasSnapshot)).To(BeTrue())
 
 		requiredIntegrationTestScenarios, err := helpers.GetRequiredIntegrationTestScenariosForApplication(k8sClient, ctx, hasApp)
-		Expect(err == nil && requiredIntegrationTestScenarios != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(requiredIntegrationTestScenarios).NotTo(BeNil())
 		if requiredIntegrationTestScenarios != nil {
 			for _, requiredIntegrationTestScenario := range *requiredIntegrationTestScenarios {
 				requiredIntegrationTestScenario := requiredIntegrationTestScenario
@@ -271,7 +276,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				Expect(err != nil && integrationPipelineRun == nil)
 
 				pipelineRunOutcome, err := helpers.CalculateIntegrationPipelineRunOutcome(logger, integrationPipelineRun)
-				Expect(err == nil && pipelineRunOutcome).To(BeTrue())
+				Expect(err).To(BeNil())
+				Expect(pipelineRunOutcome).To(BeTrue())
 
 				Expect(k8sClient.Delete(ctx, &integrationPipelineRuns.Items[0])).Should(Succeed())
 			}
@@ -376,7 +382,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(k8sClient.Status().Update(ctx, testpipelineRun)).Should(Succeed())
 
 		pipelineRunOutcome, err := helpers.CalculateIntegrationPipelineRunOutcome(logger, testpipelineRun)
-		Expect(err == nil).To(BeTrue())
+		Expect(err).To(BeNil())
 		Expect(pipelineRunOutcome).To(BeFalse())
 
 		gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
@@ -415,7 +421,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(k8sClient.Status().Update(ctx, testpipelineRun)).Should(Succeed())
 
 		pipelineRunOutcome, err := helpers.CalculateIntegrationPipelineRunOutcome(logger, testpipelineRun)
-		Expect(err == nil).To(BeTrue())
+		Expect(err).To(BeNil())
 		Expect(pipelineRunOutcome).To(BeTrue())
 
 		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")

--- a/release/releaseplan_test.go
+++ b/release/releaseplan_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Release functions for managing Releases", Ordered, func() {
 
 	It("ensures the ReleasePlan can be gotten for Application", func() {
 		gottenReleasePlanItems, err := integrationservicerelease.GetAutoReleasePlansForApplication(k8sClient, ctx, hasApp)
-		Expect(err == nil).To(BeTrue())
-		Expect(gottenReleasePlanItems != nil).To(BeTrue())
+		Expect(err).To(BeNil())
+		Expect(gottenReleasePlanItems).NotTo(BeNil())
 	})
 })


### PR DESCRIPTION
This is outlined more thoroughly in Jira, but basically using `Expect(a == b).To(BeTrue())` isn't idiomatic and hides important information in the case that tests fail.  This MR fixes statements like that throughout our unit tests.