### PR TITLE
Revert "chore(Dockerfile): bump ubi8/go-toolset from 1.18.10-1 to 1.19.6-4"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.6-4 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18.10-1 as builder
 
 WORKDIR /opt/app-root/src
 


### PR DESCRIPTION
Reverts redhat-appstudio/integration-service#172