### PR TITLE
feat(STONEINTG-458): build pipelineRuns are annotated with Snapshots

### DIFF
--- a/controllers/pipeline/pipeline_adapter_test.go
+++ b/controllers/pipeline/pipeline_adapter_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/redhat-appstudio/integration-service/tekton"
 	"reflect"
 	"time"
 
@@ -1140,6 +1141,13 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(pipelineRuns).NotTo(BeNil())
 			Expect(len(*pipelineRuns)).To(Equal(2))
 			Expect((*pipelineRuns)[0].Name == testpipelineRunBuild.Name || (*pipelineRuns)[1].Name == testpipelineRunBuild.Name).To(BeTrue())
+		})
+
+		It("can annotate the build pipelineRun with the Snapshot name", func() {
+			pipelineRun, err := adapter.annotateBuildPipelineRunWithSnapshot(testpipelineRunBuild, hasSnapshot)
+			Expect(err).To(BeNil())
+			Expect(pipelineRun).NotTo(BeNil())
+			Expect(pipelineRun.ObjectMeta.Annotations[tekton.SnapshotNameLabel]).To(Equal(hasSnapshot.Name))
 		})
 
 		It("ensure that EnsureSnapshotExists doesn't create snapshot for previous pipeline run", func() {

--- a/controllers/pipeline/pipeline_controller.go
+++ b/controllers/pipeline/pipeline_controller.go
@@ -165,6 +165,6 @@ func setupControllerWithManager(manager ctrl.Manager, reconciler *Reconciler) er
 		For(&tektonv1beta1.PipelineRun{}).
 		WithEventFilter(predicate.Or(
 			tekton.IntegrationPipelineRunPredicate(),
-			tekton.BuildPipelineRunFinishedPredicate())).
+			tekton.BuildPipelineRunSignedAndSucceededPredicate())).
 		Complete(reconciler)
 }

--- a/helpers/metadata.go
+++ b/helpers/metadata.go
@@ -23,6 +23,17 @@ func HasAnnotationWithValue(object client.Object, annotation, value string) bool
 	return false
 }
 
+// AddAnnotation adds an annotation to an object
+func AddAnnotation(objectMeta *metav1.ObjectMeta, annotation string, value string) {
+	annotations := map[string]string{}
+	if objectMeta.GetAnnotations() != nil {
+		annotations = objectMeta.GetAnnotations()
+	}
+	annotations[annotation] = value
+
+	objectMeta.SetAnnotations(annotations)
+}
+
 // HasLabel checks if a given label exists
 func HasLabel(object client.Object, label string) bool {
 	_, found := object.GetLabels()[label]

--- a/helpers/metadata_test.go
+++ b/helpers/metadata_test.go
@@ -167,5 +167,17 @@ var _ = Describe("Helpers for labels and annotation", Ordered, func() {
 			helpers.CopyAnnotationsByPrefix(&testpipelineLabel.ObjectMeta, &dest.ObjectMeta, "test.prefix", "new.prefix")
 			Expect(dest.Annotations).To(BeNil())
 		})
+		It("AddAnnotation with a test annotation", func() {
+			testpipelineLabel.ObjectMeta.Annotations = nil
+			helpers.AddAnnotation(&testpipelineLabel.ObjectMeta, "test/test", "test")
+			Expect(testpipelineLabel.ObjectMeta.Annotations).To(Not(BeNil()))
+			Expect(testpipelineLabel.ObjectMeta.Annotations["test/test"]).To(Equal("test"))
+
+			// Verify that AddAnnotation doesn't remove existing annotations
+			helpers.AddAnnotation(&testpipelineLabel.ObjectMeta, "test/test2", "test2")
+			Expect(testpipelineLabel.ObjectMeta.Annotations).To(Not(BeNil()))
+			Expect(testpipelineLabel.ObjectMeta.Annotations["test/test"]).To(Equal("test"))
+			Expect(testpipelineLabel.ObjectMeta.Annotations["test/test2"]).To(Equal("test2"))
+		})
 	})
 })

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -269,6 +269,7 @@ var _ = Describe("Loader", Ordered, func() {
 				},
 				Annotations: map[string]string{
 					"appstudio.redhat.com/updateComponentOnSuccess": "false",
+					"appstudio.openshift.io/snapshot":               hasSnapshot.Name,
 				},
 			},
 			Spec: tektonv1beta1.PipelineRunSpec{

--- a/tekton/predicates.go
+++ b/tekton/predicates.go
@@ -1,6 +1,7 @@
 package tekton
 
 import (
+	"github.com/redhat-appstudio/integration-service/helpers"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -19,8 +20,8 @@ func IntegrationPipelineRunPredicate() predicate.Predicate {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return (IsIntegrationPipelineRun(e.ObjectNew) &&
-				(hasPipelineRunStateChangedToStarted(e.ObjectOld, e.ObjectNew) || hasPipelineRunStateChangedToFinished(e.ObjectOld, e.ObjectNew)))
+			return IsIntegrationPipelineRun(e.ObjectNew) &&
+				(hasPipelineRunStateChangedToStarted(e.ObjectOld, e.ObjectNew) || hasPipelineRunStateChangedToFinished(e.ObjectOld, e.ObjectNew))
 		},
 	}
 }
@@ -39,8 +40,7 @@ func BuildPipelineRunFinishedPredicate() predicate.Predicate {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return (IsBuildPipelineRun(e.ObjectNew)) &&
-				hasPipelineRunBeenChangedToSigned(e.ObjectOld, e.ObjectNew) // only finished pipelines are signed
+			return IsBuildPipelineRun(e.ObjectNew) && isPipelineRunSigned(e.ObjectNew) && helpers.HasPipelineRunSucceeded(e.ObjectNew)
 		},
 	}
 }

--- a/tekton/predicates.go
+++ b/tekton/predicates.go
@@ -26,9 +26,9 @@ func IntegrationPipelineRunPredicate() predicate.Predicate {
 	}
 }
 
-// BuildPipelineRunFinishedPredicate returns a predicate which filters out all objects except
-// Build PipelineRuns which have finished and been just signed.
-func BuildPipelineRunFinishedPredicate() predicate.Predicate {
+// BuildPipelineRunSignedAndSucceededPredicate returns a predicate which filters out all objects except
+// Build PipelineRuns which have finished, been signed and haven't had a Snapshot created for them.
+func BuildPipelineRunSignedAndSucceededPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
 			return false
@@ -40,7 +40,9 @@ func BuildPipelineRunFinishedPredicate() predicate.Predicate {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return IsBuildPipelineRun(e.ObjectNew) && isPipelineRunSigned(e.ObjectNew) && helpers.HasPipelineRunSucceeded(e.ObjectNew)
+			return IsBuildPipelineRun(e.ObjectNew) && isPipelineRunSigned(e.ObjectNew) &&
+				helpers.HasPipelineRunSucceeded(e.ObjectNew) &&
+				!helpers.HasAnnotation(e.ObjectNew, SnapshotNameLabel)
 		},
 	}
 }

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -25,7 +25,7 @@ const (
 	// PipelineRunApplicationLabel is the label denoting the application.
 	PipelineRunApplicationLabel = "appstudio.openshift.io/application"
 
-	// PipelineRunApplicationLabel is the label added by Tekton Chains to signed PipelineRuns
+	// PipelineRunChainsSignedAnnotation is the label added by Tekton Chains to signed PipelineRuns
 	PipelineRunChainsSignedAnnotation = "chains.tekton.dev/signed"
 )
 
@@ -78,16 +78,12 @@ func hasPipelineRunStateChangedToStarted(objectOld, objectNew client.Object) boo
 	return false
 }
 
-// hasPipelineRunBeenChangedToSigned returns a boolean indicated whether the PipelineRun just been signed
-// If the objects passed to this function are not PipelineRuns, the function will return false.
-func hasPipelineRunBeenChangedToSigned(objectOld, objectNew client.Object) bool {
-	if oldPipelineRun, ok := objectOld.(*tektonv1beta1.PipelineRun); ok {
-		if newPipelineRun, ok := objectNew.(*tektonv1beta1.PipelineRun); ok {
-			return (!helpers.HasAnnotationWithValue(oldPipelineRun, PipelineRunChainsSignedAnnotation, "true") &&
-				helpers.HasAnnotationWithValue(newPipelineRun, PipelineRunChainsSignedAnnotation, "true"))
-		}
+// isPipelineRunSigned returns a boolean indicated whether the PipelineRun been signed
+// If the object passed to this function is not a PipelineRun, the function will return false.
+func isPipelineRunSigned(objectNew client.Object) bool {
+	if newPipelineRun, ok := objectNew.(*tektonv1beta1.PipelineRun); ok {
+		return helpers.HasAnnotationWithValue(newPipelineRun, PipelineRunChainsSignedAnnotation, "true")
 	}
-
 	return false
 }
 


### PR DESCRIPTION
* Build pipelineRuns are annotated with created Snapshots
* Expand build pipelineRun predicate to ignore annotated pipelineRuns
* Only require that build pipelineRun is signed by chains operator
* Require that the build pipelineRun is succeeded