### PR TITLE
fix: set maxlength for note in schema validation

### DIFF
--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -72,7 +72,8 @@ var testResultSchema = `{
       "minimum": 0
     },
     "note": {
-      "type": "string"
+      "type": "string",
+      "maxlength": 512
     },
     "failures": {
       "type": "integer",


### PR DESCRIPTION
MaxLength was set and then removed at one point during development, adding it back.