### PR TITLE
feat(STONEINTG-433): cleanup ephemeral envs for some errors

### DIFF
--- a/gitops/predicates.go
+++ b/gitops/predicates.go
@@ -29,3 +29,13 @@ func DeploymentSucceededForIntegrationBindingPredicate() predicate.Predicate {
 		},
 	}
 }
+
+// DeploymentFailedForIntegrationBindingPredicate returns a predicate which filters out update events to a
+// SnapshotEnvironmentBinding that have resulted in a deployment failure.
+func DeploymentFailedForIntegrationBindingPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return hasDeploymentFailed(e.ObjectOld, e.ObjectNew)
+		},
+	}
+}

--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -303,9 +303,7 @@ func IsEnvironmentEphemeral(testEnvironment *applicationapiv1alpha1.Environment)
 	return isEphemeral
 }
 
-func CleanUpEphemeralEnvironments(client client.Client, logger *IntegrationLogger, ctx context.Context, env *applicationapiv1alpha1.Environment,
-	dtc *applicationapiv1alpha1.DeploymentTargetClaim) error {
-
+func CleanUpEphemeralEnvironments(client client.Client, logger *IntegrationLogger, ctx context.Context, env *applicationapiv1alpha1.Environment, dtc *applicationapiv1alpha1.DeploymentTargetClaim) error {
 	logger.Info("Deleting deploymentTargetClaim", "deploymentTargetClaim.Name", dtc.Name)
 	err := client.Delete(ctx, dtc)
 	if err != nil {


### PR DESCRIPTION
When an issue happens with deployment of the Snapshot during Integration testing on ephemeral environments, the Integration service needs to delete the associated Environment and DTC CRs in order to clean up the provisioned namespace.