### PR TITLE
feat(STONEINTG-334): delete ephemeral Env CRs after int testing completes

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -74,8 +74,12 @@ rules:
   resources:
   - deploymentTargets
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - appstudio.redhat.com

--- a/controllers/pipeline/pipeline_suite_test.go
+++ b/controllers/pipeline/pipeline_suite_test.go
@@ -33,6 +33,7 @@ import (
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	integrationalpha1 "github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/controllers/snapshot"
 
 	goodies "github.com/redhat-appstudio/operator-goodies/test"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
@@ -100,6 +101,7 @@ var _ = BeforeSuite(func() {
 	go func() {
 		defer GinkgoRecover()
 		Expect(setupCache(k8sManager)).To(Succeed())
+		Expect(snapshot.SetupApplicationCache(k8sManager)).To(Succeed())
 		Expect(k8sManager.Start(ctx)).To(Succeed())
 	}()
 })

--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -390,3 +390,13 @@ func HasPipelineRunSucceeded(object client.Object) bool {
 
 	return false
 }
+
+// HasPipelineRunFinished returns a boolean indicating whether the PipelineRun finished or not.
+// If the object passed to this function is not a PipelineRun, the function will return false.
+func HasPipelineRunFinished(object client.Object) bool {
+	if pr, ok := object.(*tektonv1beta1.PipelineRun); ok {
+		return (pr.Status.GetCondition(apis.ConditionSucceeded).IsFalse() || pr.Status.GetCondition(apis.ConditionSucceeded).IsTrue())
+	}
+
+	return false
+}

--- a/tekton/predicates.go
+++ b/tekton/predicates.go
@@ -25,9 +25,9 @@ func IntegrationPipelineRunStartedPredicate() predicate.Predicate {
 	}
 }
 
-// IntegrationOrBuildPipelineRunSucceededPredicate returns a predicate which filters out all objects except
-// Integration and Build PipelineRuns which have just succeeded.
-func IntegrationOrBuildPipelineRunSucceededPredicate() predicate.Predicate {
+// IntegrationOrBuildPipelineRunFinishedPredicate returns a predicate which filters out all objects except
+// Integration and Build PipelineRuns which have just finished.
+func IntegrationOrBuildPipelineRunFinishedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
 			return false
@@ -40,7 +40,7 @@ func IntegrationOrBuildPipelineRunSucceededPredicate() predicate.Predicate {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return (IsIntegrationPipelineRun(e.ObjectNew) || IsBuildPipelineRun(e.ObjectNew)) &&
-				hasPipelineRunStateChangedToSucceeded(e.ObjectOld, e.ObjectNew)
+				hasPipelineRunStateChangedToFinished(e.ObjectOld, e.ObjectNew)
 		},
 	}
 }

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -50,13 +50,12 @@ func IsIntegrationPipelineRun(object client.Object) bool {
 	return false
 }
 
-// hasPipelineRunStateChangedToSucceeded returns a boolean indicating whether the PipelineRun status changed to succeeded or not.
+// hasPipelineRunStateChangedToFinished returns a boolean indicating whether the PipelineRun status changed to finished or not.
 // If the objects passed to this function are not PipelineRuns, the function will return false.
-func hasPipelineRunStateChangedToSucceeded(objectOld, objectNew client.Object) bool {
+func hasPipelineRunStateChangedToFinished(objectOld, objectNew client.Object) bool {
 	if oldPipelineRun, ok := objectOld.(*tektonv1beta1.PipelineRun); ok {
 		if newPipelineRun, ok := objectNew.(*tektonv1beta1.PipelineRun); ok {
-			return oldPipelineRun.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() &&
-				newPipelineRun.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
+			return oldPipelineRun.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() && !newPipelineRun.Status.GetCondition(apis.ConditionSucceeded).IsUnknown()
 		}
 	}
 


### PR DESCRIPTION
(This pr copies most of code in https://github.com/redhat-appstudio/integration-service/pull/81)

After the integration testing pipeline completes(succeed, skipped), we need to delete the CRs created for it.

* delete the ephemeral env
* delete deploymentTarget
* delete deploymentTargetClaim
* delete snapshotenvironmentbinding

This PR reference the code added in https://github.com/redhat-appstudio/integration-service/pull/154 and so should be rebased after merging https://github.com/redhat-appstudio/integration-service/pull/154.