### PR TITLE
chore: update go to 1.19 in codecov.yml

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Run tests
         run: make test
       - name: Codecov


### PR DESCRIPTION
There is an error `/pkg/cached/cache.go:242:16: undefined: atomic.Pointer` in `build-and-deploy` recently https://github.com/redhat-appstudio/integration-service/actions/workflows/codecov.yml started from https://github.com/redhat-appstudio/integration-service/actions/runs/5287590372/jobs/9568263408

Update go in codecov.yml to 1.19 can fix it.

Signed-off-by: Hongwei Liu <hongliu@redhat.com>