### PR TITLE
fix(STONEINTG-469): add SetSnapshotIntegrationStatusAsInvalidandNoRequ

### DIFF
--- a/controllers/pipeline/pipeline_adapter.go
+++ b/controllers/pipeline/pipeline_adapter.go
@@ -28,6 +28,7 @@ import (
 	"github.com/redhat-appstudio/integration-service/gitops"
 	h "github.com/redhat-appstudio/integration-service/helpers"
 	"github.com/redhat-appstudio/integration-service/loader"
+	"github.com/redhat-appstudio/integration-service/metrics"
 	"github.com/redhat-appstudio/integration-service/status"
 	"github.com/redhat-appstudio/integration-service/tekton"
 	"github.com/redhat-appstudio/operator-goodies/reconciler"
@@ -117,6 +118,7 @@ func (a *Adapter) EnsureSnapshotExists() (reconciler.OperationResult, error) {
 		a.logger.Error(err, "Failed to create Snapshot")
 		return reconciler.RequeueWithError(err)
 	}
+	go metrics.RegisterNewSnapshot()
 
 	a.logger.LogAuditEvent("Created new Snapshot", expectedSnapshot, h.LogActionAdd,
 		"snapshot.Name", expectedSnapshot.Name,
@@ -590,6 +592,7 @@ func (a *Adapter) createCompositeSnapshotsIfConflictExists(application *applicat
 			if err != nil {
 				return nil, err
 			}
+			go metrics.RegisterNewSnapshot()
 			a.logger.LogAuditEvent("CompositeSnapshot created", compositeSnapshot, h.LogActionAdd,
 				"snapshot.Spec.Components", compositeSnapshot.Spec.Components)
 			return compositeSnapshot, nil

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -129,7 +129,7 @@ func (a *Adapter) EnsureAllIntegrationTestPipelinesExist() (reconciler.Operation
 	if err != nil {
 		a.logger.Error(err, "Failed to get all required IntegrationTestScenarios")
 		patch := client.MergeFrom(a.snapshot.DeepCopy())
-		gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to get all required IntegrationTestScenarios: "+err.Error())
+		gitops.SetSnapshotIntegrationStatusAsError(a.snapshot, "Failed to get all required IntegrationTestScenarios: "+err.Error())
 		a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to get all required IntegrationTestScenarios",
 			a.snapshot, h.LogActionUpdate)
 		return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))
@@ -310,7 +310,7 @@ func (a *Adapter) EnsureAllReleasesExist() (reconciler.OperationResult, error) {
 	if err != nil {
 		a.logger.Error(err, "Failed to get all ReleasePlans")
 		patch := client.MergeFrom(a.snapshot.DeepCopy())
-		gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to get all ReleasePlans: "+err.Error())
+		gitops.SetSnapshotIntegrationStatusAsError(a.snapshot, "Failed to get all ReleasePlans: "+err.Error())
 		a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to get all ReleasePlans",
 			a.snapshot, h.LogActionUpdate)
 		return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))
@@ -320,7 +320,7 @@ func (a *Adapter) EnsureAllReleasesExist() (reconciler.OperationResult, error) {
 	if err != nil {
 		a.logger.Error(err, "Failed to create new Releases")
 		patch := client.MergeFrom(a.snapshot.DeepCopy())
-		gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to create new Releases: "+err.Error())
+		gitops.SetSnapshotIntegrationStatusAsError(a.snapshot, "Failed to create new Releases: "+err.Error())
 		a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to create new Releases",
 			a.snapshot, h.LogActionUpdate)
 		return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))
@@ -362,7 +362,7 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (reconciler.OperationR
 					"snapshotEnvironmentBinding.Environment", snapshotEnvironmentBinding.Spec.Environment,
 					"snapshotEnvironmentBinding.Snapshot", snapshotEnvironmentBinding.Spec.Snapshot)
 				patch := client.MergeFrom(a.snapshot.DeepCopy())
-				gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to update SnapshotEnvironmentBinding: "+err.Error())
+				gitops.SetSnapshotIntegrationStatusAsError(a.snapshot, "Failed to update SnapshotEnvironmentBinding: "+err.Error())
 				a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to update SnapshotEnvironmentBinding",
 					a.snapshot, h.LogActionUpdate)
 				return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))
@@ -379,7 +379,7 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (reconciler.OperationR
 					"environment", availableEnvironment.Name,
 					"snapshot", a.snapshot.Name)
 				patch := client.MergeFrom(a.snapshot.DeepCopy())
-				gitops.SetSnapshotIntegrationStatusAsInvalid(a.snapshot, "Failed to create SnapshotEnvironmentBinding: "+err.Error())
+				gitops.SetSnapshotIntegrationStatusAsError(a.snapshot, "Failed to create SnapshotEnvironmentBinding: "+err.Error())
 				a.logger.LogAuditEvent("Snapshot integration status marked as Invalid. Failed to create SnapshotEnvironmentBinding",
 					a.snapshot, h.LogActionUpdate)
 				return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -126,11 +126,12 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.AppStudioTestSuceededCondition)).To(BeFalse())
 	})
 
-	It("ensures the Snapshots status can be marked as invalid", func() {
-		gitops.SetSnapshotIntegrationStatusAsInvalid(hasSnapshot, "Test message")
+	It("ensures the Snapshots status can be marked as error", func() {
+		gitops.SetSnapshotIntegrationStatusAsError(hasSnapshot, "Test message")
 		Expect(hasSnapshot).NotTo(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.AppStudioIntegrationStatusCondition)).To(BeFalse())
+		Expect(gitops.IsSnapshotError(hasSnapshot)).To(BeTrue())
 	})
 
 	It("ensures the Snapshots status can be marked as finished", func() {


### PR DESCRIPTION
1. Added new Snapshot status "ErrorOccured" and replaced "Invalid" status in the snapshot controller logic with it.
2. Moved the RegisterNewSnapshot() function from NewSnapshot() to the place following a.client.Create(a.context, *Snapshot) action