### PR TITLE
fix(STONEINTG-433): refactor EnsureEphemeralEnvironmentsCleanedUp

### DIFF
--- a/controllers/pipeline/pipeline_adapter_test.go
+++ b/controllers/pipeline/pipeline_adapter_test.go
@@ -1410,10 +1410,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			result, err := adapter.EnsureEphemeralEnvironmentsCleanedUp()
 			Expect(!result.CancelRequest && err == nil).To(BeTrue())
 
-			expectedLogEntry := "DeploymentTarget deleted"
-			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
-
-			expectedLogEntry = "DeploymentTargetClaim deleted"
+			expectedLogEntry := "DeploymentTargetClaim deleted"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 
 			expectedLogEntry = "Ephemeral environment and its owning snapshotEnvironmentBinding deleted"


### PR DESCRIPTION
Logic for the EnsureEphemeralEnvironmentsCleanedUp function within the pipeline_adapter has been moved to a helper function to allow for use by the SnapshotEnvrionmentBinding.
See [this PR](https://github.com/redhat-appstudio/integration-service/pull/228) or [STONEINTG-433](https://issues.redhat.com/browse/STONEINTG-433) for motivation.