### PR TITLE
Drop cert manager dependency from webhook.

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -13,7 +13,7 @@ patchesStrategicMerge:
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_integrationtestscenarios.yaml
+#- patches/cainjection_in_integrationtestscenarios.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/crd/patches/cainjection_in_integrationtestscenarios.yaml
+++ b/config/crd/patches/cainjection_in_integrationtestscenarios.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    service.beta.openshift.io/inject-cabundle: "true"
   name: integrationtestscenarios.appstudio.redhat.com

--- a/config/crd/patches/webhook_in_integrationtestscenarios.yaml
+++ b/config/crd/patches/webhook_in_integrationtestscenarios.yaml
@@ -2,15 +2,16 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
   name: integrationtestscenarios.appstudio.redhat.com
 spec:
   conversion:
     strategy: Webhook
     webhook:
+      conversionReviewVersions: ["v1alpha1", "v1beta1"]
       clientConfig:
         service:
           namespace: system
           name: webhook-service
           path: /convert
-      conversionReviewVersions:
-      - v1

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ bases:
 # crd/kustomization.yaml
 - ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-- ../certmanager
+#- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 - ../prometheus
 
@@ -41,34 +41,34 @@ patchesStrategicMerge:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
+#vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-- name: SERVICE_NAMESPACE # namespace of the service
-  objref:
-    kind: Service
-    version: v1
-    name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
-- name: SERVICE_NAME
-  objref:
-    kind: Service
-    version: v1
-    name: webhook-service
+# - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#   objref:
+#     kind: Certificate
+#     group: cert-manager.io
+#     version: v1
+#     name: serving-cert # this name should match the one in certificate.yaml
+#   fieldref:
+#     fieldpath: metadata.namespace
+# - name: CERTIFICATE_NAME
+#   objref:
+#     kind: Certificate
+#     group: cert-manager.io
+#     version: v1
+#     name: serving-cert # this name should match the one in certificate.yaml
+# - name: SERVICE_NAMESPACE # namespace of the service
+#   objref:
+#     kind: Service
+#     version: v1
+#     name: webhook-service
+#   fieldref:
+#     fieldpath: metadata.namespace
+# - name: SERVICE_NAME
+#   objref:
+#     kind: Service
+#     version: v1
+#     name: webhook-service

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -3,27 +3,13 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  labels:
-    app.kubernetes.io/name: mutatingwebhookconfiguration
-    app.kubernetes.io/instance: mutating-webhook-configuration
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: integration-service
-    app.kubernetes.io/part-of: integration-service
-    app.kubernetes.io/managed-by: kustomize
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    service.beta.openshift.io/inject-cabundle: "true"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  labels:
-    app.kubernetes.io/name: validatingwebhookconfiguration
-    app.kubernetes.io/instance: validating-webhook-configuration
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: integration-service
-    app.kubernetes.io/part-of: integration-service
-    app.kubernetes.io/managed-by: kustomize
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-#- manifests.yaml
+- manifests.yaml
 - service.yaml
 
 configurations:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,79 @@
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1alpha1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-appstudio-redhat-com-v1alpha1-integrationtestscenario
+  failurePolicy: Fail
+  name: mapplication.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - applications
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-application
+  failurePolicy: Fail
+  name: vapplication.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - applications
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-component
+  failurePolicy: Fail
+  name: vcomponent.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - components
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -11,6 +11,8 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
   namespace: system
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
 spec:
   ports:
     - port: 443


### PR DESCRIPTION
Following changes inject CA bundle directly to the webhook so its not needed to be provided by third party operator.