### PR TITLE
fix(STONEINTG-431): make snapshot as failed if pipline of one scenario fails

### DIFF
--- a/loader/integration.go
+++ b/loader/integration.go
@@ -39,7 +39,7 @@ func GetLatestPipelineRunForSnapshotAndScenario(adapterClient client.Client, ctx
 	latestIntegrationPipelineRun = nil
 	for _, pipelineRun := range *integrationPipelineRuns {
 		pipelineRun := pipelineRun // G601
-		if pipelineRun.Status.GetCondition(apis.ConditionSucceeded).IsTrue() {
+		if !pipelineRun.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
 			if latestIntegrationPipelineRun == nil {
 				latestIntegrationPipelineRun = &pipelineRun
 			} else {


### PR DESCRIPTION
* get the lastest finished pipeline when trying to get latest pr
* create scenario in helpsers.integration_test.go and adjust unittest
* add Eventually to make sure the global component list is changed successfully before creating composite snapshot

Signed-off-by: Hongwei Liu <hongliu@redhat.com>