### PR TITLE
feat(STONEINTG-493): split pipeline controller to 2 new controller

### DIFF
--- a/controllers/buildpipeline/buildpipeline_adapter.go
+++ b/controllers/buildpipeline/buildpipeline_adapter.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildpipeline
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/gitops"
+	h "github.com/redhat-appstudio/integration-service/helpers"
+	"github.com/redhat-appstudio/integration-service/loader"
+	"github.com/redhat-appstudio/integration-service/metrics"
+	"github.com/redhat-appstudio/integration-service/tekton"
+	"github.com/redhat-appstudio/operator-toolkit/controller"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Adapter holds the objects needed to reconcile a build PipelineRun.
+type Adapter struct {
+	pipelineRun *tektonv1beta1.PipelineRun
+	component   *applicationapiv1alpha1.Component
+	application *applicationapiv1alpha1.Application
+	loader      loader.ObjectLoader
+	logger      h.IntegrationLogger
+	client      client.Client
+	context     context.Context
+}
+
+// NewAdapter creates and returns an Adapter instance.
+func NewAdapter(pipelineRun *tektonv1beta1.PipelineRun, component *applicationapiv1alpha1.Component, application *applicationapiv1alpha1.Application, logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
+	context context.Context) *Adapter {
+	return &Adapter{
+		pipelineRun: pipelineRun,
+		component:   component,
+		application: application,
+		logger:      logger,
+		loader:      loader,
+		client:      client,
+		context:     context,
+	}
+}
+
+// EnsureSnapshotExists is an operation that will ensure that a pipeline Snapshot associated
+// to the build PipelineRun being processed exists. Otherwise, it will create a new pipeline Snapshot.
+func (a *Adapter) EnsureSnapshotExists() (controller.OperationResult, error) {
+	if !h.HasPipelineRunSucceeded(a.pipelineRun) {
+		return controller.ContinueProcessing()
+	}
+
+	if a.component == nil {
+		a.logger.Info("The build pipelineRun does not have any component associated with it, will not create a new Snapshot.")
+		return controller.ContinueProcessing()
+	}
+
+	isLatest, err := a.isLatestSucceededBuildPipelineRun()
+	if err != nil {
+		return controller.RequeueWithError(err)
+	}
+	if !isLatest {
+		// not the last started pipeline that succeeded for current snapshot
+		// this prevents deploying older pipeline run over new deployment
+		a.logger.Info("The pipelineRun is not the latest successful build pipelineRun for the component, skipping creation of a new Snapshot ",
+			"component.Name", a.component.Name)
+		return controller.ContinueProcessing()
+	}
+
+	expectedSnapshot, err := a.prepareSnapshotForPipelineRun(a.pipelineRun, a.component, a.application)
+	if err != nil {
+		return controller.RequeueWithError(err)
+	}
+
+	allSnapshots, err := a.loader.GetAllSnapshots(a.client, a.context, a.application)
+	if err != nil {
+		return controller.RequeueWithError(err)
+	}
+	existingSnapshot := gitops.FindMatchingSnapshot(a.application, allSnapshots, expectedSnapshot)
+
+	if existingSnapshot != nil {
+		a.logger.Info("Found existing Snapshot",
+			"snapshot.Name", existingSnapshot.Name,
+			"snapshot.Spec.Components", existingSnapshot.Spec.Components)
+		// Annotate the build pipelineRun with the existing Snapshot if it hasn't been already annotated
+		if _, found := a.pipelineRun.ObjectMeta.Annotations[tekton.SnapshotNameLabel]; !found {
+			a.pipelineRun, err = a.annotateBuildPipelineRunWithSnapshot(a.pipelineRun, existingSnapshot)
+			if err != nil {
+				a.logger.Error(err, "Failed to update the build pipelineRun with new annotations",
+					"pipelineRun.Name", a.pipelineRun.Name)
+				return controller.RequeueWithError(err)
+			}
+		}
+		return controller.ContinueProcessing()
+	}
+
+	err = a.client.Create(a.context, expectedSnapshot)
+	if err != nil {
+		a.logger.Error(err, "Failed to create Snapshot")
+		return controller.RequeueWithError(err)
+	}
+	go metrics.RegisterNewSnapshot()
+
+	a.logger.LogAuditEvent("Created new Snapshot", expectedSnapshot, h.LogActionAdd,
+		"snapshot.Name", expectedSnapshot.Name,
+		"snapshot.Spec.Components", expectedSnapshot.Spec.Components)
+
+	a.pipelineRun, err = a.annotateBuildPipelineRunWithSnapshot(a.pipelineRun, expectedSnapshot)
+	if err != nil {
+		a.logger.Error(err, "Failed to update the build pipelineRun with new annotations",
+			"pipelineRun.Name", a.pipelineRun.Name)
+		return controller.RequeueWithError(err)
+	}
+
+	return controller.ContinueProcessing()
+}
+
+// getImagePullSpecFromPipelineRun gets the full image pullspec from the given build PipelineRun,
+// In case the Image pullspec can't be composed, an error will be returned.
+func (a *Adapter) getImagePullSpecFromPipelineRun(pipelineRun *tektonv1beta1.PipelineRun) (string, error) {
+	outputImage, err := tekton.GetOutputImage(pipelineRun)
+	if err != nil {
+		return "", err
+	}
+	imageDigest, err := tekton.GetOutputImageDigest(pipelineRun)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s@%s", strings.Split(outputImage, ":")[0], imageDigest), nil
+}
+
+// getComponentSourceFromPipelineRun gets the component Git Source for the Component built in the given build PipelineRun,
+// In case the Git Source can't be composed, an error will be returned.
+func (a *Adapter) getComponentSourceFromPipelineRun(pipelineRun *tektonv1beta1.PipelineRun) (*applicationapiv1alpha1.ComponentSource, error) {
+	componentSourceGitUrl, err := tekton.GetComponentSourceGitUrl(pipelineRun)
+	if err != nil {
+		return nil, err
+	}
+	componentSourceGitCommit, err := tekton.GetComponentSourceGitCommit(pipelineRun)
+	if err != nil {
+		return nil, err
+	}
+	componentSource := applicationapiv1alpha1.ComponentSource{
+		ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+			GitSource: &applicationapiv1alpha1.GitSource{
+				URL:      componentSourceGitUrl,
+				Revision: componentSourceGitCommit,
+			},
+		},
+	}
+
+	return &componentSource, nil
+}
+
+// prepareSnapshotForPipelineRun prepares the Snapshot for a given PipelineRun,
+// component and application. In case the Snapshot can't be created, an error will be returned.
+func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1beta1.PipelineRun, component *applicationapiv1alpha1.Component, application *applicationapiv1alpha1.Application) (*applicationapiv1alpha1.Snapshot, error) {
+	newContainerImage, err := a.getImagePullSpecFromPipelineRun(pipelineRun)
+	if err != nil {
+		return nil, err
+	}
+	componentSource, err := a.getComponentSourceFromPipelineRun(pipelineRun)
+	if err != nil {
+		return nil, err
+	}
+
+	applicationComponents, err := a.loader.GetAllApplicationComponents(a.client, a.context, application)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot, err := gitops.PrepareSnapshot(a.client, a.context, application, applicationComponents, component, newContainerImage, componentSource)
+	if err != nil {
+		return nil, err
+	}
+
+	if snapshot.Labels == nil {
+		snapshot.Labels = make(map[string]string)
+	}
+	snapshot.Labels[gitops.SnapshotTypeLabel] = gitops.SnapshotComponentType
+	snapshot.Labels[gitops.SnapshotComponentLabel] = a.component.Name
+	snapshot.Labels[gitops.BuildPipelineRunNameLabel] = pipelineRun.Name
+	if pipelineRun.Status.CompletionTime != nil {
+		snapshot.Labels[gitops.BuildPipelineRunFinishTimeLabel] = strconv.FormatInt(pipelineRun.Status.CompletionTime.Time.Unix(), 10)
+	} else {
+		snapshot.Labels[gitops.BuildPipelineRunFinishTimeLabel] = strconv.FormatInt(time.Now().Unix(), 10)
+	}
+
+	// Copy PipelineRun PAC annotations/labels from Build to snapshot.
+	// Modify the prefix so the PaC controller won't react to PipelineRuns generated from the snapshot.
+	h.CopyLabelsByPrefix(&pipelineRun.ObjectMeta, &snapshot.ObjectMeta, "pipelinesascode.tekton.dev", gitops.PipelinesAsCodePrefix)
+	h.CopyAnnotationsByPrefix(&pipelineRun.ObjectMeta, &snapshot.ObjectMeta, "pipelinesascode.tekton.dev", gitops.PipelinesAsCodePrefix)
+
+	// Copy build labels and annotations prefixed with build.appstudio from Build to Snapshot.
+	h.CopyLabelsByPrefix(&pipelineRun.ObjectMeta, &snapshot.ObjectMeta, gitops.BuildPipelineRunPrefix, gitops.BuildPipelineRunPrefix)
+	h.CopyAnnotationsByPrefix(&pipelineRun.ObjectMeta, &snapshot.ObjectMeta, gitops.BuildPipelineRunPrefix, gitops.BuildPipelineRunPrefix)
+
+	return snapshot, nil
+}
+
+// isLatestSucceededBuildPipelineRun return true if pipelineRun is the latest succeded pipelineRun
+// for the component. Pipeline start timestamp is used for comparison because we care about
+// time when pipeline was created.
+func (a *Adapter) isLatestSucceededBuildPipelineRun() (bool, error) {
+
+	pipelineStartTime := a.pipelineRun.CreationTimestamp.Time
+
+	pipelineRuns, err := a.getSucceededBuildPipelineRunsForComponent(a.component)
+	if err != nil {
+		return false, err
+	}
+	for _, run := range *pipelineRuns {
+		if a.pipelineRun.Name == run.Name {
+			// it's the same pipeline
+			continue
+		}
+		timestamp := run.CreationTimestamp.Time
+		if pipelineStartTime.Before(timestamp) {
+			// pipeline is not the latest
+			// 1 second is minimal granularity, if both pipelines started at the same second, we cannot decide
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// getSucceededBuildPipelineRunsForComponent returns all  succeeded PipelineRun for the
+// associated component. In the case the List operation fails,
+// an error will be returned.
+func (a *Adapter) getSucceededBuildPipelineRunsForComponent(component *applicationapiv1alpha1.Component) (*[]tektonv1beta1.PipelineRun, error) {
+	var succeededPipelineRuns []tektonv1beta1.PipelineRun
+
+	buildPipelineRuns, err := a.loader.GetAllBuildPipelineRunsForComponent(a.client, a.context, component)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pipelineRun := range *buildPipelineRuns {
+		pipelineRun := pipelineRun // G601
+		if h.HasPipelineRunSucceeded(&pipelineRun) {
+			succeededPipelineRuns = append(succeededPipelineRuns, pipelineRun)
+		}
+	}
+	return &succeededPipelineRuns, nil
+}
+
+func (a *Adapter) annotateBuildPipelineRunWithSnapshot(pipelineRun *tektonv1beta1.PipelineRun, snapshot *applicationapiv1alpha1.Snapshot) (*tektonv1beta1.PipelineRun, error) {
+	patch := client.MergeFrom(pipelineRun.DeepCopy())
+	h.AddAnnotation(&pipelineRun.ObjectMeta, tekton.SnapshotNameLabel, snapshot.Name)
+	err := a.client.Patch(a.context, pipelineRun, patch)
+	if err != nil {
+		return pipelineRun, err
+	}
+	a.logger.LogAuditEvent("Updated build pipelineRun", pipelineRun, h.LogActionUpdate,
+		"snapshot.Name", snapshot.Name)
+	return pipelineRun, nil
+}

--- a/controllers/buildpipeline/buildpipeline_adapter_test.go
+++ b/controllers/buildpipeline/buildpipeline_adapter_test.go
@@ -1,0 +1,724 @@
+/*
+Copyright 2023.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildpipeline
+
+import (
+	"bytes"
+	"reflect"
+	"time"
+
+	"github.com/redhat-appstudio/integration-service/gitops"
+	"github.com/redhat-appstudio/integration-service/helpers"
+	"github.com/redhat-appstudio/integration-service/loader"
+	"github.com/redhat-appstudio/integration-service/tekton"
+	"knative.dev/pkg/apis"
+	v1 "knative.dev/pkg/apis/duck/v1"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tonglil/buflogr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Pipeline Adapter", Ordered, func() {
+	var (
+		adapter       *Adapter
+		createAdapter func() *Adapter
+		logger        helpers.IntegrationLogger
+
+		successfulTaskRun *tektonv1beta1.TaskRun
+		failedTaskRun     *tektonv1beta1.TaskRun
+		buildPipelineRun  *tektonv1beta1.PipelineRun
+		buildPipelineRun2 *tektonv1beta1.PipelineRun
+		hasComp           *applicationapiv1alpha1.Component
+		hasComp2          *applicationapiv1alpha1.Component
+		hasApp            *applicationapiv1alpha1.Application
+		hasSnapshot       *applicationapiv1alpha1.Snapshot
+	)
+	const (
+		SampleRepoLink           = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		SampleCommit             = "a2ba645d50e471d5f084b"
+		SampleDigest             = "sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+		SampleImageWithoutDigest = "quay.io/redhat-appstudio/sample-image"
+		SampleImage              = SampleImageWithoutDigest + "@" + SampleDigest
+	)
+
+	BeforeAll(func() {
+		hasApp = &applicationapiv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "application-sample",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ApplicationSpec{
+				DisplayName: "application-sample",
+				Description: "This is an example application",
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
+
+		logger = helpers.IntegrationLogger{Logger: ctrl.Log}.WithApp(*hasApp)
+
+		hasComp = &applicationapiv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "component-sample",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				ComponentName:  "component-sample",
+				Application:    "application-sample",
+				ContainerImage: "invalidImage",
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL:      SampleRepoLink,
+							Revision: SampleCommit,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
+
+		hasComp2 = &applicationapiv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "another-component-sample",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				ComponentName:  "another-component-sample",
+				Application:    "application-sample",
+				ContainerImage: "",
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL:      SampleRepoLink,
+							Revision: SampleCommit,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasComp2)).Should(Succeed())
+
+		hasSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:      "component",
+					gitops.SnapshotComponentLabel: hasComp.Name,
+				},
+				Annotations: map[string]string{
+					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           hasComp.Name,
+						ContainerImage: SampleImage,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasSnapshot)).Should(Succeed())
+
+		successfulTaskRun = &tektonv1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-pass",
+				Namespace: "default",
+			},
+			Spec: tektonv1beta1.TaskRunSpec{
+				TaskRef: &tektonv1beta1.TaskRef{
+					Name:   "test-taskrun-pass",
+					Bundle: "quay.io/redhat-appstudio/example-tekton-bundle:test",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, successfulTaskRun)).Should(Succeed())
+
+		now := time.Now()
+		successfulTaskRun.Status = tektonv1beta1.TaskRunStatus{
+			TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
+				StartTime:      &metav1.Time{Time: now},
+				CompletionTime: &metav1.Time{Time: now.Add(5 * time.Minute)},
+				TaskRunResults: []tektonv1beta1.TaskRunResult{
+					{
+						Name: "TEST_OUTPUT",
+						Value: *tektonv1beta1.NewStructuredValues(`{
+											"result": "SUCCESS",
+											"timestamp": "1665405318",
+											"failures": 0,
+											"successes": 10,
+											"warnings": 0
+										}`),
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, successfulTaskRun)).Should(Succeed())
+
+		failedTaskRun = &tektonv1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-fail",
+				Namespace: "default",
+			},
+			Spec: tektonv1beta1.TaskRunSpec{
+				TaskRef: &tektonv1beta1.TaskRef{
+					Name:   "test-taskrun-fail",
+					Bundle: "quay.io/redhat-appstudio/example-tekton-bundle:test",
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, failedTaskRun)).Should(Succeed())
+
+		failedTaskRun.Status = tektonv1beta1.TaskRunStatus{
+			TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
+				StartTime:      &metav1.Time{Time: now},
+				CompletionTime: &metav1.Time{Time: now.Add(5 * time.Minute)},
+				TaskRunResults: []tektonv1beta1.TaskRunResult{
+					{
+						Name: "TEST_OUTPUT",
+						Value: *tektonv1beta1.NewStructuredValues(`{
+											"result": "FAILURE",
+											"timestamp": "1665405317",
+											"failures": 1,
+											"successes": 0,
+											"warnings": 0
+										}`),
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, failedTaskRun)).Should(Succeed())
+	})
+
+	BeforeEach(func() {
+		buildPipelineRun = &tektonv1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipelinerun-build-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					"pipelines.appstudio.openshift.io/type":    "build",
+					"pipelines.openshift.io/used-by":           "build-cloud",
+					"pipelines.openshift.io/runtime":           "nodejs",
+					"pipelines.openshift.io/strategy":          "s2i",
+					"appstudio.openshift.io/component":         "component-sample",
+					"pipelinesascode.tekton.dev/event-type":    "pull_request",
+					"build.appstudio.redhat.com/target_branch": "main",
+				},
+				Annotations: map[string]string{
+					"appstudio.redhat.com/updateComponentOnSuccess": "false",
+					"pipelinesascode.tekton.dev/on-target-branch":   "[main,master]",
+					"build.appstudio.openshift.io/repo":             "https://github.com/devfile-samples/devfile-sample-go-basic?rev=c713067b0e65fb3de50d1f7c457eb51c2ab0dbb0",
+					"foo":                                           "bar",
+				},
+			},
+			Spec: tektonv1beta1.PipelineRunSpec{
+				PipelineRef: &tektonv1beta1.PipelineRef{
+					Name:   "build-pipeline-pass",
+					Bundle: "quay.io/kpavic/test-bundle:build-pipeline-pass",
+				},
+				Params: []tektonv1beta1.Param{
+					{
+						Name: "output-image",
+						Value: tektonv1beta1.ParamValue{
+							Type:      tektonv1beta1.ParamTypeString,
+							StringVal: SampleImageWithoutDigest,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, buildPipelineRun)).Should(Succeed())
+
+		buildPipelineRun.Status = tektonv1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
+				PipelineResults: []tektonv1beta1.PipelineRunResult{
+					{
+						Name:  "IMAGE_DIGEST",
+						Value: *tektonv1beta1.NewStructuredValues(SampleDigest),
+					},
+					{
+						Name:  "IMAGE_URL",
+						Value: *tektonv1beta1.NewStructuredValues(SampleImageWithoutDigest),
+					},
+					{
+						Name:  "CHAINS-GIT_URL",
+						Value: *tektonv1beta1.NewStructuredValues(SampleRepoLink),
+					},
+					{
+						Name:  "CHAINS-GIT_COMMIT",
+						Value: *tektonv1beta1.NewStructuredValues(SampleCommit),
+					},
+				},
+			},
+			Status: v1.Status{
+				Conditions: v1.Conditions{
+					apis.Condition{
+						Reason: "Completed",
+						Status: "True",
+						Type:   apis.ConditionSucceeded,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, buildPipelineRun)).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		err := k8sClient.Delete(ctx, buildPipelineRun)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	AfterAll(func() {
+		err := k8sClient.Delete(ctx, hasApp)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasComp)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasSnapshot)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, successfulTaskRun)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, failedTaskRun)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	When("NewAdapter is called", func() {
+		It("creates and return a new adapter", func() {
+			Expect(reflect.TypeOf(NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
+		})
+	})
+
+	When("NewAdapter is created", func() {
+		BeforeEach(func() {
+			adapter = createAdapter()
+			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.ComponentContextKey,
+					Resource:   hasComp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasSnapshot,
+				},
+				{
+					ContextKey: loader.ApplicationComponentsContextKey,
+					Resource:   []applicationapiv1alpha1.Component{*hasComp, *hasComp2},
+				},
+			})
+		})
+
+		It("ensures the Imagepullspec and ComponentSource from pipelinerun and prepare snapshot can be created", func() {
+			imagePullSpec, err := adapter.getImagePullSpecFromPipelineRun(buildPipelineRun)
+			Expect(err).To(BeNil())
+			Expect(imagePullSpec).NotTo(BeEmpty())
+
+			componentSource, err := adapter.getComponentSourceFromPipelineRun(buildPipelineRun)
+			Expect(err).To(BeNil())
+
+			applicationComponents, err := adapter.loader.GetAllApplicationComponents(adapter.client, adapter.context, adapter.application)
+			Expect(err).To(BeNil())
+			Expect(applicationComponents).NotTo(BeNil())
+
+			snapshot, err := gitops.PrepareSnapshot(adapter.client, adapter.context, hasApp, applicationComponents, hasComp, imagePullSpec, componentSource)
+			Expect(snapshot).NotTo(BeNil())
+			Expect(err).To(BeNil())
+			Expect(snapshot).NotTo(BeNil())
+			Expect(snapshot.Spec.Components).To(HaveLen(1), "One component should have been added to snapshot.  Other component should have been omited due to empty ContainerImage field or missing valid digest")
+			Expect(snapshot.Spec.Components[0].Name).To(Equal(hasComp.Name), "The built component should have been added to the snapshot")
+		})
+
+		It("ensures that snapshot has label pointing to build pipelinerun", func() {
+			expectedSnapshot, err := adapter.prepareSnapshotForPipelineRun(buildPipelineRun, hasComp, hasApp)
+			Expect(err).To(BeNil())
+			Expect(expectedSnapshot).NotTo(BeNil())
+
+			Expect(expectedSnapshot.Labels).NotTo(BeNil())
+			Expect(expectedSnapshot.Labels).Should(HaveKeyWithValue(Equal(gitops.BuildPipelineRunNameLabel), Equal(buildPipelineRun.Name)))
+		})
+
+		It("ensure err is returned when pipelinerun doesn't have Result for ", func() {
+			buildPipelineRun.Status = tektonv1beta1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
+					ChildReferences: []tektonv1beta1.ChildStatusReference{
+						{
+							Name:             successfulTaskRun.Name,
+							PipelineTaskName: "task1",
+						},
+					},
+					PipelineResults: []tektonv1beta1.PipelineRunResult{
+						{
+							Name:  "CHAINS-GIT_URL",
+							Value: *tektonv1beta1.NewStructuredValues(SampleRepoLink),
+						},
+					},
+				},
+				Status: v1.Status{
+					Conditions: v1.Conditions{
+						apis.Condition{
+							Reason: "Completed",
+							Status: "True",
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, buildPipelineRun)).Should(Succeed())
+
+			componentSource, err := adapter.getComponentSourceFromPipelineRun(buildPipelineRun)
+			Expect(componentSource).To(BeNil())
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("ensures pipelines as code labels and annotations are propagated to the snapshot", func() {
+			snapshot, err := adapter.prepareSnapshotForPipelineRun(buildPipelineRun, hasComp, hasApp)
+			Expect(err).To(BeNil())
+			Expect(snapshot).ToNot(BeNil())
+			annotation, found := snapshot.GetAnnotations()["pac.test.appstudio.openshift.io/on-target-branch"]
+			Expect(found).To(BeTrue())
+			Expect(annotation).To(Equal("[main,master]"))
+			label, found := snapshot.GetLabels()["pac.test.appstudio.openshift.io/event-type"]
+			Expect(found).To(BeTrue())
+			Expect(label).To(Equal("pull_request"))
+		})
+
+		It("ensures non-pipelines as code labels and annotations are NOT propagated to the snapshot", func() {
+			snapshot, err := adapter.prepareSnapshotForPipelineRun(buildPipelineRun, hasComp, hasApp)
+			Expect(err).To(BeNil())
+			Expect(snapshot).ToNot(BeNil())
+
+			// non-PaC labels are not copied
+			_, found := buildPipelineRun.GetLabels()["pipelines.appstudio.openshift.io/type"]
+			Expect(found).To(BeTrue())
+			_, found = snapshot.GetLabels()["pipelines.appstudio.openshift.io/type"]
+			Expect(found).To(BeFalse())
+
+			// non-PaC annotations are not copied
+			_, found = buildPipelineRun.GetAnnotations()["foo"]
+			Expect(found).To(BeTrue())
+			_, found = snapshot.GetAnnotations()["foo"]
+			Expect(found).To(BeFalse())
+		})
+
+		It("ensures build labels and annotations prefixed with 'build.appstudio' are propagated to the snapshot", func() {
+			snapshot, err := adapter.prepareSnapshotForPipelineRun(buildPipelineRun, hasComp, hasApp)
+			Expect(err).To(BeNil())
+			Expect(snapshot).ToNot(BeNil())
+
+			annotation, found := snapshot.GetAnnotations()["build.appstudio.openshift.io/repo"]
+			Expect(found).To(BeTrue())
+			Expect(annotation).To(Equal("https://github.com/devfile-samples/devfile-sample-go-basic?rev=c713067b0e65fb3de50d1f7c457eb51c2ab0dbb0"))
+
+			label, found := snapshot.GetLabels()["build.appstudio.redhat.com/target_branch"]
+			Expect(found).To(BeTrue())
+			Expect(label).To(Equal("main"))
+		})
+
+		It("ensures build labels and annotations non-prefixed with 'build.appstudio' are NOT propagated to the snapshot", func() {
+			snapshot, err := adapter.prepareSnapshotForPipelineRun(buildPipelineRun, hasComp, hasApp)
+			Expect(err).To(BeNil())
+			Expect(snapshot).ToNot(BeNil())
+
+			// build annotations non-prefixed with 'build.appstudio' are not copied
+			_, found := buildPipelineRun.GetAnnotations()["appstudio.redhat.com/updateComponentOnSuccess"]
+			Expect(found).To(BeTrue())
+			_, found = snapshot.GetAnnotations()["appstudio.redhat.com/updateComponentOnSuccess"]
+			Expect(found).To(BeFalse())
+
+			// build labels non-prefixed with 'build.appstudio' are not copied
+			_, found = buildPipelineRun.GetLabels()["pipelines.appstudio.openshift.io/type"]
+			Expect(found).To(BeTrue())
+			_, found = snapshot.GetLabels()["pipelines.appstudio.openshift.io/type"]
+			Expect(found).To(BeFalse())
+
+		})
+	})
+
+	When("Adapter is created but no components defined", func() {
+		It("ensures snapshot creation is skipped when there is no component defined ", func() {
+			adapter = NewAdapter(buildPipelineRun, nil, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			Expect(reflect.TypeOf(adapter)).To(Equal(reflect.TypeOf(&Adapter{})))
+
+			result, err := adapter.EnsureSnapshotExists()
+			Expect(!result.CancelRequest).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("Snapshot already exists", func() {
+		BeforeEach(func() {
+			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.ComponentContextKey,
+					Resource:   hasComp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasSnapshot,
+				},
+				{
+					ContextKey: loader.AllSnapshotsContextKey,
+					Resource:   []applicationapiv1alpha1.Snapshot{*hasSnapshot},
+				},
+				{
+					ContextKey: loader.TaskRunContextKey,
+					Resource:   successfulTaskRun,
+				},
+				{
+					ContextKey: loader.ApplicationComponentsContextKey,
+					Resource:   []applicationapiv1alpha1.Component{*hasComp},
+				},
+			})
+			existingSnapshot, err := adapter.loader.GetSnapshotFromPipelineRun(adapter.client, adapter.context, buildPipelineRun)
+			Expect(err).To(BeNil())
+			Expect(existingSnapshot).ToNot(BeNil())
+		})
+
+		It("ensures snapshot creation is skipped when snapshot already exists", func() {
+			Eventually(func() bool {
+				result, err := adapter.EnsureSnapshotExists()
+				return !result.CancelRequest && err == nil
+			}, time.Second*10).Should(BeTrue())
+		})
+	})
+
+	When("multiple succesfull build pipeline runs exists for the same component", func() {
+		BeforeAll(func() {
+			buildPipelineRun2 = &tektonv1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pipelinerun-build-sample-2",
+					Namespace: "default",
+					Labels: map[string]string{
+						"pipelines.appstudio.openshift.io/type": "build",
+						"pipelines.openshift.io/used-by":        "build-cloud",
+						"pipelines.openshift.io/runtime":        "nodejs",
+						"pipelines.openshift.io/strategy":       "s2i",
+						"appstudio.openshift.io/component":      "component-sample",
+						"pipelinesascode.tekton.dev/event-type": "pull_request",
+					},
+					Annotations: map[string]string{
+						"appstudio.redhat.com/updateComponentOnSuccess": "false",
+						"pipelinesascode.tekton.dev/on-target-branch":   "[main,master]",
+						"foo": "bar",
+					},
+				},
+				Spec: tektonv1beta1.PipelineRunSpec{
+					PipelineRef: &tektonv1beta1.PipelineRef{
+						Name:   "build-pipeline-pass",
+						Bundle: "quay.io/kpavic/test-bundle:build-pipeline-pass",
+					},
+					Params: []tektonv1beta1.Param{
+						{
+							Name: "output-image",
+							Value: tektonv1beta1.ParamValue{
+								Type:      tektonv1beta1.ParamTypeString,
+								StringVal: SampleImageWithoutDigest,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, buildPipelineRun2)).Should(Succeed())
+
+			buildPipelineRun2.Status = tektonv1beta1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
+					PipelineResults: []tektonv1beta1.PipelineRunResult{
+						{
+							Name:  "IMAGE_DIGEST",
+							Value: *tektonv1beta1.NewStructuredValues(SampleDigest),
+						},
+					},
+				},
+				Status: v1.Status{
+					Conditions: v1.Conditions{
+						apis.Condition{
+							Reason: "Completed",
+							Status: "True",
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, buildPipelineRun2)).Should(Succeed())
+			Expect(helpers.HasPipelineRunSucceeded(buildPipelineRun2)).To(BeTrue())
+		})
+
+		AfterAll(func() {
+			err := k8sClient.Delete(ctx, buildPipelineRun2)
+			Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("isLatestSucceededBuildPipelineRun reports second pipeline as the latest pipeline", func() {
+			// make sure the seocnd pipeline started as second
+			buildPipelineRun2.CreationTimestamp.Time = buildPipelineRun2.CreationTimestamp.Add(2 * time.Hour)
+			adapter = NewAdapter(buildPipelineRun2, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.ComponentContextKey,
+					Resource:   hasComp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasSnapshot,
+				},
+				{
+					ContextKey: loader.PipelineRunsContextKey,
+					Resource:   []tektonv1beta1.PipelineRun{*buildPipelineRun2, *buildPipelineRun},
+				},
+			})
+			isLatest, err := adapter.isLatestSucceededBuildPipelineRun()
+			Expect(err).To(BeNil())
+			Expect(isLatest).To(BeTrue())
+		})
+
+		It("isLatestSucceededBuildPipelineRun doesn't report first pipeline as the latest pipeline", func() {
+			// make sure the first pipeline started as first
+			buildPipelineRun.CreationTimestamp.Time = buildPipelineRun.CreationTimestamp.Add(-2 * time.Hour)
+			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.ComponentContextKey,
+					Resource:   hasComp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasSnapshot,
+				},
+				{
+					ContextKey: loader.PipelineRunsContextKey,
+					Resource:   []tektonv1beta1.PipelineRun{*buildPipelineRun2, *buildPipelineRun},
+				},
+			})
+			isLatest, err := adapter.isLatestSucceededBuildPipelineRun()
+			Expect(err).To(BeNil())
+			Expect(isLatest).To(BeFalse())
+		})
+
+		It("can detect if a PipelineRun has succeeded", func() {
+			buildPipelineRun.Status.SetCondition(&apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: "False",
+			})
+			Expect(helpers.HasPipelineRunSucceeded(buildPipelineRun)).To(BeFalse())
+			buildPipelineRun.Status.SetCondition(&apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: "True",
+			})
+			Expect(helpers.HasPipelineRunSucceeded(buildPipelineRun)).To(BeTrue())
+			Expect(helpers.HasPipelineRunSucceeded(&tektonv1beta1.TaskRun{})).To(BeFalse())
+		})
+
+		It("can fetch all succeeded build pipelineRuns", func() {
+			pipelineRuns, err := adapter.getSucceededBuildPipelineRunsForComponent(hasComp)
+			Expect(err).To(BeNil())
+			Expect(pipelineRuns).NotTo(BeNil())
+			Expect(len(*pipelineRuns)).To(Equal(2))
+			Expect((*pipelineRuns)[0].Name == buildPipelineRun.Name || (*pipelineRuns)[1].Name == buildPipelineRun.Name).To(BeTrue())
+		})
+
+		It("can annotate the build pipelineRun with the Snapshot name", func() {
+			pipelineRun, err := adapter.annotateBuildPipelineRunWithSnapshot(buildPipelineRun, hasSnapshot)
+			Expect(err).To(BeNil())
+			Expect(pipelineRun).NotTo(BeNil())
+			Expect(pipelineRun.ObjectMeta.Annotations[tekton.SnapshotNameLabel]).To(Equal(hasSnapshot.Name))
+		})
+
+		It("ensure that EnsureSnapshotExists doesn't create snapshot for previous pipeline run", func() {
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			// make sure the first pipeline started as first
+			buildPipelineRun.CreationTimestamp.Time = buildPipelineRun.CreationTimestamp.Add(-2 * time.Hour)
+			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.ComponentContextKey,
+					Resource:   hasComp,
+				},
+				{
+					ContextKey: loader.PipelineRunsContextKey,
+					Resource:   []tektonv1beta1.PipelineRun{*buildPipelineRun2, *buildPipelineRun},
+				},
+			})
+			Eventually(func() bool {
+				result, err := adapter.EnsureSnapshotExists()
+				return !result.CancelRequest && err == nil
+			}, time.Second*10).Should(BeTrue())
+
+			expectedLogEntry := "INFO The pipelineRun is not the latest successful build pipelineRun for the component, " +
+				"skipping creation of a new Snapshot"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+		})
+
+		It("can find matching snapshot", func() {
+			// make sure the first pipeline started as first
+			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.ComponentContextKey,
+					Resource:   hasComp,
+				},
+				{
+					ContextKey: loader.AllSnapshotsContextKey,
+					Resource:   []applicationapiv1alpha1.Snapshot{*hasSnapshot},
+				},
+			})
+			allSnapshots, err := adapter.loader.GetAllSnapshots(adapter.client, adapter.context, adapter.application)
+			Expect(err).To(BeNil())
+			Expect(allSnapshots).NotTo(BeNil())
+			existingSnapshot := gitops.FindMatchingSnapshot(hasApp, allSnapshots, hasSnapshot)
+			Expect(existingSnapshot.Name).To(Equal(hasSnapshot.Name))
+		})
+	})
+
+	createAdapter = func() *Adapter {
+		adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+		return adapter
+	}
+})

--- a/controllers/buildpipeline/buildpipeline_controller.go
+++ b/controllers/buildpipeline/buildpipeline_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022.
+Copyright 2023.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions andF
 limitations under the License.
 */
 
-package pipeline
+package buildpipeline
 
 import (
 	"context"
 	"fmt"
-
-	"github.com/redhat-appstudio/integration-service/cache"
 
 	"github.com/go-logr/logr"
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
@@ -36,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// Reconciler reconciles a PipelineRun object
+// Reconciler reconciles a build PipelineRun object
 type Reconciler struct {
 	client.Client
 	Log    logr.Logger
@@ -47,22 +45,17 @@ type Reconciler struct {
 func NewIntegrationReconciler(client client.Client, logger *logr.Logger, scheme *runtime.Scheme) *Reconciler {
 	return &Reconciler{
 		Client: client,
-		Log:    logger.WithName("pipeline"),
+		Log:    logger.WithName("build pipeline"),
 		Scheme: scheme,
 	}
 }
 
-//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=deploymenttargetclaims,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=deploymenttargets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;update;patch;delete;deletecollection
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/finalizers,verbs=update
 //+kubebuilder:rbac:groups=tekton.dev,resources=taskruns,verbs=get;list;watch
 //+kubebuilder:rbac:groups=tekton.dev,resources=taskruns/status,verbs=get
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/finalizers,verbs=update
-//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments/finalizers,verbs=update
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications,verbs=get;list;watch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/status,verbs=get
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
@@ -71,13 +64,13 @@ func NewIntegrationReconciler(client client.Client, logger *logr.Logger, scheme 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := helpers.IntegrationLogger{Logger: r.Log.WithValues("pipelineRun", req.NamespacedName)}
+	logger := helpers.IntegrationLogger{Logger: r.Log.WithValues("buildpipelineRun", req.NamespacedName)}
 	loader := loader.NewLoader()
 
 	pipelineRun := &tektonv1beta1.PipelineRun{}
 	err := r.Get(ctx, req.NamespacedName, pipelineRun)
 	if err != nil {
-		logger.Error(err, "Failed to get pipelineRun for", "req", req.NamespacedName)
+		logger.Error(err, "Failed to get build pipelineRun for", "req", req.NamespacedName)
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
@@ -85,12 +78,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	pipelineType, err := tekton.GetTypeFromPipelineRun(pipelineRun)
-	if err != nil {
-		logger.Error(err, "Failed to get Pipeline Type for",
-			"PipelineRun.Name", pipelineRun.Name, "PipelineRun.Namespace", pipelineRun.Namespace)
-		return ctrl.Result{}, err
-	}
 	component, err := loader.GetComponentFromPipelineRun(r.Client, ctx, pipelineRun)
 	if err != nil {
 		logger.Error(err, "Failed to get Component for",
@@ -106,12 +93,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				"Component.Name ", component.Name, "Component.Namespace ", component.Namespace)
 			return ctrl.Result{}, err
 		}
-	} else if pipelineType == tekton.PipelineRunTestType {
-		application, err = loader.GetApplicationFromPipelineRun(r.Client, ctx, pipelineRun)
-		if err != nil {
-			logger.Error(err, "Failed to get Application from the pipelineRun")
-			return ctrl.Result{}, err
-		}
 	}
 
 	if application == nil {
@@ -125,18 +106,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureSnapshotExists,
-		adapter.EnsureSnapshotPassedAllTests,
-		adapter.EnsureStatusReported,
-		adapter.EnsureEphemeralEnvironmentsCleanedUp,
 	})
 }
 
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
 	EnsureSnapshotExists() (controller.OperationResult, error)
-	EnsureSnapshotPassedAllTests() (controller.OperationResult, error)
-	EnsureStatusReported() (controller.OperationResult, error)
-	EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationResult, error)
 }
 
 // SetupController creates a new Integration controller and adds it to the Manager.
@@ -144,32 +119,12 @@ func SetupController(manager ctrl.Manager, log *logr.Logger) error {
 	return setupControllerWithManager(manager, NewIntegrationReconciler(manager.GetClient(), log, manager.GetScheme()))
 }
 
-// setupCache indexes fields for each of the resources used in the pipeline adapter in those cases where filtering by
-// field is required.
-func setupCache(mgr ctrl.Manager) error {
-	if err := cache.SetupApplicationComponentCache(mgr); err != nil {
-		return err
-	}
-
-	if err := cache.SetupSnapshotCache(mgr); err != nil {
-		return err
-	}
-
-	return cache.SetupIntegrationTestScenarioCache(mgr)
-}
-
-// setupControllerWithManager sets up the controller with the Manager which monitors new PipelineRuns and filters
+// setupControllerWithManager sets up the controller with the Manager which monitors new build PipelineRuns and filters
 // out status updates.
 func setupControllerWithManager(manager ctrl.Manager, controller *Reconciler) error {
-	err := setupCache(manager)
-	if err != nil {
-		return err
-	}
-
 	return ctrl.NewControllerManagedBy(manager).
 		For(&tektonv1beta1.PipelineRun{}).
 		WithEventFilter(predicate.Or(
-			tekton.IntegrationPipelineRunPredicate(),
 			tekton.BuildPipelineRunSignedAndSucceededPredicate())).
 		Complete(controller)
 }

--- a/controllers/buildpipeline/buildpipeline_controller_test.go
+++ b/controllers/buildpipeline/buildpipeline_controller_test.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildpipeline
+
+import (
+	"reflect"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	klog "k8s.io/klog/v2"
+)
+
+var _ = Describe("PipelineController", func() {
+	var (
+		manager            ctrl.Manager
+		pipelineReconciler *Reconciler
+		scheme             runtime.Scheme
+		req                ctrl.Request
+		successfulTaskRun  *tektonv1beta1.TaskRun
+		buildPipelineRun   *tektonv1beta1.PipelineRun
+		hasApp             *applicationapiv1alpha1.Application
+		hasComp            *applicationapiv1alpha1.Component
+	)
+	const (
+		applicationName = "application-sample"
+		SampleRepoLink  = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+	)
+
+	BeforeEach(func() {
+
+		hasApp = &applicationapiv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      applicationName,
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ApplicationSpec{
+				DisplayName: "application-sample",
+				Description: "This is an example application",
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
+
+		hasComp = &applicationapiv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "component-sample",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				ComponentName: "component-sample",
+				Application:   applicationName,
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL: SampleRepoLink,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
+
+		successfulTaskRun = &tektonv1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-pass",
+				Namespace: "default",
+			},
+			Spec: tektonv1beta1.TaskRunSpec{
+				TaskRef: &tektonv1beta1.TaskRef{
+					Name:   "test-taskrun-pass",
+					Bundle: "quay.io/redhat-appstudio/example-tekton-bundle:test",
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, successfulTaskRun)).Should(Succeed())
+
+		now := time.Now()
+		successfulTaskRun.Status = tektonv1beta1.TaskRunStatus{
+			TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
+				StartTime:      &metav1.Time{Time: now},
+				CompletionTime: &metav1.Time{Time: now.Add(5 * time.Minute)},
+				TaskRunResults: []tektonv1beta1.TaskRunResult{
+					{
+						Name: "TEST_OUTPUT",
+						Value: *tektonv1beta1.NewStructuredValues(`{
+											"result": "SUCCESS",
+											"timestamp": "1665405318",
+											"failures": 0,
+											"successes": 10,
+											"warnings": 0
+										}`),
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, successfulTaskRun)).Should(Succeed())
+
+		buildPipelineRun = &tektonv1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipelinerun-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					"pipelines.appstudio.openshift.io/type": "build",
+					"pipelines.openshift.io/used-by":        "build-cloud",
+					"pipelines.openshift.io/runtime":        "nodejs",
+					"pipelines.openshift.io/strategy":       "s2i",
+					"appstudio.openshift.io/component":      "component-sample",
+					"appstudio.openshift.io/application":    applicationName,
+				},
+				Annotations: map[string]string{
+					"appstudio.redhat.com/updateComponentOnSuccess": "false",
+				},
+			},
+			Spec: tektonv1beta1.PipelineRunSpec{
+				PipelineRef: &tektonv1beta1.PipelineRef{
+					Name:   "build-pipeline-pass",
+					Bundle: "quay.io/kpavic/test-bundle:build-pipeline-pass",
+				},
+				Params: []tektonv1beta1.Param{
+					{
+						Name: "output-image",
+						Value: tektonv1beta1.ParamValue{
+							Type:      tektonv1beta1.ParamTypeString,
+							StringVal: "quay.io/redhat-appstudio/sample-image",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, buildPipelineRun)).Should(Succeed())
+
+		buildPipelineRun.Status = tektonv1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
+				ChildReferences: []tektonv1beta1.ChildStatusReference{
+					{
+						Name:             successfulTaskRun.Name,
+						PipelineTaskName: "task1",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, buildPipelineRun)).Should(Succeed())
+
+		req = ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "default",
+				Name:      buildPipelineRun.Name,
+			},
+		}
+
+		webhookInstallOptions := &testEnv.WebhookInstallOptions
+
+		klog.Info(webhookInstallOptions.LocalServingHost)
+		klog.Info(webhookInstallOptions.LocalServingPort)
+		klog.Info(webhookInstallOptions.LocalServingCertDir)
+
+		var err error
+		manager, err = ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:             clientsetscheme.Scheme,
+			Host:               webhookInstallOptions.LocalServingHost,
+			Port:               webhookInstallOptions.LocalServingPort,
+			CertDir:            webhookInstallOptions.LocalServingCertDir,
+			MetricsBindAddress: "0", // this disables metrics
+			LeaderElection:     false,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(err).To(BeNil())
+
+		pipelineReconciler = NewIntegrationReconciler(k8sClient, &logf.Log, &scheme)
+	})
+
+	AfterEach(func() {
+		err := k8sClient.Delete(ctx, hasApp)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasComp)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, buildPipelineRun)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, successfulTaskRun)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("can create and return a new Reconciler object", func() {
+		Expect(reflect.TypeOf(pipelineReconciler)).To(Equal(reflect.TypeOf(&Reconciler{})))
+	})
+
+	It("can fail when Reconcile fails to prepare the adapter when pipeline is not found", func() {
+		Expect(k8sClient.Delete(ctx, buildPipelineRun)).Should(Succeed())
+		Eventually(func() error {
+			_, err := pipelineReconciler.Reconcile(ctx, req)
+			return err
+		}).Should(BeNil())
+	})
+
+	It("can Reconcile function prepare the adapter and return the result of the reconcile handling operation", func() {
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "non-existent",
+				Namespace: "default",
+			},
+		}
+		result, err := pipelineReconciler.Reconcile(ctx, req)
+		Expect(reflect.TypeOf(result)).To(Equal(reflect.TypeOf(reconcile.Result{})))
+		Expect(err).To(BeNil())
+	})
+
+	It("can setup a new controller manager with the given reconciler", func() {
+		err := setupControllerWithManager(manager, pipelineReconciler)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("can setup a new Controller manager and start it", func() {
+		err := SetupController(manager, &ctrl.Log)
+		Expect(err).To(BeNil())
+		go func() {
+			defer GinkgoRecover()
+			err = manager.Start(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+	})
+
+	When("pipelinerun has no component", func() {
+
+		var (
+			buildPipelineRunNoComponent *tektonv1beta1.PipelineRun
+			reqNoComponent              ctrl.Request
+		)
+
+		BeforeEach(func() {
+			buildPipelineRunNoComponent = &tektonv1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pipelinerun-sample-no-component",
+					Namespace: "default",
+					Labels: map[string]string{
+						"pipelines.appstudio.openshift.io/type": "test",
+						"pipelines.openshift.io/used-by":        "build-cloud",
+						"pipelines.openshift.io/runtime":        "nodejs",
+						"pipelines.openshift.io/strategy":       "s2i",
+						"appstudio.openshift.io/application":    applicationName,
+					},
+					Annotations: map[string]string{
+						"appstudio.redhat.com/updateComponentOnSuccess": "false",
+					},
+				},
+				Spec: tektonv1beta1.PipelineRunSpec{
+					PipelineRef: &tektonv1beta1.PipelineRef{
+						Name:   "build-pipeline-pass",
+						Bundle: "quay.io/kpavic/test-bundle:build-pipeline-pass",
+					},
+					Params: []tektonv1beta1.Param{
+						{
+							Name: "output-image",
+							Value: tektonv1beta1.ParamValue{
+								Type:      tektonv1beta1.ParamTypeString,
+								StringVal: "quay.io/redhat-appstudio/sample-image",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, buildPipelineRunNoComponent)).Should(Succeed())
+
+			reqNoComponent = ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "default",
+					Name:      buildPipelineRunNoComponent.Name,
+				},
+			}
+		})
+
+		AfterEach(func() {
+			err := k8sClient.Delete(ctx, buildPipelineRunNoComponent)
+			Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("reconcile with application taken from pipelinerun (test pipeline)", func() {
+			result, err := pipelineReconciler.Reconcile(ctx, reqNoComponent)
+			Expect(reflect.TypeOf(result)).To(Equal(reflect.TypeOf(reconcile.Result{})))
+			Expect(err).To(BeNil())
+		})
+
+	})
+})

--- a/controllers/buildpipeline/buildpipeline_suite_test.go
+++ b/controllers/buildpipeline/buildpipeline_suite_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildpipeline
+
+import (
+	"context"
+	"go/build"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/api/v1beta1"
+
+	toolkit "github.com/redhat-appstudio/operator-toolkit/test"
+	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestControllerPipeline(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Build Pipeline Controller Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	//adding required CRDs, including tekton for PipelineRun Kind
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", toolkit.GetRelativeDependencyPath("tektoncd/pipeline"), "config",
+			),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", toolkit.GetRelativeDependencyPath("application-api"),
+				"config", "crd", "bases",
+			),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", toolkit.GetRelativeDependencyPath("release-service"), "config", "crd", "bases",
+			),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	Expect(applicationapiv1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(tektonv1beta1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(releasev1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(v1beta1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+
+	k8sManager, _ := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             clientsetscheme.Scheme,
+		MetricsBindAddress: "0", // this disables metrics
+		LeaderElection:     false,
+	})
+
+	k8sClient = k8sManager.GetClient()
+	go func() {
+		defer GinkgoRecover()
+		Expect(k8sManager.Start(ctx)).To(Succeed())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -19,7 +19,8 @@ package controllers
 import (
 	"github.com/go-logr/logr"
 	"github.com/redhat-appstudio/integration-service/controllers/binding"
-	"github.com/redhat-appstudio/integration-service/controllers/pipeline"
+	"github.com/redhat-appstudio/integration-service/controllers/buildpipeline"
+	"github.com/redhat-appstudio/integration-service/controllers/integrationpipeline"
 	"github.com/redhat-appstudio/integration-service/controllers/scenario"
 	"github.com/redhat-appstudio/integration-service/controllers/snapshot"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -28,7 +29,8 @@ import (
 
 // setupFunctions is a list of register functions to be invoked so all controllers are added to the Manager
 var setupFunctions = []func(manager.Manager, *logr.Logger) error{
-	pipeline.SetupController,
+	integrationpipeline.SetupController,
+	buildpipeline.SetupController,
 	snapshot.SetupController,
 	scenario.SetupController,
 	binding.SetupController,

--- a/controllers/integrationpipeline/integrationpipeline_controller.go
+++ b/controllers/integrationpipeline/integrationpipeline_controller.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions andF
+limitations under the License.
+*/
+
+package integrationpipeline
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redhat-appstudio/integration-service/cache"
+
+	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/helpers"
+	"github.com/redhat-appstudio/integration-service/loader"
+	"github.com/redhat-appstudio/integration-service/tekton"
+	"github.com/redhat-appstudio/operator-toolkit/controller"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// Reconciler reconciles an integration PipelineRun object
+type Reconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// NewIntegrationReconciler creates and returns a Reconciler.
+func NewIntegrationReconciler(client client.Client, logger *logr.Logger, scheme *runtime.Scheme) *Reconciler {
+	return &Reconciler{
+		Client: client,
+		Log:    logger.WithName("integration pipeline"),
+		Scheme: scheme,
+	}
+}
+
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=deploymenttargetclaims,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=deploymenttargets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;update;patch;delete;deletecollection
+//+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/finalizers,verbs=update
+//+kubebuilder:rbac:groups=tekton.dev,resources=taskruns,verbs=get;list;watch
+//+kubebuilder:rbac:groups=tekton.dev,resources=taskruns/status,verbs=get
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/finalizers,verbs=update
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments/finalizers,verbs=update
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications,verbs=get;list;watch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/status,verbs=get
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=pipelinesascode.tekton.dev,resources=repositories,verbs=get;list;watch
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := helpers.IntegrationLogger{Logger: r.Log.WithValues("pipelineRun", req.NamespacedName)}
+	loader := loader.NewLoader()
+
+	pipelineRun := &tektonv1beta1.PipelineRun{}
+	err := r.Get(ctx, req.NamespacedName, pipelineRun)
+	if err != nil {
+		logger.Error(err, "Failed to get integration pipelineRun for", "req", req.NamespacedName)
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, err
+	}
+
+	component, err := loader.GetComponentFromPipelineRun(r.Client, ctx, pipelineRun)
+	if err != nil {
+		logger.Error(err, "Failed to get Component for",
+			"PipelineRun.Name", pipelineRun.Name, "PipelineRun.Namespace", pipelineRun.Namespace)
+		return ctrl.Result{}, err
+	}
+
+	application := &applicationapiv1alpha1.Application{}
+	application, err = loader.GetApplicationFromPipelineRun(r.Client, ctx, pipelineRun)
+	if err != nil {
+		logger.Error(err, "Failed to get Application from the test pipelineRun",
+			"PipelineRun.Name", pipelineRun.Name, "PipelineRun.Namespace", pipelineRun.Namespace)
+		return ctrl.Result{}, err
+	}
+
+	if application == nil {
+		err := fmt.Errorf("failed to get Application")
+		logger.Error(err, "reconcile cannot resolve application")
+		return ctrl.Result{}, err
+	}
+	logger = logger.WithApp(*application)
+
+	adapter := NewAdapter(pipelineRun, component, application, logger, loader, r.Client, ctx)
+
+	return controller.ReconcileHandler([]controller.Operation{
+		adapter.EnsureSnapshotPassedAllTests,
+		adapter.EnsureStatusReported,
+		adapter.EnsureEphemeralEnvironmentsCleanedUp,
+	})
+}
+
+// AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
+type AdapterInterface interface {
+	EnsureSnapshotPassedAllTests() (controller.OperationResult, error)
+	EnsureStatusReported() (controller.OperationResult, error)
+	EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationResult, error)
+}
+
+// SetupController creates a new Integration controller and adds it to the Manager.
+func SetupController(manager ctrl.Manager, log *logr.Logger) error {
+	return setupControllerWithManager(manager, NewIntegrationReconciler(manager.GetClient(), log, manager.GetScheme()))
+}
+
+// setupCache indexes fields for each of the resources used in the pipeline adapter in those cases where filtering by
+// field is required.
+func setupCache(mgr ctrl.Manager) error {
+	if err := cache.SetupApplicationComponentCache(mgr); err != nil {
+		return err
+	}
+
+	if err := cache.SetupSnapshotCache(mgr); err != nil {
+		return err
+	}
+
+	return cache.SetupIntegrationTestScenarioCache(mgr)
+}
+
+// setupControllerWithManager sets up the controller with the Manager which monitors new PipelineRuns and filters
+// out status updates.
+func setupControllerWithManager(manager ctrl.Manager, controller *Reconciler) error {
+	err := setupCache(manager)
+	if err != nil {
+		return err
+	}
+
+	return ctrl.NewControllerManagedBy(manager).
+		For(&tektonv1beta1.PipelineRun{}).
+		WithEventFilter(predicate.Or(
+			tekton.IntegrationPipelineRunPredicate())).
+		Complete(controller)
+}

--- a/controllers/integrationpipeline/integrationpipeline_controller_test.go
+++ b/controllers/integrationpipeline/integrationpipeline_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022.
+Copyright 2023.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pipeline
+package integrationpipeline
 
 import (
 	"reflect"
@@ -39,16 +39,16 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
-var _ = Describe("PipelineController", func() {
+var _ = Describe("Integration PipelineController", func() {
 	var (
-		manager            ctrl.Manager
-		pipelineReconciler *Reconciler
-		scheme             runtime.Scheme
-		req                ctrl.Request
-		successfulTaskRun  *tektonv1beta1.TaskRun
-		testpipelineRun    *tektonv1beta1.PipelineRun
-		hasApp             *applicationapiv1alpha1.Application
-		hasComp            *applicationapiv1alpha1.Component
+		manager                ctrl.Manager
+		pipelineReconciler     *Reconciler
+		scheme                 runtime.Scheme
+		req                    ctrl.Request
+		successfulTaskRun      *tektonv1beta1.TaskRun
+		integrationPipelineRun *tektonv1beta1.PipelineRun
+		hasApp                 *applicationapiv1alpha1.Application
+		hasComp                *applicationapiv1alpha1.Component
 	)
 	const (
 		applicationName = "application-sample"
@@ -124,7 +124,7 @@ var _ = Describe("PipelineController", func() {
 		}
 		Expect(k8sClient.Status().Update(ctx, successfulTaskRun)).Should(Succeed())
 
-		testpipelineRun = &tektonv1beta1.PipelineRun{
+		integrationPipelineRun = &tektonv1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pipelinerun-sample",
 				Namespace: "default",
@@ -156,9 +156,9 @@ var _ = Describe("PipelineController", func() {
 				},
 			},
 		}
-		Expect(k8sClient.Create(ctx, testpipelineRun)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, integrationPipelineRun)).Should(Succeed())
 
-		testpipelineRun.Status = tektonv1beta1.PipelineRunStatus{
+		integrationPipelineRun.Status = tektonv1beta1.PipelineRunStatus{
 			PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
 				ChildReferences: []tektonv1beta1.ChildStatusReference{
 					{
@@ -168,12 +168,12 @@ var _ = Describe("PipelineController", func() {
 				},
 			},
 		}
-		Expect(k8sClient.Status().Update(ctx, testpipelineRun)).Should(Succeed())
+		Expect(k8sClient.Status().Update(ctx, integrationPipelineRun)).Should(Succeed())
 
 		req = ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "default",
-				Name:      testpipelineRun.Name,
+				Name:      integrationPipelineRun.Name,
 			},
 		}
 
@@ -203,7 +203,7 @@ var _ = Describe("PipelineController", func() {
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasComp)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
-		err = k8sClient.Delete(ctx, testpipelineRun)
+		err = k8sClient.Delete(ctx, integrationPipelineRun)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, successfulTaskRun)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
@@ -214,7 +214,7 @@ var _ = Describe("PipelineController", func() {
 	})
 
 	It("can fail when Reconcile fails to prepare the adapter when pipeline is not found", func() {
-		Expect(k8sClient.Delete(ctx, testpipelineRun)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, integrationPipelineRun)).Should(Succeed())
 		Eventually(func() error {
 			_, err := pipelineReconciler.Reconcile(ctx, req)
 			return err
@@ -256,12 +256,12 @@ var _ = Describe("PipelineController", func() {
 	When("pipelinerun has no component", func() {
 
 		var (
-			testPipelineRunNoComponent *tektonv1beta1.PipelineRun
-			reqNoComponent             ctrl.Request
+			integrationPipelineRunNoComponent *tektonv1beta1.PipelineRun
+			reqNoComponent                    ctrl.Request
 		)
 
 		BeforeEach(func() {
-			testPipelineRunNoComponent = &tektonv1beta1.PipelineRun{
+			integrationPipelineRunNoComponent = &tektonv1beta1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pipelinerun-sample-no-component",
 					Namespace: "default",
@@ -292,18 +292,18 @@ var _ = Describe("PipelineController", func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, testPipelineRunNoComponent)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, integrationPipelineRunNoComponent)).Should(Succeed())
 
 			reqNoComponent = ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: "default",
-					Name:      testPipelineRunNoComponent.Name,
+					Name:      integrationPipelineRunNoComponent.Name,
 				},
 			}
 		})
 
 		AfterEach(func() {
-			err := k8sClient.Delete(ctx, testPipelineRunNoComponent)
+			err := k8sClient.Delete(ctx, integrationPipelineRunNoComponent)
 			Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		})
 

--- a/controllers/integrationpipeline/integrationpipeline_suite_test.go
+++ b/controllers/integrationpipeline/integrationpipeline_suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022.
+Copyright 2023.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pipeline
+package integrationpipeline
 
 import (
 	"context"
@@ -52,7 +52,7 @@ var (
 
 func TestControllerPipeline(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Pipeline Controller Test Suite")
+	RunSpecs(t, "Integration Pipeline Controller Test Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		hasSnapshot                       *applicationapiv1alpha1.Snapshot
 		hasSnapshotPR                     *applicationapiv1alpha1.Snapshot
 		deploymentTargetClass             *applicationapiv1alpha1.DeploymentTargetClass
-		testpipelineRun                   *tektonv1beta1.PipelineRun
+		integrationPipelineRun            *tektonv1beta1.PipelineRun
 		integrationTestScenario           *v1beta1.IntegrationTestScenario
 		integrationTestScenarioWithoutEnv *v1beta1.IntegrationTestScenario
 		env                               *applicationapiv1alpha1.Environment
@@ -265,7 +265,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		}
 		Expect(k8sClient.Create(ctx, hasSnapshotPR)).Should(Succeed())
 
-		testpipelineRun = &tektonv1beta1.PipelineRun{
+		integrationPipelineRun = &tektonv1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "build-pipelinerun" + "-",
 				Namespace:    "default",
@@ -297,7 +297,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				},
 			},
 		}
-		Expect(k8sClient.Create(ctx, testpipelineRun)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, integrationPipelineRun)).Should(Succeed())
 
 		Eventually(func() error {
 			err := k8sClient.Get(ctx, types.NamespacedName{
@@ -311,7 +311,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 	AfterEach(func() {
 		err := k8sClient.Delete(ctx, hasSnapshotPR)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
-		err = k8sClient.Delete(ctx, testpipelineRun)
+		err = k8sClient.Delete(ctx, integrationPipelineRun)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 	})
 

--- a/loader/integration_test.go
+++ b/loader/integration_test.go
@@ -41,8 +41,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 	var (
 		taskRun                 *tektonv1beta1.TaskRun
-		testpipelineRun1        *tektonv1beta1.PipelineRun
-		testpipelineRun2        *tektonv1beta1.PipelineRun
+		integrationPipelineRun1 *tektonv1beta1.PipelineRun
+		integrationPipelineRun2 *tektonv1beta1.PipelineRun
 		hasApp                  *applicationapiv1alpha1.Application
 		hasSnapshot             *applicationapiv1alpha1.Snapshot
 		integrationTestScenario *v1beta1.IntegrationTestScenario
@@ -162,7 +162,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		}
 		Expect(k8sClient.Status().Update(ctx, taskRun)).Should(Succeed())
 
-		testpipelineRun1 = &tektonv1beta1.PipelineRun{
+		integrationPipelineRun1 = &tektonv1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pipelinerun-component-sample-1",
 				Namespace: "default",
@@ -187,9 +187,9 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				},
 			},
 		}
-		Expect(k8sClient.Create(ctx, testpipelineRun1)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, integrationPipelineRun1)).Should(Succeed())
 
-		testpipelineRun1.Status = tektonv1beta1.PipelineRunStatus{
+		integrationPipelineRun1.Status = tektonv1beta1.PipelineRunStatus{
 			PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
 				CompletionTime: &metav1.Time{Time: time.Now()},
 				ChildReferences: []tektonv1beta1.ChildStatusReference{
@@ -209,18 +209,18 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				},
 			},
 		}
-		Expect(k8sClient.Status().Update(ctx, testpipelineRun1)).Should(Succeed())
+		Expect(k8sClient.Status().Update(ctx, integrationPipelineRun1)).Should(Succeed())
 
 		pr := &tektonv1beta1.PipelineRun{}
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      testpipelineRun1.Name,
-				Namespace: testpipelineRun1.Namespace,
+				Name:      integrationPipelineRun1.Name,
+				Namespace: integrationPipelineRun1.Namespace,
 			}, pr)
 			return err == nil && pr.Status.CompletionTime != nil
 		}, time.Second*10).Should(BeTrue(), "timed out when waiting for the PipelineRun to be updated")
 
-		testpipelineRun2 = &tektonv1beta1.PipelineRun{
+		integrationPipelineRun2 = &tektonv1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pipelinerun-component-sample-2",
 				Namespace: "default",
@@ -245,9 +245,9 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				},
 			},
 		}
-		Expect(k8sClient.Create(ctx, testpipelineRun2)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, integrationPipelineRun2)).Should(Succeed())
 
-		testpipelineRun2.Status = tektonv1beta1.PipelineRunStatus{
+		integrationPipelineRun2.Status = tektonv1beta1.PipelineRunStatus{
 			PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
 				CompletionTime: &metav1.Time{Time: time.Now().Add(5 * time.Minute)},
 				ChildReferences: []tektonv1beta1.ChildStatusReference{
@@ -267,13 +267,13 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				},
 			},
 		}
-		Expect(k8sClient.Status().Update(ctx, testpipelineRun2)).Should(Succeed())
+		Expect(k8sClient.Status().Update(ctx, integrationPipelineRun2)).Should(Succeed())
 
 		pr = &tektonv1beta1.PipelineRun{}
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      testpipelineRun2.Name,
-				Namespace: testpipelineRun2.Namespace,
+				Name:      integrationPipelineRun2.Name,
+				Namespace: integrationPipelineRun2.Namespace,
 			}, pr)
 			return err == nil && pr.Status.CompletionTime != nil
 		}, time.Second*10).Should(BeTrue(), "timed out when waiting for the PipelineRun to be updated")
@@ -282,9 +282,9 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 	AfterAll(func() {
 		err := k8sClient.Delete(ctx, hasSnapshot)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
-		err = k8sClient.Delete(ctx, testpipelineRun1)
+		err = k8sClient.Delete(ctx, integrationPipelineRun1)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
-		err = k8sClient.Delete(ctx, testpipelineRun2)
+		err = k8sClient.Delete(ctx, integrationPipelineRun2)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasApp)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
@@ -296,8 +296,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 	It("can fetch latest pipelineRun for snapshot and scenario", func() {
 		pipelineRun, err := GetLatestPipelineRunForSnapshotAndScenario(k8sClient, ctx, loader, hasSnapshot, integrationTestScenario)
-		Expect(pipelineRun.Name == testpipelineRun2.Name).To(BeTrue())
+		Expect(pipelineRun.Name == integrationPipelineRun2.Name).To(BeTrue())
 		Expect(err).To(BeNil())
 	})
-
 })

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -43,8 +43,8 @@ var _ = Describe("Loader", Ordered, func() {
 		deploymentTargetClaim   *applicationapiv1alpha1.DeploymentTargetClaim
 		integrationTestScenario *v1beta1.IntegrationTestScenario
 		successfulTaskRun       *tektonv1beta1.TaskRun
-		testBuildPipelineRun    *tektonv1beta1.PipelineRun
-		testPipelineRun         *tektonv1beta1.PipelineRun
+		buildPipelineRun        *tektonv1beta1.PipelineRun
+		integrationPipelineRun  *tektonv1beta1.PipelineRun
 		hasBinding              *applicationapiv1alpha1.SnapshotEnvironmentBinding
 	)
 
@@ -267,7 +267,7 @@ var _ = Describe("Loader", Ordered, func() {
 		}
 		Expect(k8sClient.Create(ctx, hasEnv)).Should(Succeed())
 
-		testBuildPipelineRun = &tektonv1beta1.PipelineRun{
+		buildPipelineRun = &tektonv1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pipelinerun-sample",
 				Namespace: "default",
@@ -303,9 +303,9 @@ var _ = Describe("Loader", Ordered, func() {
 				},
 			},
 		}
-		Expect(k8sClient.Create(ctx, testBuildPipelineRun)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, buildPipelineRun)).Should(Succeed())
 
-		testBuildPipelineRun.Status = tektonv1beta1.PipelineRunStatus{
+		buildPipelineRun.Status = tektonv1beta1.PipelineRunStatus{
 			PipelineRunStatusFields: tektonv1beta1.PipelineRunStatusFields{
 				ChildReferences: []tektonv1beta1.ChildStatusReference{
 					{
@@ -315,9 +315,9 @@ var _ = Describe("Loader", Ordered, func() {
 				},
 			},
 		}
-		Expect(k8sClient.Status().Update(ctx, testBuildPipelineRun)).Should(Succeed())
+		Expect(k8sClient.Status().Update(ctx, buildPipelineRun)).Should(Succeed())
 
-		testPipelineRun = &tektonv1beta1.PipelineRun{
+		integrationPipelineRun = &tektonv1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pipelinerun-component-sample",
 				Namespace: "default",
@@ -345,7 +345,7 @@ var _ = Describe("Loader", Ordered, func() {
 			},
 		}
 
-		Expect(k8sClient.Create(ctx, testPipelineRun)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, integrationPipelineRun)).Should(Succeed())
 
 		hasBinding = &applicationapiv1alpha1.SnapshotEnvironmentBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -367,8 +367,8 @@ var _ = Describe("Loader", Ordered, func() {
 
 	AfterAll(func() {
 		_ = k8sClient.Delete(ctx, hasSnapshot)
-		_ = k8sClient.Delete(ctx, testBuildPipelineRun)
-		_ = k8sClient.Delete(ctx, testPipelineRun)
+		_ = k8sClient.Delete(ctx, buildPipelineRun)
+		_ = k8sClient.Delete(ctx, integrationPipelineRun)
 		_ = k8sClient.Delete(ctx, successfulTaskRun)
 		_ = k8sClient.Delete(ctx, hasEnv)
 		_ = k8sClient.Delete(ctx, integrationTestScenario)
@@ -469,21 +469,21 @@ var _ = Describe("Loader", Ordered, func() {
 	})
 
 	It("ensures we can get a Component from a Pipeline Run ", func() {
-		comp, err := loader.GetComponentFromPipelineRun(k8sClient, ctx, testBuildPipelineRun)
+		comp, err := loader.GetComponentFromPipelineRun(k8sClient, ctx, buildPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(comp).NotTo(BeNil())
 		Expect(comp.ObjectMeta).To(Equal(hasComp.ObjectMeta))
 	})
 
 	It("ensures we can get the application from the Pipeline Run", func() {
-		app, err := loader.GetApplicationFromPipelineRun(k8sClient, ctx, testBuildPipelineRun)
+		app, err := loader.GetApplicationFromPipelineRun(k8sClient, ctx, buildPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(app).NotTo(BeNil())
 		Expect(app.ObjectMeta).To(Equal(hasApp.ObjectMeta))
 	})
 
 	It("ensures we can get the environment from the Pipeline Run", func() {
-		env, err := loader.GetApplicationFromPipelineRun(k8sClient, ctx, testBuildPipelineRun)
+		env, err := loader.GetApplicationFromPipelineRun(k8sClient, ctx, buildPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(env).NotTo(BeNil())
 	})
@@ -496,14 +496,14 @@ var _ = Describe("Loader", Ordered, func() {
 	})
 
 	It("ensures we can get the Snapshot from a Pipeline Run", func() {
-		snapshot, err := loader.GetSnapshotFromPipelineRun(k8sClient, ctx, testBuildPipelineRun)
+		snapshot, err := loader.GetSnapshotFromPipelineRun(k8sClient, ctx, buildPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(snapshot).NotTo(BeNil())
 		Expect(snapshot.ObjectMeta).To(Equal(hasSnapshot.ObjectMeta))
 	})
 
 	It("ensures we can get the Environment from a Pipeline Run", func() {
-		env, err := loader.GetEnvironmentFromIntegrationPipelineRun(k8sClient, ctx, testBuildPipelineRun)
+		env, err := loader.GetEnvironmentFromIntegrationPipelineRun(k8sClient, ctx, buildPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(env).NotTo(BeNil())
 		Expect(env.ObjectMeta).To(Equal(hasEnv.ObjectMeta))
@@ -514,7 +514,7 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(err).To(BeNil())
 		Expect(pipelineRuns).NotTo(BeNil())
 		Expect(len(*pipelineRuns)).To(Equal(1))
-		Expect((*pipelineRuns)[0].Name == testBuildPipelineRun.Name)
+		Expect((*pipelineRuns)[0].Name == buildPipelineRun.Name)
 	})
 
 	It("can fetch all pipelineRuns for snapshot and scenario", func() {
@@ -522,7 +522,7 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(err).To(BeNil())
 		Expect(pipelineRuns).NotTo(BeNil())
 		Expect(len(*pipelineRuns)).To(Equal(1))
-		Expect((*pipelineRuns)[0].Name == testBuildPipelineRun.Name)
+		Expect((*pipelineRuns)[0].Name == buildPipelineRun.Name)
 	})
 
 	It("can fetch all integrationTestScenario for application", func() {


### PR DESCRIPTION
* split pipeline controller to build and test pipeline controller
* move func PrepareSnapshot() to gitops pkg and refactor it
* rename the pipelinerun variable in unittest to buildPipelineRun
  or integrationPipelineRun

Signed-off-by: Hongwei Liu <hongliu@redhat.com>