### PR TITLE
fix(STONEINTG-508): copy build labels/annotations to the intg test PLR

### DIFF
--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -476,6 +476,11 @@ func (a *Adapter) createIntegrationPipelineRun(application *applicationapiv1alph
 	// copy PipelineRun PAC annotations/labels from snapshot to integration test PipelineRuns
 	h.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.PipelinesAsCodePrefix, gitops.PipelinesAsCodePrefix)
 	h.CopyLabelsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.PipelinesAsCodePrefix, gitops.PipelinesAsCodePrefix)
+
+	// Copy build labels and annotations prefixed with build.appstudio from snapshot to integration test PipelineRuns
+	h.CopyLabelsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.BuildPipelineRunPrefix, gitops.BuildPipelineRunPrefix)
+	h.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.BuildPipelineRunPrefix, gitops.BuildPipelineRunPrefix)
+
 	err := ctrl.SetControllerReference(snapshot, pipelineRun, a.client.Scheme())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR is to add a fix for copying build labels/annotations from the Snapshots to the integration test PLRs