### PR TITLE
Revert "chore(Dockerfile): bump ubi8/ubi-minimal from 8.7-1107 to 8.8-860"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 # Use ubi-minimal as minimal base image to package the manager binary
 # Refer to https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-860
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1107
 COPY --from=builder /opt/app-root/src/manager /
 USER 65532:65532
 


### PR DESCRIPTION
Reverts redhat-appstudio/integration-service#173