### PR TITLE
feat: enable podman support in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ IMG ?= $(IMAGE_TAG_BASE):$(TAG_NAME)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 
+# container engine to use.  Defaults to docker
+CONT_ENGINE ?= docker
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -119,13 +122,13 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
-.PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+.PHONY: img-build
+img-build: test ## Build container image with the manager.
+	$(CONT_ENGINE) build -t ${IMG} .
 
-.PHONY: docker-push
-docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+.PHONY: img-push
+img-push: ## Push container image with the manager.
+	$(CONT_ENGINE) push ${IMG}
 
 ##@ Deployment
 
@@ -195,7 +198,7 @@ bundle-build: ## Build the bundle image.
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
-	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
+	$(MAKE) img-push IMG=$(BUNDLE_IMG)
 
 .PHONY: opm
 OPM = ./bin/opm
@@ -236,4 +239,4 @@ catalog-build: opm ## Build a catalog image.
 # Push the catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+	$(MAKE) img-push IMG=$(CATALOG_IMG)

--- a/README.md
+++ b/README.md
@@ -18,23 +18,23 @@ and build the operator.
 To build the operator and push a new image to the registry, the following commands can be used:
 
 ```shell
-$ make docker-build
-$ make docker-push
+$ make img-build
+$ make img-push
 ```
 
 These commands will use the default image and tag. To modify them, new values for `TAG` and `IMG` environment variables
 can be passed. For example, to override the tag:
 
 ```shell
-$ TAG=my-tag make docker-build
-$ TAG=my-tag make docker-push
+$ TAG=my-tag make img-build
+$ TAG=my-tag make img-push
 ```
 
 Or, in the case the image should be pushed to a different repository:
 
 ```shell
-$ IMG=quay.io/user/integration-service:my-tag make docker-build
-$ IMG=quay.io/user/integration-service:my-tag make docker-push
+$ IMG=quay.io/user/integration-service:my-tag make img-build
+$ IMG=quay.io/user/integration-service:my-tag make img-push
 ```
 
 ### Running tests


### PR DESCRIPTION
Our Makefile only supports docker.  Since podman is developed at Red Hat cri-o is the default OpenShift runtime, we should also make sure we support development using podman.  This is just a quick change to the Makefile and documentation to enable users to override the default docker container runtime via the 'CONT_ENGINE' environment variable.

Note: I grepped for references to `docker-build` and `docker-push`.  I saw some pipelineRefs in `.tekton` named `docker-build`.  Should those be renamed too?