### PR TITLE
feat(STONEINTG-333): create a controller to trigger integration pipeline

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -72,6 +72,14 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - deploymentTargets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
   - environments
   verbs:
   - create

--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2023.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binding
+
+import (
+	"context"
+	"github.com/redhat-appstudio/operator-goodies/reconciler"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/gitops"
+	"github.com/redhat-appstudio/integration-service/helpers"
+	"github.com/redhat-appstudio/integration-service/tekton"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Adapter holds the objects needed to reconcile a SnapshotEnvironmentBinding.
+type Adapter struct {
+	snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding
+	snapshot                   *applicationapiv1alpha1.Snapshot
+	application                *applicationapiv1alpha1.Application
+	environment                *applicationapiv1alpha1.Environment
+	integrationTestScenario    *v1alpha1.IntegrationTestScenario
+	logger                     logr.Logger
+	client                     client.Client
+	context                    context.Context
+}
+
+// NewAdapter creates and returns an Adapter instance.
+func NewAdapter(snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding, snapshot *applicationapiv1alpha1.Snapshot, environment *applicationapiv1alpha1.Environment, application *applicationapiv1alpha1.Application, integrationTestScenario *v1alpha1.IntegrationTestScenario, logger logr.Logger, client client.Client,
+	context context.Context) *Adapter {
+	return &Adapter{
+		snapshotEnvironmentBinding: snapshotEnvironmentBinding,
+		snapshot:                   snapshot,
+		environment:                environment,
+		application:                application,
+		integrationTestScenario:    integrationTestScenario,
+		logger:                     logger,
+		client:                     client,
+		context:                    context,
+	}
+}
+
+// EnsureIntegrationTestPipelineForScenarioExists is an operation that will ensure that the Integration test pipeline
+// associated with the Snapshot and the SnapshotEnvironmentBinding's IntegrationTestScenarios exist.
+func (a *Adapter) EnsureIntegrationTestPipelineForScenarioExists() (reconciler.OperationResult, error) {
+	if gitops.HaveHACBSTestsFinished(a.snapshot) {
+		a.logger.Info("The Snapshot has finished testing.")
+		return reconciler.ContinueProcessing()
+	}
+
+	if a.integrationTestScenario != nil {
+		integrationPipelineRun, err := helpers.GetLatestPipelineRunForSnapshotAndScenario(a.client, a.context, a.snapshot, a.integrationTestScenario)
+		if err != nil {
+			a.logger.Error(err, "Failed to get latest pipelineRun for snapshot and scenario",
+				"snapshot", a.snapshot,
+				"integrationTestScenario", a.integrationTestScenario)
+			return reconciler.RequeueOnErrorOrStop(err)
+		}
+		if integrationPipelineRun != nil {
+			a.logger.Info("Found existing integrationPipelineRun",
+				"IntegrationTestScenario.Name", a.integrationTestScenario.Name,
+				"integrationPipelineRun.Name", integrationPipelineRun.Name)
+		} else {
+			a.logger.Info("Creating new pipelinerun for integrationTestscenario",
+				"IntegrationTestScenario.Name", a.integrationTestScenario.Name,
+				"app name", a.application.Name,
+				"namespace", a.application.Namespace)
+			err := a.createIntegrationPipelineRunWithEnvironment(a.application, a.integrationTestScenario, a.snapshot, a.environment)
+			if err != nil {
+				a.logger.Error(err, "Failed to create pipelineRun for snapshot, environment and scenario")
+				return reconciler.RequeueOnErrorOrStop(err)
+			}
+		}
+	}
+
+	return reconciler.ContinueProcessing()
+}
+
+// createIntegrationPipelineRunWithEnvironment creates new integration PipelineRun. The Pipeline information and the parameters to it
+// will be extracted from the given integrationScenario. The integration's Snapshot will also be passed to the integration PipelineRun.
+// If the creation of the PipelineRun is unsuccessful, an error will be returned.
+func (a *Adapter) createIntegrationPipelineRunWithEnvironment(application *applicationapiv1alpha1.Application, integrationTestScenario *v1alpha1.IntegrationTestScenario, snapshot *applicationapiv1alpha1.Snapshot, environment *applicationapiv1alpha1.Environment) error {
+	deploymentTarget, err := gitops.GetDeploymentTargetForEnvironment(a.client, a.context, environment)
+	if err != nil || deploymentTarget == nil {
+		return err
+	}
+
+	pipelineRun := tekton.NewIntegrationPipelineRun(snapshot.Name, application.Namespace, *integrationTestScenario).
+		WithSnapshot(snapshot).
+		WithIntegrationLabels(integrationTestScenario).
+		WithEnvironmentAndDeploymentTarget(deploymentTarget, environment.Name).
+		AsPipelineRun()
+	// copy PipelineRun PAC annotations/labels from snapshot to integration test PipelineRuns
+	helpers.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.PipelinesAsCodePrefix, gitops.PipelinesAsCodePrefix)
+	helpers.CopyLabelsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.PipelinesAsCodePrefix, gitops.PipelinesAsCodePrefix)
+	err = ctrl.SetControllerReference(snapshot, pipelineRun, a.client.Scheme())
+	if err != nil {
+		return err
+	}
+	err = a.client.Create(a.context, pipelineRun)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}

--- a/controllers/binding/snapshotenvironmentbinding_adapter_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter_test.go
@@ -1,0 +1,385 @@
+/*
+Copyright 2023.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binding
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/redhat-appstudio/integration-service/gitops"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Binding Adapter", Ordered, func() {
+	var (
+		adapter *Adapter
+
+		testReleasePlan         *releasev1alpha1.ReleasePlan
+		hasApp                  *applicationapiv1alpha1.Application
+		hasComp                 *applicationapiv1alpha1.Component
+		hasSnapshot             *applicationapiv1alpha1.Snapshot
+		finishedSnapshot        *applicationapiv1alpha1.Snapshot
+		deploymentTargetClaim   *applicationapiv1alpha1.DeploymentTargetClaim
+		deploymentTarget        *applicationapiv1alpha1.DeploymentTarget
+		integrationTestScenario *v1alpha1.IntegrationTestScenario
+		hasEnv                  *applicationapiv1alpha1.Environment
+		hasBinding              *applicationapiv1alpha1.SnapshotEnvironmentBinding
+	)
+	const (
+		SampleRepoLink = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		sampleImage    = "quay.io/redhat-appstudio/sample-image"
+	)
+
+	BeforeAll(func() {
+
+		hasApp = &applicationapiv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "application-sample",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ApplicationSpec{
+				DisplayName: "application-sample",
+				Description: "This is an example application",
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
+
+		integrationTestScenario = &v1alpha1.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-pass",
+				Namespace: "default",
+
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/optional": "false",
+				},
+			},
+			Spec: v1alpha1.IntegrationTestScenarioSpec{
+				Application: "application-sample",
+				Bundle:      "quay.io/kpavic/test-bundle:component-pipeline-pass",
+				Pipeline:    "component-pipeline-pass",
+				Environment: v1alpha1.TestEnvironment{
+					Name: "envname",
+					Type: "POC",
+					Configuration: &applicationapiv1alpha1.EnvironmentConfiguration{
+						Env: []applicationapiv1alpha1.EnvVarPair{},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, integrationTestScenario)).Should(Succeed())
+
+		testReleasePlan = &releasev1alpha1.ReleasePlan{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-releaseplan-",
+				Namespace:    "default",
+				Labels: map[string]string{
+					releasev1alpha1.AutoReleaseLabel: "true",
+				},
+			},
+			Spec: releasev1alpha1.ReleasePlanSpec{
+				Application: hasApp.Name,
+				Target:      "default",
+			},
+		}
+		Expect(k8sClient.Create(ctx, testReleasePlan)).Should(Succeed())
+
+		deploymentTarget = &applicationapiv1alpha1.DeploymentTarget{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "dt" + "-",
+				Namespace:    "default",
+			},
+			Spec: applicationapiv1alpha1.DeploymentTargetSpec{
+				DeploymentTargetClassName: "dtcls-name",
+				KubernetesClusterCredentials: applicationapiv1alpha1.DeploymentTargetKubernetesClusterCredentials{
+					DefaultNamespace:           "default",
+					APIURL:                     "https://url",
+					ClusterCredentialsSecret:   "secret-sample",
+					AllowInsecureSkipTLSVerify: false,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, deploymentTarget)).Should(Succeed())
+
+		deploymentTargetClaim = &applicationapiv1alpha1.DeploymentTargetClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "dtc" + "-",
+				Namespace:    "default",
+			},
+			Spec: applicationapiv1alpha1.DeploymentTargetClaimSpec{
+				DeploymentTargetClassName: applicationapiv1alpha1.DeploymentTargetClassName("dtcls-name"),
+				TargetName:                deploymentTarget.Name,
+			},
+		}
+		Expect(k8sClient.Create(ctx, deploymentTargetClaim)).Should(Succeed())
+
+		hasEnv = &applicationapiv1alpha1.Environment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "envname",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.EnvironmentSpec{
+				Type:               "POC",
+				DisplayName:        "my-environment",
+				DeploymentStrategy: applicationapiv1alpha1.DeploymentStrategy_Manual,
+				ParentEnvironment:  "",
+				Tags:               []string{},
+				Configuration: applicationapiv1alpha1.EnvironmentConfiguration{
+					Env: []applicationapiv1alpha1.EnvVarPair{
+						{
+							Name:  "var_name",
+							Value: "test",
+						},
+					},
+					Target: applicationapiv1alpha1.EnvironmentTarget{
+						DeploymentTargetClaim: applicationapiv1alpha1.DeploymentTargetClaimConfig{
+							ClaimName: deploymentTargetClaim.Name,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasEnv)).Should(Succeed())
+
+		hasComp = &applicationapiv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "component-sample",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				ComponentName:  "component-sample",
+				Application:    "application-sample",
+				ContainerImage: "",
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL: SampleRepoLink,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
+
+		finishedSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-sample-finished",
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:            "component",
+					gitops.SnapshotComponentLabel:       hasComp.Name,
+					gitops.PipelineAsCodeEventTypeLabel: "push",
+				},
+				Annotations: map[string]string{
+					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           hasComp.Name,
+						ContainerImage: sampleImage,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, finishedSnapshot)).Should(Succeed())
+
+		Eventually(func() error {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      finishedSnapshot.Name,
+				Namespace: "default",
+			}, finishedSnapshot)
+			return err
+		}, time.Second*10).ShouldNot(HaveOccurred())
+
+		finishedSnapshot, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, finishedSnapshot, "Snapshot passed")
+		Expect(err == nil).To(BeTrue())
+		Expect(gitops.HaveHACBSTestsFinished(finishedSnapshot)).To(BeTrue())
+	})
+
+	BeforeEach(func() {
+		hasSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:            "component",
+					gitops.SnapshotComponentLabel:       hasComp.Name,
+					gitops.PipelineAsCodeEventTypeLabel: "push",
+				},
+				Annotations: map[string]string{
+					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "component-sample",
+						ContainerImage: sampleImage,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasSnapshot)).Should(Succeed())
+
+		hasBinding = &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-binding-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTestScenarioLabel: integrationTestScenario.Name,
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+				Application: hasApp.Name,
+				Snapshot:    hasSnapshot.Name,
+				Environment: hasEnv.Name,
+				Components:  []applicationapiv1alpha1.BindingComponent{},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasBinding)).Should(Succeed())
+
+		hasBinding.Status = applicationapiv1alpha1.SnapshotEnvironmentBindingStatus{
+			BindingConditions: []metav1.Condition{
+				{
+					Reason:             "Completed",
+					Status:             "True",
+					Type:               gitops.BindingDeploymentStatusConditionType,
+					LastTransitionTime: metav1.Time{Time: time.Now()},
+				},
+			},
+		}
+
+		Expect(k8sClient.Status().Update(ctx, hasBinding)).Should(Succeed())
+
+		Eventually(func() error {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      hasBinding.Name,
+				Namespace: "default",
+			}, hasBinding)
+			return err
+		}, time.Second*10).ShouldNot(HaveOccurred())
+
+		adapter = NewAdapter(hasBinding, hasSnapshot, hasEnv, hasApp, integrationTestScenario, ctrl.Log, k8sClient, ctx)
+		Expect(reflect.TypeOf(adapter)).To(Equal(reflect.TypeOf(&Adapter{})))
+
+	})
+
+	AfterEach(func() {
+		err := k8sClient.Delete(ctx, hasBinding)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasSnapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	AfterAll(func() {
+		err := k8sClient.Delete(ctx, hasApp)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasComp)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasEnv)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, integrationTestScenario)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, testReleasePlan)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, deploymentTarget)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, deploymentTargetClaim)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, finishedSnapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+
+	})
+
+	It("can create a new Adapter instance", func() {
+		Expect(reflect.TypeOf(NewAdapter(hasBinding, hasSnapshot, hasEnv, hasApp, integrationTestScenario, ctrl.Log, k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
+	})
+
+	It("ensures the integrationTestPipelines are created for a deployed SnapshotEnvironment binding", func() {
+		Eventually(func() bool {
+			result, err := adapter.EnsureIntegrationTestPipelineForScenarioExists()
+			return !result.CancelRequest && err == nil
+		}, time.Second*20).Should(BeTrue())
+
+		integrationPipelineRuns := &tektonv1beta1.PipelineRunList{}
+		opts := []client.ListOption{
+			client.InNamespace(hasApp.Namespace),
+			client.MatchingLabels{
+				"pipelines.appstudio.openshift.io/type": "test",
+				"appstudio.openshift.io/snapshot":       hasSnapshot.Name,
+				"test.appstudio.openshift.io/scenario":  integrationTestScenario.Name,
+				"appstudio.openshift.io/environment":    hasEnv.Name,
+			},
+		}
+		Eventually(func() bool {
+			err := k8sClient.List(ctx, integrationPipelineRuns, opts...)
+			return len(integrationPipelineRuns.Items) > 0 && err == nil
+		}, time.Second*20).Should(BeTrue())
+
+		integrationPipelineRun := integrationPipelineRuns.Items[0]
+		fmt.Fprintf(GinkgoWriter, "*******integrationPipelineRun: %v\n", integrationPipelineRun)
+		Expect(integrationPipelineRun.Labels["appstudio.openshift.io/environment"] == hasEnv.Name).To(BeTrue())
+		Expect(integrationPipelineRun.Spec.Workspaces != nil).To(BeTrue())
+		Expect(len(integrationPipelineRun.Spec.Workspaces) > 0).To(BeTrue())
+		Expect(len(integrationPipelineRun.Spec.Params) > 0).To(BeTrue())
+
+		Expect(k8sClient.Delete(ctx, &integrationPipelineRuns.Items[0])).Should(Succeed())
+
+	})
+
+	It("ensures the integrationTestPipelines are NOT created for a Snapshot that finished testing", func() {
+		finishedAdapter := NewAdapter(hasBinding, finishedSnapshot, hasEnv, hasApp, integrationTestScenario, ctrl.Log, k8sClient, ctx)
+		Expect(reflect.TypeOf(adapter)).To(Equal(reflect.TypeOf(&Adapter{})))
+
+		Eventually(func() bool {
+			result, err := finishedAdapter.EnsureIntegrationTestPipelineForScenarioExists()
+			return !result.CancelRequest && err == nil
+		}, time.Second*20).Should(BeTrue())
+
+		integrationPipelineRuns := &tektonv1beta1.PipelineRunList{}
+		opts := []client.ListOption{
+			client.InNamespace(hasApp.Namespace),
+			client.MatchingLabels{
+				"pipelines.appstudio.openshift.io/type": "test",
+				"appstudio.openshift.io/snapshot":       finishedSnapshot.Name,
+				"test.appstudio.openshift.io/scenario":  integrationTestScenario.Name,
+				"appstudio.openshift.io/environment":    hasEnv.Name,
+			},
+		}
+		Eventually(func() bool {
+			err := k8sClient.List(ctx, integrationPipelineRuns, opts...)
+			return len(integrationPipelineRuns.Items) == 0 && err == nil
+		}, time.Second*10).Should(BeTrue())
+	})
+
+})

--- a/controllers/binding/snapshotenvironmentbinding_controller.go
+++ b/controllers/binding/snapshotenvironmentbinding_controller.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2023.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions andF
+limitations under the License.
+*/
+
+package binding
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/gitops"
+	"github.com/redhat-appstudio/operator-goodies/predicates"
+	"github.com/redhat-appstudio/operator-goodies/reconciler"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Reconciler reconciles a SnapshotEnvironmentBinding object
+type Reconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// NewBindingReconciler creates and returns a Reconciler.
+func NewBindingReconciler(client client.Client, logger *logr.Logger, scheme *runtime.Scheme) *Reconciler {
+	return &Reconciler{
+		Client: client,
+		Log:    logger.WithName("binding"),
+		Scheme: scheme,
+	}
+}
+
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=snapshots,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=snapshots/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=snapshots/finalizers,verbs=update
+//+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/finalizers,verbs=update
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=deploymentTargets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=deploymentTargetClaims,verbs=get;list;watch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments,verbs=get;list;watch
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := r.Log.WithValues("Integration", req.NamespacedName)
+
+	snapshotEnvironmentBinding := &applicationapiv1alpha1.SnapshotEnvironmentBinding{}
+	err := r.Get(ctx, req.NamespacedName, snapshotEnvironmentBinding)
+	if err != nil {
+		logger.Error(err, "Failed to get snapshotEnvironmentBinding for", "req", req.NamespacedName)
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, err
+	}
+
+	application, err := r.getApplicationFromSnapshotEnvironmentBinding(ctx, snapshotEnvironmentBinding)
+	if err != nil {
+		logger.Error(err, "Failed to get Application for ",
+			"SnapshotEnvironmentBinding.Name ", snapshotEnvironmentBinding.Name, "SnapshotEnvironmentBinding.Namespace ", snapshotEnvironmentBinding.Namespace)
+		return ctrl.Result{}, err
+	}
+
+	snapshot, err := r.getSnapshotFromSnapshotEnvironmentBinding(ctx, snapshotEnvironmentBinding)
+	if err != nil {
+		logger.Error(err, "Failed to get Snapshot for ",
+			"SnapshotEnvironmentBinding.Name ", snapshotEnvironmentBinding.Name, "SnapshotEnvironmentBinding.Namespace ", snapshotEnvironmentBinding.Namespace)
+		return ctrl.Result{}, err
+	}
+
+	environment, err := r.getEnvironmentFromSnapshotEnvironmentBinding(ctx, snapshotEnvironmentBinding)
+	if err != nil {
+		logger.Error(err, "Failed to get Environment for ",
+			"SnapshotEnvironmentBinding.Name ", snapshotEnvironmentBinding.Name, "SnapshotEnvironmentBinding.Namespace ", snapshotEnvironmentBinding.Namespace)
+		return ctrl.Result{}, err
+	}
+
+	integrationTestScenario, err := r.getIntegrationTestScenarioFromSnapshotEnvironmentBiding(ctx, snapshotEnvironmentBinding)
+	if err != nil {
+		logger.Error(err, "Failed to get IntegrationTestScenario for ",
+			"SnapshotEnvironmentBinding.Name ", snapshotEnvironmentBinding.Name, "SnapshotEnvironmentBinding.Namespace ", snapshotEnvironmentBinding.Namespace)
+		return ctrl.Result{}, err
+	}
+
+	adapter := NewAdapter(snapshotEnvironmentBinding, snapshot, environment, application, integrationTestScenario, logger, r.Client, ctx)
+
+	return reconciler.ReconcileHandler([]reconciler.ReconcileOperation{
+		adapter.EnsureIntegrationTestPipelineForScenarioExists,
+	})
+}
+
+// getApplicationFromSnapshotEnvironmentBinding loads from the cluster the Application referenced in the given SnapshotEnvironmentBinding.
+// If the SnapshotEnvironmentBinding doesn't specify an Application or this is not found in the cluster, an error will be returned.
+func (r *Reconciler) getApplicationFromSnapshotEnvironmentBinding(context context.Context, snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding) (*applicationapiv1alpha1.Application, error) {
+	application := &applicationapiv1alpha1.Application{}
+	err := r.Get(context, types.NamespacedName{
+		Namespace: snapshotEnvironmentBinding.Namespace,
+		Name:      snapshotEnvironmentBinding.Spec.Application,
+	}, application)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return application, nil
+}
+
+// getSnapshotFromSnapshotEnvironmentBinding loads from the cluster the Snapshot referenced in the given SnapshotEnvironmentBinding.
+// If the SnapshotEnvironmentBinding doesn't specify a Snapshot or this is not found in the cluster, an error will be returned.
+func (r *Reconciler) getSnapshotFromSnapshotEnvironmentBinding(context context.Context, snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding) (*applicationapiv1alpha1.Snapshot, error) {
+	snapshot := &applicationapiv1alpha1.Snapshot{}
+	err := r.Get(context, types.NamespacedName{
+		Namespace: snapshotEnvironmentBinding.Namespace,
+		Name:      snapshotEnvironmentBinding.Spec.Snapshot,
+	}, snapshot)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshot, nil
+}
+
+// getEnvironmentFromSnapshotEnvironmentBinding loads from the cluster the Environment referenced in the given SnapshotEnvironmentBinding.
+// If the SnapshotEnvironmentBinding doesn't specify an Environment or this is not found in the cluster, an error will be returned.
+func (r *Reconciler) getEnvironmentFromSnapshotEnvironmentBinding(context context.Context, snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding) (*applicationapiv1alpha1.Environment, error) {
+	environment := &applicationapiv1alpha1.Environment{}
+	err := r.Get(context, types.NamespacedName{
+		Namespace: snapshotEnvironmentBinding.Namespace,
+		Name:      snapshotEnvironmentBinding.Spec.Environment,
+	}, environment)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return environment, nil
+}
+
+// getIntegrationTestScenarioFromSnapshotEnvironmentBiding loads from the cluster the IntegrationTestScenario referenced in the given SnapshotEnvironmentBiding.
+// If the SnapshotEnvironmentBinding doesn't specify an IntegrationTestScenario or this is not found in the cluster, an error will be returned.
+func (r *Reconciler) getIntegrationTestScenarioFromSnapshotEnvironmentBiding(context context.Context, snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding) (*v1alpha1.IntegrationTestScenario, error) {
+	if scenarioLabel, ok := snapshotEnvironmentBinding.Labels[gitops.SnapshotTestScenarioLabel]; ok {
+		integrationTestScenario := &v1alpha1.IntegrationTestScenario{}
+		err := r.Get(context, types.NamespacedName{
+			Namespace: snapshotEnvironmentBinding.Namespace,
+			Name:      scenarioLabel,
+		}, integrationTestScenario)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return integrationTestScenario, nil
+	} else {
+		return nil, nil
+	}
+}
+
+// AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
+type AdapterInterface interface {
+	EnsureIntegrationTestPipelineForScenarioExists() (reconciler.OperationResult, error)
+}
+
+// SetupController creates a new Integration reconciler and adds it to the Manager.
+func SetupController(manager ctrl.Manager, log *logr.Logger) error {
+	return setupControllerWithManager(manager, NewBindingReconciler(manager.GetClient(), log, manager.GetScheme()))
+}
+
+// setupControllerWithManager sets up the controller with the Manager which monitors new SnapshotEnvironmentBindings
+func setupControllerWithManager(manager ctrl.Manager, reconciler *Reconciler) error {
+	return ctrl.NewControllerManagedBy(manager).
+		For(&applicationapiv1alpha1.SnapshotEnvironmentBinding{}, builder.WithPredicates(predicates.GenerationUnchangedOnUpdatePredicate{}, gitops.DeploymentFinishedForIntegrationBindingPredicate())).
+		Complete(reconciler)
+}

--- a/controllers/binding/snapshotenvironmentbinding_controller_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_controller_test.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2023.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binding
+
+import (
+	"github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"reflect"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/gitops"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	klog "k8s.io/klog/v2"
+)
+
+var _ = Describe("BindingController", func() {
+	var (
+		manager                 ctrl.Manager
+		bindingReconciler       *Reconciler
+		scheme                  runtime.Scheme
+		req                     ctrl.Request
+		hasApp                  *applicationapiv1alpha1.Application
+		hasComp                 *applicationapiv1alpha1.Component
+		hasSnapshot             *applicationapiv1alpha1.Snapshot
+		hasEnv                  *applicationapiv1alpha1.Environment
+		hasBinding              *applicationapiv1alpha1.SnapshotEnvironmentBinding
+		deploymentTargetClaim   *applicationapiv1alpha1.DeploymentTargetClaim
+		deploymentTarget        *applicationapiv1alpha1.DeploymentTarget
+		integrationTestScenario *v1alpha1.IntegrationTestScenario
+	)
+	const (
+		SampleRepoLink = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+	)
+
+	BeforeEach(func() {
+
+		applicationName := "application-sample"
+
+		hasApp = &applicationapiv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      applicationName,
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ApplicationSpec{
+				DisplayName: "application-sample",
+				Description: "This is an example application",
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
+
+		hasComp = &applicationapiv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "component-sample",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				ComponentName: "component-sample",
+				Application:   applicationName,
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL: SampleRepoLink,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
+
+		deploymentTarget = &applicationapiv1alpha1.DeploymentTarget{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "dt" + "-",
+				Namespace:    "default",
+			},
+			Spec: applicationapiv1alpha1.DeploymentTargetSpec{
+				DeploymentTargetClassName: "dtcls-name",
+				KubernetesClusterCredentials: applicationapiv1alpha1.DeploymentTargetKubernetesClusterCredentials{
+					DefaultNamespace:           "default",
+					APIURL:                     "https://url",
+					ClusterCredentialsSecret:   "secret-sample",
+					AllowInsecureSkipTLSVerify: false,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, deploymentTarget)).Should(Succeed())
+
+		deploymentTargetClaim = &applicationapiv1alpha1.DeploymentTargetClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "dtc" + "-",
+				Namespace:    "default",
+			},
+			Spec: applicationapiv1alpha1.DeploymentTargetClaimSpec{
+				DeploymentTargetClassName: applicationapiv1alpha1.DeploymentTargetClassName("dtcls-name"),
+				TargetName:                deploymentTarget.Name,
+			},
+		}
+		Expect(k8sClient.Create(ctx, deploymentTargetClaim)).Should(Succeed())
+
+		hasEnv = &applicationapiv1alpha1.Environment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "envname",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.EnvironmentSpec{
+				Type:               "POC",
+				DisplayName:        "my-environment",
+				DeploymentStrategy: applicationapiv1alpha1.DeploymentStrategy_Manual,
+				ParentEnvironment:  "",
+				Tags:               []string{},
+				Configuration: applicationapiv1alpha1.EnvironmentConfiguration{
+					Env: []applicationapiv1alpha1.EnvVarPair{
+						{
+							Name:  "var_name",
+							Value: "test",
+						},
+					},
+					Target: applicationapiv1alpha1.EnvironmentTarget{
+						DeploymentTargetClaim: applicationapiv1alpha1.DeploymentTargetClaimConfig{
+							ClaimName: deploymentTargetClaim.Name,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasEnv)).Should(Succeed())
+
+		integrationTestScenario = &v1alpha1.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-pass",
+				Namespace: "default",
+
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/optional": "false",
+				},
+			},
+			Spec: v1alpha1.IntegrationTestScenarioSpec{
+				Application: "application-sample",
+				Bundle:      "quay.io/redhat-appstudio/example-tekton-bundle:component-pipeline-pass",
+				Pipeline:    "component-pipeline-pass",
+				Environment: v1alpha1.TestEnvironment{
+					Name: hasEnv.Name,
+					Type: "POC",
+					Configuration: &applicationapiv1alpha1.EnvironmentConfiguration{
+						Env: []applicationapiv1alpha1.EnvVarPair{},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, integrationTestScenario)).Should(Succeed())
+
+		hasSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:      "component",
+					gitops.SnapshotComponentLabel: "component-sample",
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "component-sample",
+						ContainerImage: "testimage",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasSnapshot)).Should(Succeed())
+
+		hasBinding = &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-binding-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTestScenarioLabel: integrationTestScenario.Name,
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+				Application: hasApp.Name,
+				Snapshot:    hasSnapshot.Name,
+				Environment: hasEnv.Name,
+				Components:  []applicationapiv1alpha1.BindingComponent{},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasBinding)).Should(Succeed())
+
+		hasBinding.Status = applicationapiv1alpha1.SnapshotEnvironmentBindingStatus{
+			BindingConditions: []metav1.Condition{
+				{
+					Reason:             "Completed",
+					Status:             "True",
+					Type:               gitops.BindingDeploymentStatusConditionType,
+					LastTransitionTime: metav1.Time{Time: time.Now()},
+				},
+			},
+		}
+
+		Expect(k8sClient.Status().Update(ctx, hasBinding)).Should(Succeed())
+
+		req = ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "default",
+				Name:      hasBinding.Name,
+			},
+		}
+
+		webhookInstallOptions := &testEnv.WebhookInstallOptions
+
+		klog.Info(webhookInstallOptions.LocalServingHost)
+		klog.Info(webhookInstallOptions.LocalServingPort)
+		klog.Info(webhookInstallOptions.LocalServingCertDir)
+
+		var err error
+		manager, err = ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:             clientsetscheme.Scheme,
+			Host:               webhookInstallOptions.LocalServingHost,
+			Port:               webhookInstallOptions.LocalServingPort,
+			CertDir:            webhookInstallOptions.LocalServingCertDir,
+			MetricsBindAddress: "0", // this disables metrics
+			LeaderElection:     false,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(err).To(BeNil())
+
+		bindingReconciler = NewBindingReconciler(k8sClient, &logf.Log, &scheme)
+	})
+	AfterEach(func() {
+		err := k8sClient.Delete(ctx, hasApp)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasComp)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasSnapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasEnv)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasBinding)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, integrationTestScenario)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("can create and return a new Reconciler object", func() {
+		Expect(reflect.TypeOf(bindingReconciler)).To(Equal(reflect.TypeOf(&Reconciler{})))
+		klog.Info("Test First Logic")
+	})
+
+	It("can fail when Reconcile fails to prepare the adapter when SnapshotEnvironmentBinding is not found", func() {
+		Expect(k8sClient.Delete(ctx, hasBinding)).Should(Succeed())
+		Eventually(func() error {
+			_, err := bindingReconciler.Reconcile(ctx, req)
+			return err
+		}).Should(BeNil())
+	})
+
+	It("can fail when Reconcile fails to prepare the adapter when Application is not found", func() {
+		Expect(k8sClient.Delete(ctx, hasApp)).Should(Succeed())
+		Eventually(func() error {
+			_, err := bindingReconciler.Reconcile(ctx, req)
+			return err
+		}).ShouldNot(BeNil())
+	})
+
+	It("can fail when Reconcile fails to prepare the adapter when Snapshot is not found", func() {
+		Expect(k8sClient.Delete(ctx, hasSnapshot)).Should(Succeed())
+		Eventually(func() error {
+			_, err := bindingReconciler.Reconcile(ctx, req)
+			return err
+		}).ShouldNot(BeNil())
+	})
+
+	It("can fail when Reconcile fails to prepare the adapter when Environment is not found", func() {
+		Expect(k8sClient.Delete(ctx, hasEnv)).Should(Succeed())
+		Eventually(func() error {
+			_, err := bindingReconciler.Reconcile(ctx, req)
+			return err
+		}).ShouldNot(BeNil())
+	})
+
+	It("can Reconcile function prepare the adapter and return the result of the reconcile handling operation", func() {
+		result, err := bindingReconciler.Reconcile(ctx, req)
+		Expect(reflect.TypeOf(result)).To(Equal(reflect.TypeOf(reconcile.Result{})))
+		Expect(err).To(BeNil())
+	})
+
+	It("can setup a new controller manager with the given reconciler", func() {
+		err := setupControllerWithManager(manager, bindingReconciler)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("can setup a new Controller manager and start it", func() {
+		err := SetupController(manager, &ctrl.Log)
+		Expect(err).To(BeNil())
+		go func() {
+			defer GinkgoRecover()
+			err = manager.Start(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+	})
+
+})

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"github.com/go-logr/logr"
+	"github.com/redhat-appstudio/integration-service/controllers/binding"
 	"github.com/redhat-appstudio/integration-service/controllers/pipeline"
 	"github.com/redhat-appstudio/integration-service/controllers/scenario"
 	"github.com/redhat-appstudio/integration-service/controllers/snapshot"
@@ -30,6 +31,7 @@ var setupFunctions = []func(manager.Manager, *logr.Logger) error{
 	pipeline.SetupController,
 	snapshot.SetupController,
 	scenario.SetupController,
+	binding.SetupController,
 }
 
 // SetupControllers invoke all SetupController functions defined in setupFunctions, setting all controllers up and

--- a/controllers/snapshot/cache.go
+++ b/controllers/snapshot/cache.go
@@ -54,8 +54,8 @@ func SetupApplicationCache(mgr ctrl.Manager) error {
 		"spec.environment", applicationIndexFunc)
 }
 
-// SetupEnvironmentCache adds a new index field to be able to search SnapshotEnvironmentBindings by Application.
-func SetupEnvironmentCache(mgr ctrl.Manager) error {
+// SetupSnapshotEnvironmentBindingCache adds a new index field to be able to search SnapshotEnvironmentBindings by Application.
+func SetupSnapshotEnvironmentBindingCache(mgr ctrl.Manager) error {
 	environmentIndexFunc := func(obj client.Object) []string {
 		return []string{obj.(*applicationapiv1alpha1.SnapshotEnvironmentBinding).Spec.Application}
 	}

--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -165,7 +165,7 @@ func setupCache(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return SetupEnvironmentCache(mgr)
+	return SetupSnapshotEnvironmentBindingCache(mgr)
 }
 
 // setupControllerWithManager sets up the controller with the Manager which monitors new Snapshots

--- a/gitops/predicates.go
+++ b/gitops/predicates.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2023.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops
+
+import (
+	"github.com/redhat-appstudio/integration-service/helpers"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// DeploymentFinishedForIntegrationBindingPredicate returns a predicate which filters out update events to a
+// SnapshotEnvironmentBinding that has the IntegrationTestScenario specified in the label and
+// where the component deployment status goes from unknown to true/false.
+func DeploymentFinishedForIntegrationBindingPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return hasDeploymentFinished(e.ObjectOld, e.ObjectNew) && helpers.HasLabel(e.ObjectNew, SnapshotTestScenarioLabel)
+		},
+	}
+}

--- a/gitops/predicates_test.go
+++ b/gitops/predicates_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2023 Red Hat Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops_test
+
+import (
+	"context"
+	"github.com/redhat-appstudio/integration-service/gitops"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Predicates", Ordered, func() {
+
+	const (
+		namespace       = "default"
+		applicationName = "test-application"
+		environmentName = "test-environment"
+		snapshotName    = "test-snapshot"
+	)
+
+	var bindingUnknownStatus, bindingTrueStatus *applicationapiv1alpha1.SnapshotEnvironmentBinding
+
+	BeforeAll(func() {
+		bindingUnknownStatus = &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "bindingunknownstatus",
+				Namespace:  namespace,
+				Generation: 1,
+			},
+			Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+				Application: applicationName,
+				Environment: environmentName,
+				Snapshot:    snapshotName,
+				Components:  []applicationapiv1alpha1.BindingComponent{},
+			},
+		}
+		bindingTrueStatus = &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "bindingtruestatus",
+				Namespace:  namespace,
+				Generation: 1,
+				Labels:     map[string]string{gitops.SnapshotTestScenarioLabel: "test-scenario"},
+			},
+			Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+				Application: applicationName,
+				Environment: environmentName,
+				Snapshot:    snapshotName,
+				Components:  []applicationapiv1alpha1.BindingComponent{},
+			},
+		}
+		ctx := context.Background()
+
+		Expect(k8sClient.Create(ctx, bindingUnknownStatus)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, bindingTrueStatus)).Should(Succeed())
+
+		// Set the binding statuses after they are created
+		bindingUnknownStatus.Status.ComponentDeploymentConditions = []metav1.Condition{
+			{
+				Type:   gitops.BindingDeploymentStatusConditionType,
+				Status: metav1.ConditionUnknown,
+			},
+		}
+		bindingTrueStatus.Status.ComponentDeploymentConditions = []metav1.Condition{
+			{
+				Type:   gitops.BindingDeploymentStatusConditionType,
+				Status: metav1.ConditionTrue,
+			},
+		}
+	})
+
+	AfterAll(func() {
+		err := k8sClient.Delete(ctx, bindingUnknownStatus)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, bindingTrueStatus)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	Context("when testing DeploymentFinishedPredicate predicate", func() {
+		instance := gitops.DeploymentFinishedForIntegrationBindingPredicate()
+
+		It("returns true when the old SnapshotEnvironmentBinding has unknown status and the new one has true status", func() {
+			contextEvent := event.UpdateEvent{
+				ObjectOld: bindingUnknownStatus,
+				ObjectNew: bindingTrueStatus,
+			}
+			Expect(instance.Update(contextEvent)).To(BeTrue())
+		})
+	})
+})

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -19,11 +19,13 @@ package tekton
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/helpers"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -53,6 +55,9 @@ var (
 
 	// SnapshotNameLabel is the label of specific the name of the snapshot associated with PipelineRun
 	SnapshotNameLabel = fmt.Sprintf("%s/%s", ResourceLabelSuffix, "snapshot")
+
+	// EnvironmentNameLabel is the label of specific the name of the environment associated with PipelineRun
+	EnvironmentNameLabel = fmt.Sprintf("%s/%s", ResourceLabelSuffix, "environment")
 
 	// ApplicationNameLabel is the label of specific the name of the Application associated with PipelineRun
 	ApplicationNameLabel = fmt.Sprintf("%s/%s", ResourceLabelSuffix, "application")
@@ -168,6 +173,37 @@ func (r *IntegrationPipelineRun) WithApplicationAndComponent(application *applic
 		r.ObjectMeta.Labels[ComponentNameLabel] = component.Name
 	}
 	r.ObjectMeta.Labels[ApplicationNameLabel] = application.Name
+
+	return r
+}
+
+// WithEnvironmentAndDeploymentTarget adds a param containing the DeploymentTarget connection details and Environment name
+// to the integration PipelineRun.
+func (r *IntegrationPipelineRun) WithEnvironmentAndDeploymentTarget(dt *applicationapiv1alpha1.DeploymentTarget, environmentName string) *IntegrationPipelineRun {
+	if !reflect.ValueOf(dt.Spec.KubernetesClusterCredentials).IsZero() {
+		// Add the NAMESPACE parameter to the pipeline
+		r.WithExtraParam("NAMESPACE", tektonv1beta1.ArrayOrString{
+			Type:      tektonv1beta1.ParamTypeString,
+			StringVal: dt.Spec.KubernetesClusterCredentials.DefaultNamespace,
+		})
+
+		// Create a new Workspace binding which will allow mounting the ClusterCredentialsSecret in the Tekton pipelineRun
+		workspace := tektonv1beta1.WorkspaceBinding{
+			Name:   "cluster-credentials",
+			Secret: &corev1.SecretVolumeSource{SecretName: dt.Spec.KubernetesClusterCredentials.ClusterCredentialsSecret},
+		}
+		// Add the new workspace to the pipelineRun Spec
+		if r.Spec.Workspaces == nil {
+			r.Spec.Workspaces = []tektonv1beta1.WorkspaceBinding{}
+		}
+		r.Spec.Workspaces = append(r.Spec.Workspaces, workspace)
+	}
+
+	// Add the environment label to the pipelineRun
+	if r.ObjectMeta.Labels == nil {
+		r.ObjectMeta.Labels = map[string]string{}
+	}
+	r.ObjectMeta.Labels[EnvironmentNameLabel] = environmentName
 
 	return r
 }

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -20,16 +20,18 @@ type ExtraParams struct {
 var _ = Describe("Integration pipeline", func() {
 
 	const (
-		prefix                  = "testpipeline"
-		namespace               = "default"
-		PipelineTypeIntegration = "integration"
-		applicationName         = "application-sample"
-		SampleRepoLink          = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		prefix          = "testpipeline"
+		namespace       = "default"
+		applicationName = "application-sample"
+		SampleRepoLink  = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
 	)
 	var (
 		hasApp                    *applicationapiv1alpha1.Application
 		hasSnapshot               *applicationapiv1alpha1.Snapshot
 		hasComp                   *applicationapiv1alpha1.Component
+		hasEnv                    *applicationapiv1alpha1.Environment
+		deploymentTargetClaim     *applicationapiv1alpha1.DeploymentTargetClaim
+		deploymentTarget          *applicationapiv1alpha1.DeploymentTarget
 		newIntegrationPipelineRun *tekton.IntegrationPipelineRun
 		integrationTestScenario   *v1alpha1.IntegrationTestScenario
 		extraParams               *ExtraParams
@@ -86,6 +88,63 @@ var _ = Describe("Integration pipeline", func() {
 		}
 		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
 
+		deploymentTargetClaim = &applicationapiv1alpha1.DeploymentTargetClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "dtc" + "-",
+				Namespace:    namespace,
+			},
+			Spec: applicationapiv1alpha1.DeploymentTargetClaimSpec{
+				DeploymentTargetClassName: applicationapiv1alpha1.DeploymentTargetClassName("dtcls-name"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, deploymentTargetClaim)).Should(Succeed())
+
+		deploymentTarget = &applicationapiv1alpha1.DeploymentTarget{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "dt" + "-",
+				Namespace:    namespace,
+			},
+			Spec: applicationapiv1alpha1.DeploymentTargetSpec{
+				ClaimRef:                  deploymentTargetClaim.Name,
+				DeploymentTargetClassName: "dtcls-name",
+				KubernetesClusterCredentials: applicationapiv1alpha1.DeploymentTargetKubernetesClusterCredentials{
+					DefaultNamespace:           "default",
+					APIURL:                     "https://url",
+					ClusterCredentialsSecret:   "secret-sample",
+					AllowInsecureSkipTLSVerify: false,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, deploymentTarget)).Should(Succeed())
+
+		hasEnv = &applicationapiv1alpha1.Environment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "envname",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.EnvironmentSpec{
+				Type:               "POC",
+				DisplayName:        "my-environment",
+				DeploymentStrategy: applicationapiv1alpha1.DeploymentStrategy_Manual,
+				ParentEnvironment:  "",
+				Tags:               []string{},
+				Configuration: applicationapiv1alpha1.EnvironmentConfiguration{
+					Env: []applicationapiv1alpha1.EnvVarPair{
+						{
+							Name:  "var_name",
+							Value: "test",
+						},
+					},
+					Target: applicationapiv1alpha1.EnvironmentTarget{
+						DeploymentTargetClaim: applicationapiv1alpha1.DeploymentTargetClaimConfig{
+							ClaimName: deploymentTargetClaim.Name,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasEnv)).Should(Succeed())
+
 		hasSnapshot = &applicationapiv1alpha1.Snapshot{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "snapshot-sample",
@@ -133,6 +192,9 @@ var _ = Describe("Integration pipeline", func() {
 		_ = k8sClient.Delete(ctx, hasApp)
 		_ = k8sClient.Delete(ctx, hasSnapshot)
 		_ = k8sClient.Delete(ctx, hasComp)
+		_ = k8sClient.Delete(ctx, hasEnv)
+		_ = k8sClient.Delete(ctx, deploymentTargetClaim)
+		_ = k8sClient.Delete(ctx, deploymentTarget)
 		_ = k8sClient.Delete(ctx, newIntegrationPipelineRun.AsPipelineRun())
 	})
 
@@ -168,12 +230,29 @@ var _ = Describe("Integration pipeline", func() {
 				To(Equal(hasSnapshot.Name))
 		})
 
-		It("can append labels comming from Application and Component to IntegrationPipelineRun and making sure that label values matches application and component names", func() {
+		It("can append labels coming from Application and Component to IntegrationPipelineRun and making sure that label values matches application and component names", func() {
 			newIntegrationPipelineRun.WithApplicationAndComponent(hasApp, hasComp)
 			Expect(newIntegrationPipelineRun.Labels["appstudio.openshift.io/component"]).
 				To(Equal(hasComp.Name))
 			Expect(newIntegrationPipelineRun.Labels["appstudio.openshift.io/application"]).
 				To(Equal(hasApp.Name))
+		})
+
+		It("can append labels, workspaces and parameters that comes from Environment to IntegrationPipelineRun", func() {
+			newIntegrationPipelineRun.WithEnvironmentAndDeploymentTarget(deploymentTarget, hasEnv.Name)
+			Expect(newIntegrationPipelineRun.Labels["appstudio.openshift.io/environment"]).
+				To(Equal(hasEnv.Name))
+
+			Expect(newIntegrationPipelineRun.Spec.Workspaces != nil).To(BeTrue())
+			Expect(len(newIntegrationPipelineRun.Spec.Workspaces) > 0).To(BeTrue())
+			Expect(newIntegrationPipelineRun.Spec.Workspaces[0].Name).To(Equal("cluster-credentials"))
+			Expect(newIntegrationPipelineRun.Spec.Workspaces[0].Secret.SecretName).
+				To(Equal(deploymentTarget.Spec.KubernetesClusterCredentials.ClusterCredentialsSecret))
+
+			Expect(len(newIntegrationPipelineRun.Spec.Params) > 0).To(BeTrue())
+			Expect(newIntegrationPipelineRun.Spec.Params[0].Name).To(Equal("NAMESPACE"))
+			Expect(newIntegrationPipelineRun.Spec.Params[0].Value.StringVal).
+				To(Equal(deploymentTarget.Spec.KubernetesClusterCredentials.DefaultNamespace))
 		})
 
 		It("provides parameters from IntegrationTestScenario to the PipelineRun", func() {


### PR DESCRIPTION
Copied most of code from https://github.com/redhat-appstudio/integration-service/pull/81 and add the code for the new Environments API

* Add binding controller for test pipeline deployments on ephemeral envs
* Add functions that can detect a SEB with a finished deployment
* Ensure creation of test pipelines with associated DT
* Add unit tests for the binding controller
* Add unit tests for updated code in other packages

Signed-off-by: Hongwei Liu <hongliu@redhat.com>