### PR TITLE
chore(CI): bump static check version

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -89,7 +89,7 @@ jobs:
           fi
       - uses: dominikh/staticcheck-action@v1.3.0
         with:
-          version: "2022.1"
+          version: "2022.1.3"
           install-go: false
       - name: Check manifests # make generate manifests touches files even for no changes
         run: |


### PR DESCRIPTION
Static check version is quite old and may case issues in new code