### PR TITLE
fix(stoneintg-505): Use snapshot components when creating SEB

### DIFF
--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -344,7 +344,7 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (reconciler.OperationR
 		return reconciler.RequeueWithError(err)
 	}
 
-	components, err := a.loader.GetAllApplicationComponents(a.client, a.context, a.application)
+	components, err := a.loader.GetAllSnapshotComponents(a.client, a.context, a.snapshot)
 	if err != nil {
 		return reconciler.RequeueWithError(err)
 	}

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -362,7 +362,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					Resource:   env,
 				},
 				{
-					ContextKey: loader.ApplicationComponentsContextKey,
+					ContextKey: loader.SnapshotComponentsContextKey,
 					Resource:   []applicationapiv1alpha1.Component{*hasComp},
 				},
 				{

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -38,6 +38,7 @@ type ObjectLoader interface {
 	GetAllEnvironments(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Environment, error)
 	GetReleasesWithSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.Release, error)
 	GetAllApplicationComponents(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Component, error)
+	GetAllSnapshotComponents(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*[]applicationapiv1alpha1.Component, error)
 	GetApplicationFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Application, error)
 	GetComponentFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Component, error)
 	GetComponentFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1beta1.PipelineRun) (*applicationapiv1alpha1.Component, error)
@@ -117,6 +118,27 @@ func (l *loader) GetAllApplicationComponents(c client.Client, ctx context.Contex
 	}
 
 	return &applicationComponents.Items, nil
+}
+
+// GetAllSnapshotComponents loads from the cluster all Components associated with the given Snapshot.
+// If the Snapshot doesn't have any Components or this is not found in the cluster, an error will be returned.
+func (l *loader) GetAllSnapshotComponents(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*[]applicationapiv1alpha1.Component, error) {
+	components := []applicationapiv1alpha1.Component{}
+
+	for _, sc := range snapshot.Spec.Components {
+		component := &applicationapiv1alpha1.Component{}
+		err := c.Get(ctx, types.NamespacedName{
+			Namespace: snapshot.Namespace,
+			Name:      sc.Name,
+		}, component)
+		if err != nil {
+			return nil, err
+		}
+
+		components = append(components, *component)
+	}
+
+	return &components, nil
 }
 
 // GetApplicationFromSnapshot loads from the cluster the Application referenced in the given Snapshot.

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -48,6 +48,7 @@ const (
 	IntegrationTestScenarioContextKey          contextKey = iota
 	TaskRunContextKey                          contextKey = iota
 	ApplicationComponentsContextKey            contextKey = iota
+	SnapshotComponentsContextKey               contextKey = iota
 	EnvironmentContextKey                      contextKey = iota
 	ReleaseContextKey                          contextKey = iota
 	PipelineRunsContextKey                     contextKey = iota
@@ -119,6 +120,15 @@ func (l *mockLoader) GetAllApplicationComponents(c client.Client, ctx context.Co
 		return l.loader.GetAllApplicationComponents(c, ctx, application)
 	}
 	components, err := getMockedResourceAndErrorFromContext(ctx, ApplicationComponentsContextKey, []applicationapiv1alpha1.Component{})
+	return &components, err
+}
+
+// GetAllSnapshotComponents returns the resource and error passed as values of the context.
+func (l *mockLoader) GetAllSnapshotComponents(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*[]applicationapiv1alpha1.Component, error) {
+	if ctx.Value(SnapshotComponentsContextKey) == nil {
+		return l.loader.GetAllSnapshotComponents(c, ctx, snapshot)
+	}
+	components, err := getMockedResourceAndErrorFromContext(ctx, SnapshotComponentsContextKey, []applicationapiv1alpha1.Component{})
 	return &components, err
 }
 

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -139,6 +139,21 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		})
 	})
 
+	Context("When calling GetAllSnapshotComponents", func() {
+		It("returns resource and error from the context", func() {
+			snapshotComponents := []applicationapiv1alpha1.Component{}
+			mockContext := GetMockedContext(ctx, []MockData{
+				{
+					ContextKey: SnapshotComponentsContextKey,
+					Resource:   snapshotComponents,
+				},
+			})
+			resource, err := loader.GetAllSnapshotComponents(nil, mockContext, nil)
+			Expect(resource).To(Equal(&snapshotComponents))
+			Expect(err).To(BeNil())
+		})
+	})
+
 	Context("When calling GetApplicationFromSnapshot", func() {
 		It("returns resource and error from the context", func() {
 			application := &applicationapiv1alpha1.Application{}


### PR DESCRIPTION
The integration service added a list of components to the SnapshotEnvironmentBinding upon creation.  Prior to this change the list was derived from the Application associated with the snapshot. This changes makes the integration service derive the components from the snapshot itself.