### PR TITLE
feat(STONEINTG-454): copy build labels/annotations to new Snapshots

### DIFF
--- a/controllers/pipeline/pipeline_adapter.go
+++ b/controllers/pipeline/pipeline_adapter.go
@@ -536,6 +536,10 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1beta1.Pipel
 	h.CopyLabelsByPrefix(&pipelineRun.ObjectMeta, &snapshot.ObjectMeta, "pipelinesascode.tekton.dev", gitops.PipelinesAsCodePrefix)
 	h.CopyAnnotationsByPrefix(&pipelineRun.ObjectMeta, &snapshot.ObjectMeta, "pipelinesascode.tekton.dev", gitops.PipelinesAsCodePrefix)
 
+	// Copy build labels and annotations prefixed with build.appstudio from Build to Snapshot.
+	h.CopyLabelsByPrefix(&pipelineRun.ObjectMeta, &snapshot.ObjectMeta, gitops.BuildPipelineRunPrefix, gitops.BuildPipelineRunPrefix)
+	h.CopyAnnotationsByPrefix(&pipelineRun.ObjectMeta, &snapshot.ObjectMeta, gitops.BuildPipelineRunPrefix, gitops.BuildPipelineRunPrefix)
+
 	return snapshot, nil
 }
 

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -29,6 +29,9 @@ const (
 	// SnapshotTestScenarioLabel contains the name of the Snapshot test scenario.
 	SnapshotTestScenarioLabel = "test.appstudio.openshift.io/scenario"
 
+	// BuildPipelineRunPrefix contains the build pipeline run related labels and annotations
+	BuildPipelineRunPrefix = "build.appstudio"
+
 	// BuildPipelineRunFinishTimeLabel contains the build PipelineRun finish time of the Snapshot.
 	BuildPipelineRunFinishTimeLabel = "test.appstudio.openshift.io/pipelinerunfinishtime"
 


### PR DESCRIPTION
Copy build labels/annotations prefixed with build.appstudio from pipeline runs to new Snapshots