### PR TITLE
feat(STONEINTG-484): set environment as owner reference of binding

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -96,6 +96,12 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - environments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
   - integrationtestscenarios
   verbs:
   - create

--- a/controllers/pipeline/pipeline_adapter.go
+++ b/controllers/pipeline/pipeline_adapter.go
@@ -286,6 +286,12 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (reconciler.OperationRe
 			return reconciler.RequeueWithError(err)
 		}
 
+		binding, err := a.loader.FindExistingSnapshotEnvironmentBinding(a.client, a.context, a.application, testEnvironment)
+		if err != nil || binding == nil {
+			a.logger.Error(err, "Failed to find snapshotEnvironmentBinding associated with environment", "environment.Name", testEnvironment.Name)
+			return reconciler.RequeueWithError(err)
+		}
+
 		a.logger.Info("Deleting deploymentTarget", "deploymentTarget.Name", dt.Name)
 		err = a.client.Delete(a.context, dt)
 		if err != nil {
@@ -302,13 +308,13 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (reconciler.OperationRe
 		}
 		a.logger.LogAuditEvent("DeploymentTargetClaim deleted", dtc, h.LogActionDelete)
 
-		a.logger.Info("Deleting environment and its owning snapshotEnvironmentBinding", "environment.Name", testEnvironment.Name)
+		a.logger.Info("Deleting environment and its owning snapshotEnvironmentBinding", "environment.Name", testEnvironment.Name, "binding.Name", binding.Name)
 		err = a.client.Delete(a.context, testEnvironment)
 		if err != nil {
-			a.logger.Error(err, "Failed to delete the test ephemeral environment and the owning snapshotEnvironmentBinding")
+			a.logger.Error(err, "Failed to delete the test ephemeral environment and its owning snapshotEnvironmentBinding", "environment.Name", testEnvironment.Name, "binding.Name", binding.Name)
 			return reconciler.RequeueWithError(err)
 		}
-		a.logger.LogAuditEvent("Ephemeral environment and the owning snapshotEnvironmentBinding deleted", testEnvironment, h.LogActionDelete)
+		a.logger.LogAuditEvent("Ephemeral environment and its owning snapshotEnvironmentBinding deleted", testEnvironment, h.LogActionDelete)
 	} else {
 		a.logger.Info("The pipelineRun test Environment is not ephemeral, skipping cleanup.")
 	}

--- a/controllers/pipeline/pipeline_adapter_test.go
+++ b/controllers/pipeline/pipeline_adapter_test.go
@@ -1380,7 +1380,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			expectedLogEntry = "DeploymentTargetClaim deleted"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 
-			expectedLogEntry = "Ephemeral environment and the owning snapshotEnvironmentBinding deleted"
+			expectedLogEntry = "Ephemeral environment and its owning snapshotEnvironmentBinding deleted"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 	})

--- a/controllers/pipeline/pipeline_adapter_test.go
+++ b/controllers/pipeline/pipeline_adapter_test.go
@@ -1380,10 +1380,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			expectedLogEntry = "DeploymentTargetClaim deleted"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 
-			expectedLogEntry = "Ephemeral environment deleted"
-			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
-
-			expectedLogEntry = "SnapshotEnvironmentBinding deleted"
+			expectedLogEntry = "Ephemeral environment and the owning snapshotEnvironmentBinding deleted"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 	})

--- a/controllers/pipeline/pipeline_controller.go
+++ b/controllers/pipeline/pipeline_controller.go
@@ -60,6 +60,7 @@ func NewIntegrationReconciler(client client.Client, logger *logr.Logger, scheme 
 //+kubebuilder:rbac:groups=tekton.dev,resources=taskruns,verbs=get;list;watch
 //+kubebuilder:rbac:groups=tekton.dev,resources=taskruns/status,verbs=get
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/finalizers,verbs=update
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=pipelinesascode.tekton.dev,resources=repositories,verbs=get;list;watch
 

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -501,7 +501,7 @@ func (a *Adapter) createSnapshotEnvironmentBindingForSnapshot(application *appli
 		environment.Name,
 		snapshot, *components)
 
-	// set environemtn as owner of snapshotEnvironmentBinding on controlled
+	// set environment as owner of snapshotEnvironmentBinding on controlled
 	err := ctrl.SetControllerReference(environment, snapshotEnvironmentBinding, a.client.Scheme())
 	if err != nil {
 		return nil, err

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -130,7 +130,7 @@ func (a *Adapter) EnsureAllIntegrationTestPipelinesExist() (reconciler.Operation
 	if err != nil {
 		a.logger.Error(err, "Failed to get all required IntegrationTestScenarios")
 		patch := client.MergeFrom(a.snapshot.DeepCopy())
-		gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to get all required IntegrationTestScenarios")
+		gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to get all required IntegrationTestScenarios: "+err.Error())
 		a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to get all required IntegrationTestScenarios",
 			a.snapshot, h.LogActionUpdate)
 		return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))
@@ -311,7 +311,7 @@ func (a *Adapter) EnsureAllReleasesExist() (reconciler.OperationResult, error) {
 	if err != nil {
 		a.logger.Error(err, "Failed to get all ReleasePlans")
 		patch := client.MergeFrom(a.snapshot.DeepCopy())
-		gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to get all ReleasePlans")
+		gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to get all ReleasePlans: "+err.Error())
 		a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to get all ReleasePlans",
 			a.snapshot, h.LogActionUpdate)
 		return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))
@@ -321,7 +321,7 @@ func (a *Adapter) EnsureAllReleasesExist() (reconciler.OperationResult, error) {
 	if err != nil {
 		a.logger.Error(err, "Failed to create new Releases")
 		patch := client.MergeFrom(a.snapshot.DeepCopy())
-		gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to create new Releases")
+		gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to create new Releases: "+err.Error())
 		a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to create new Releases",
 			a.snapshot, h.LogActionUpdate)
 		return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))
@@ -364,7 +364,7 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (reconciler.OperationR
 					"snapshotEnvironmentBinding.Environment", snapshotEnvironmentBinding.Spec.Environment,
 					"snapshotEnvironmentBinding.Snapshot", snapshotEnvironmentBinding.Spec.Snapshot)
 				patch := client.MergeFrom(a.snapshot.DeepCopy())
-				gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to update SnapshotEnvironmentBinding")
+				gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to update SnapshotEnvironmentBinding: "+err.Error())
 				a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to update SnapshotEnvironmentBinding",
 					a.snapshot, h.LogActionUpdate)
 				return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))
@@ -383,7 +383,7 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (reconciler.OperationR
 					"environment", availableEnvironment.Name,
 					"snapshot", a.snapshot.Name)
 				patch := client.MergeFrom(a.snapshot.DeepCopy())
-				gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to create SnapshotEnvironmentBinding: " + err.Error())
+				gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to create SnapshotEnvironmentBinding: "+err.Error())
 				a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to create SnapshotEnvironmentBinding",
 					a.snapshot, h.LogActionUpdate)
 				return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -378,10 +378,10 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (reconciler.OperationR
 		} else {
 			snapshotEnvironmentBinding, err = a.createSnapshotEnvironmentBindingForSnapshot(a.application, &availableEnvironment, a.snapshot, components)
 			if err != nil {
-				a.logger.Error(err, "Failed to create SnapshotEnvironmentBinding",
-					"snapshotEnvironmentBinding.Application", snapshotEnvironmentBinding.Spec.Application,
-					"snapshotEnvironmentBinding.Environment", snapshotEnvironmentBinding.Spec.Environment,
-					"snapshotEnvironmentBinding.Snapshot", snapshotEnvironmentBinding.Spec.Snapshot)
+				a.logger.Error(err, "Failed to create SnapshotEnvironmentBinding for snapshot",
+					"application", a.application.Name,
+					"environment", availableEnvironment.Name,
+					"snapshot", a.snapshot.Name)
 				patch := client.MergeFrom(a.snapshot.DeepCopy())
 				gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to create SnapshotEnvironmentBinding")
 				a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to create SnapshotEnvironmentBinding",
@@ -505,7 +505,8 @@ func (a *Adapter) createSnapshotEnvironmentBindingForSnapshot(application *appli
 		environment.Name,
 		snapshot, *components)
 
-	err := ctrl.SetControllerReference(application, snapshotEnvironmentBinding, a.client.Scheme())
+	// set environemtn as owner of snapshotEnvironmentBinding on controlled
+	err := ctrl.SetControllerReference(environment, snapshotEnvironmentBinding, a.client.Scheme())
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -383,7 +383,7 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (reconciler.OperationR
 					"environment", availableEnvironment.Name,
 					"snapshot", a.snapshot.Name)
 				patch := client.MergeFrom(a.snapshot.DeepCopy())
-				gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to create SnapshotEnvironmentBinding")
+				gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to create SnapshotEnvironmentBinding: " + err.Error())
 				a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to create SnapshotEnvironmentBinding",
 					a.snapshot, h.LogActionUpdate)
 				return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -76,7 +76,6 @@ func (a *Adapter) EnsureAllIntegrationTestPipelinesExist() (reconciler.Operation
 	integrationTestScenarios, err := a.loader.GetAllIntegrationTestScenariosForApplication(a.client, a.context, a.application)
 	if err != nil {
 		a.logger.Error(err, "Failed to get Integration test scenarios for the following application",
-			"Application.Name", a.application.Name,
 			"Application.Namespace", a.application.Namespace)
 	}
 
@@ -360,7 +359,6 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (reconciler.OperationR
 			snapshotEnvironmentBinding, err = a.updateExistingSnapshotEnvironmentBindingWithSnapshot(snapshotEnvironmentBinding, a.snapshot, components)
 			if err != nil {
 				a.logger.Error(err, "Failed to update SnapshotEnvironmentBinding",
-					"snapshotEnvironmentBinding.Application", snapshotEnvironmentBinding.Spec.Application,
 					"snapshotEnvironmentBinding.Environment", snapshotEnvironmentBinding.Spec.Environment,
 					"snapshotEnvironmentBinding.Snapshot", snapshotEnvironmentBinding.Spec.Snapshot)
 				patch := client.MergeFrom(a.snapshot.DeepCopy())
@@ -371,7 +369,6 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (reconciler.OperationR
 			}
 			a.logger.LogAuditEvent("Existing SnapshotEnvironmentBinding updated with Snapshot",
 				snapshotEnvironmentBinding, h.LogActionUpdate,
-				"snapshotEnvironmentBinding.Application", snapshotEnvironmentBinding.Spec.Application,
 				"snapshotEnvironmentBinding.Environment", snapshotEnvironmentBinding.Spec.Environment,
 				"snapshotEnvironmentBinding.Snapshot", snapshotEnvironmentBinding.Spec.Snapshot)
 
@@ -379,7 +376,6 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (reconciler.OperationR
 			snapshotEnvironmentBinding, err = a.createSnapshotEnvironmentBindingForSnapshot(a.application, &availableEnvironment, a.snapshot, components)
 			if err != nil {
 				a.logger.Error(err, "Failed to create SnapshotEnvironmentBinding for snapshot",
-					"application", a.application.Name,
 					"environment", availableEnvironment.Name,
 					"snapshot", a.snapshot.Name)
 				patch := client.MergeFrom(a.snapshot.DeepCopy())
@@ -582,7 +578,6 @@ func (a *Adapter) createCopyOfExistingEnvironment(existingEnvironment *applicati
 	ref := ctrl.SetControllerReference(application, environment, a.client.Scheme())
 	if ref != nil {
 		a.logger.Error(ref, "Failed to set controller reference for Environment!",
-			"application.Name", application.Name,
 			"environment.Name", environment.Name)
 	}
 

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -784,8 +784,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(binding.Spec.Snapshot).To(Equal(hasSnapshotPR.Name))
 			Expect(binding.Spec.Environment).To(Equal(ephemeralEnv.Name))
 
-			err := k8sClient.Delete(ctx, &binding)
-			Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+			owners := binding.GetOwnerReferences()
+			Expect(len(owners) == 1).To(BeTrue())
+			Expect(owners[0].Name).To(Equal(ephemeralEnv.Name))
 		})
 	})
 })

--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -56,6 +56,7 @@ func NewSnapshotReconciler(client client.Client, logger *logr.Logger, scheme *ru
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/finalizers,verbs=update
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments/finalizers,verbs=update
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=deploymenttargetclasses,verbs=get;list;watch


### PR DESCRIPTION
* As an object can have only one owner reference on controlled, so we change to make environment own binding on controlled.
* add err.Error() to reason when marking snapshot as invalid
* add rbac for environments/finalizers
* update log message

Signed-off-by: Hongwei Liu <hongliu@redhat.com>