### PR TITLE
fix(STONEINTG-419): Release pipeline run fails on missing attestation

### DIFF
--- a/controllers/pipeline/pipeline_controller.go
+++ b/controllers/pipeline/pipeline_controller.go
@@ -162,7 +162,7 @@ func setupControllerWithManager(manager ctrl.Manager, reconciler *Reconciler) er
 	return ctrl.NewControllerManagedBy(manager).
 		For(&tektonv1beta1.PipelineRun{}).
 		WithEventFilter(predicate.Or(
-			tekton.IntegrationPipelineRunStartedPredicate(),
-			tekton.IntegrationOrBuildPipelineRunFinishedPredicate())).
+			tekton.IntegrationPipelineRunPredicate(),
+			tekton.BuildPipelineRunFinishedPredicate())).
 		Complete(reconciler)
 }

--- a/tekton/predicates.go
+++ b/tekton/predicates.go
@@ -5,9 +5,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// IntegrationPipelineRunStartedPredicate returns a predicate which filters out all objects except
-// integration PipelineRuns that have just started.
-func IntegrationPipelineRunStartedPredicate() predicate.Predicate {
+// IntegrationPipelineRunPredicate returns a predicate which filters out all objects except
+// integration PipelineRuns that have just started or finished.
+func IntegrationPipelineRunPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
 			return false
@@ -20,14 +20,14 @@ func IntegrationPipelineRunStartedPredicate() predicate.Predicate {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return (IsIntegrationPipelineRun(e.ObjectNew) &&
-				hasPipelineRunStateChangedToStarted(e.ObjectOld, e.ObjectNew))
+				(hasPipelineRunStateChangedToStarted(e.ObjectOld, e.ObjectNew) || hasPipelineRunStateChangedToFinished(e.ObjectOld, e.ObjectNew)))
 		},
 	}
 }
 
-// IntegrationOrBuildPipelineRunFinishedPredicate returns a predicate which filters out all objects except
-// Integration and Build PipelineRuns which have just finished.
-func IntegrationOrBuildPipelineRunFinishedPredicate() predicate.Predicate {
+// BuildPipelineRunFinishedPredicate returns a predicate which filters out all objects except
+// Build PipelineRuns which have finished and been just signed.
+func BuildPipelineRunFinishedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
 			return false
@@ -39,8 +39,8 @@ func IntegrationOrBuildPipelineRunFinishedPredicate() predicate.Predicate {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return (IsIntegrationPipelineRun(e.ObjectNew) || IsBuildPipelineRun(e.ObjectNew)) &&
-				hasPipelineRunStateChangedToFinished(e.ObjectOld, e.ObjectNew)
+			return (IsBuildPipelineRun(e.ObjectNew)) &&
+				hasPipelineRunBeenChangedToSigned(e.ObjectOld, e.ObjectNew) // only finished pipelines are signed
 		},
 	}
 }

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -24,6 +24,9 @@ const (
 
 	// PipelineRunApplicationLabel is the label denoting the application.
 	PipelineRunApplicationLabel = "appstudio.openshift.io/application"
+
+	// PipelineRunApplicationLabel is the label added by Tekton Chains to signed PipelineRuns
+	PipelineRunChainsSignedAnnotation = "chains.tekton.dev/signed"
 )
 
 // IsBuildPipelineRun returns a boolean indicating whether the object passed is a PipelineRun from
@@ -69,6 +72,19 @@ func hasPipelineRunStateChangedToStarted(objectOld, objectNew client.Object) boo
 		if newPipelineRun, ok := objectNew.(*tektonv1beta1.PipelineRun); ok {
 			return (oldPipelineRun.Status.StartTime == nil || oldPipelineRun.Status.StartTime.IsZero()) &&
 				(newPipelineRun.Status.StartTime != nil && !newPipelineRun.Status.StartTime.IsZero())
+		}
+	}
+
+	return false
+}
+
+// hasPipelineRunBeenChangedToSigned returns a boolean indicated whether the PipelineRun just been signed
+// If the objects passed to this function are not PipelineRuns, the function will return false.
+func hasPipelineRunBeenChangedToSigned(objectOld, objectNew client.Object) bool {
+	if oldPipelineRun, ok := objectOld.(*tektonv1beta1.PipelineRun); ok {
+		if newPipelineRun, ok := objectNew.(*tektonv1beta1.PipelineRun); ok {
+			return (!helpers.HasAnnotationWithValue(oldPipelineRun, PipelineRunChainsSignedAnnotation, "true") &&
+				helpers.HasAnnotationWithValue(newPipelineRun, PipelineRunChainsSignedAnnotation, "true"))
 		}
 	}
 


### PR DESCRIPTION
PipelineRun are signed with tekton chains after they finish. We are
hitting race condition than sometimes we are creating release without
signed pipeline and cause error mentioned in subject.
Reconcile only build pipelines which have been signed
by tekton chains to avoid this issue.

Signed pipelineRuns are marked with annotation chains.tekton.dev/signed
