### PR TITLE
feat(STONEINTG-483): add requeueDelay to ensure* functions

### DIFF
--- a/controllers/pipeline/pipeline_adapter.go
+++ b/controllers/pipeline/pipeline_adapter.go
@@ -126,6 +126,7 @@ func (a *Adapter) EnsureSnapshotExists() (reconciler.OperationResult, error) {
 	if err != nil {
 		a.logger.Error(err, "Failed to update the build pipelineRun with new annotations",
 			"pipelineRun.Name", a.pipelineRun.Name)
+		return reconciler.RequeueWithError(err)
 	}
 
 	return reconciler.ContinueProcessing()

--- a/controllers/scenario/scenario_adapter.go
+++ b/controllers/scenario/scenario_adapter.go
@@ -121,7 +121,7 @@ func (a *Adapter) EnsureCreatedScenarioIsValid() (reconciler.OperationResult, er
 		err := a.client.Status().Patch(a.context, a.scenario, patch)
 		if err != nil {
 			a.logger.Error(err, "Failed to update Scenario")
-			return reconciler.ContinueProcessing()
+			return reconciler.RequeueWithError(err)
 		}
 		a.logger.LogAuditEvent("IntegrationTestScenario marked as Valid", a.scenario, h.LogActionUpdate)
 	}

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -94,7 +94,7 @@ func (a *Adapter) EnsureAllIntegrationTestPipelinesExist() (reconciler.Operation
 			if err != nil {
 				a.logger.Error(err, "Failed to get pipelineRuns for snapshot and scenario",
 					"integrationTestScenario.Name", integrationTestScenario.Name)
-				return reconciler.RequeueOnErrorOrStop(err)
+				return reconciler.RequeueWithError(err)
 			}
 			if integrationPipelineRuns != nil && len(*integrationPipelineRuns) > 0 {
 				a.logger.Info("Found existing integrationPipelineRuns",
@@ -106,7 +106,7 @@ func (a *Adapter) EnsureAllIntegrationTestPipelinesExist() (reconciler.Operation
 				pipelineRun, err := a.createIntegrationPipelineRun(a.application, &integrationTestScenario, a.snapshot)
 				if err != nil {
 					a.logger.Error(err, "Failed to create pipelineRun for snapshot and scenario")
-					return reconciler.RequeueOnErrorOrStop(err)
+					return reconciler.RequeueWithError(err)
 				}
 				a.logger.LogAuditEvent("IntegrationTestscenario pipeline has been created", pipelineRun, h.LogActionAdd,
 					"integrationTestScenario.Name", integrationTestScenario.Name)
@@ -161,7 +161,7 @@ func (a *Adapter) EnsureCreationOfEnvironment() (reconciler.OperationResult, err
 
 	if err != nil {
 		a.logger.Error(err, "Failed to get Integration test scenarios for the following application")
-		return reconciler.RequeueOnErrorOrStop(err)
+		return reconciler.RequeueWithError(err)
 	}
 	if integrationTestScenarios == nil {
 		a.logger.Info("No integration test scenario found for Application")


### PR DESCRIPTION
Read the code about `RequeueRequest`, `CancelRequest` and `error` in [ReconcileHandler(operations []ReconcileOperation)](https://github.com/redhat-appstudio/operator-goodies/blob/main/reconciler/handler.go#L23-L35), according to the definitions of [RequeueWithError(error)](https://github.com/redhat-appstudio/operator-goodies/blob/main/reconciler/results.go#L45) and [RequeueOnErrorOrStop(error)](https://github.com/redhat-appstudio/operator-goodies/blob/main/reconciler/results.go#L75), these two functions are the same when the `error` is not `nil`, that is to `requeue`.

1. Replace `RequeueOnErrorOrStop(error)` with `RequeueWithError(error)` when error is not `nil` to be consistent in all  adapters
2. Call `RequeueWithError(err)` when failing to update scenario to requeue

Signed-off-by: Hongwei Liu <hongliu@redhat.com>