### PR TITLE
fix(RHTAPWATCH-8): Update GrafanaDashboard to match GrafanaOperator v5

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -18,7 +18,7 @@ spec:
     - name: infra-deployment-update-script
       value: |
         sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/integration/kustomization.yaml
-        sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/integration/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest

--- a/config/grafana/dashboard.yaml
+++ b/config/grafana/dashboard.yaml
@@ -1,10 +1,13 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-integration-service
   labels:
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-integration-service
     key: integration-service-dashboard.json


### PR DESCRIPTION
as part of this bug fix and the upgrade to `GrafanaOperator` v5, we have to update the `GrafanaDashboard` resource to match the new api

More details:
https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1690371680784569

The dashboard is still presenting data due to a patch we merged to RHTAP, and it will be removed after these changes will be merged