### PR TITLE
chore(STONEINTG-379): use go 1.19

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:
@@ -89,7 +89,7 @@ jobs:
           fi
       - uses: dominikh/staticcheck-action@v1.3.0
         with:
-          version: "2022.1"
+          version: "2023.1.3"
           install-go: false
       - name: Check manifests # make generate manifests touches files even for no changes
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.10-1 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19.9-3 as builder
 
 WORKDIR /opt/app-root/src
 

--- a/controllers/scenario/scenario_controller_test.go
+++ b/controllers/scenario/scenario_controller_test.go
@@ -32,9 +32,6 @@ var _ = Describe("ScenarioController", func() {
 		hasScenario        *v1alpha1.IntegrationTestScenario
 		failScenario       *v1alpha1.IntegrationTestScenario
 	)
-	const (
-		SampleRepoLink = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
-	)
 
 	BeforeEach(func() {
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-appstudio/integration-service
 
-go 1.18
+go 1.19
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.4.0


### PR DESCRIPTION
Go 1.18 is quite old and our dependecies already requires go 1.19 as min version. Moving to 1.19 will allow us to use latest versions of libraries.