### PR TITLE
fix(STONEINTG-185): remove cluster-monitring label

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    openshift.io/cluster-monitoring: "true"
   name: system
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
This label is not supposed to be included in manager config as it may be monitored by user workload prometheus instance