### PR TITLE
fix(STONEINTG-469): fix the negative number in SnapshotConcurrentTotal

### DIFF
--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -36,6 +36,7 @@ import (
 	"github.com/redhat-appstudio/operator-toolkit/controller"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -134,7 +135,7 @@ func (a *Adapter) EnsureAllIntegrationTestPipelinesExist() (controller.Operation
 			a.snapshot, h.LogActionUpdate)
 		return controller.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))
 	}
-	if len(*requiredIntegrationTestScenarios) == 0 {
+	if len(*requiredIntegrationTestScenarios) == 0 && !gitops.IsSnapshotStatusConditionSet(a.snapshot, gitops.AppStudioTestSuceededCondition, metav1.ConditionTrue, "") {
 		updatedSnapshot, err := gitops.MarkSnapshotAsPassed(a.client, a.context, a.snapshot, "No required IntegrationTestScenarios found, skipped testing")
 		if err != nil {
 			a.logger.Error(err, "Failed to update Snapshot status")

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -268,6 +268,24 @@ func IsSnapshotValid(snapshot *applicationapiv1alpha1.Snapshot) bool {
 	return false
 }
 
+// IsSnapshotStatusConditionSet checks if the condition with the conditionType in the status of Snapshot has been marked as the conditionStatus and reason.
+func IsSnapshotStatusConditionSet(snapshot *applicationapiv1alpha1.Snapshot, conditionType string, conditionStatus metav1.ConditionStatus, reason string) bool {
+	condition := meta.FindStatusCondition(snapshot.Status.Conditions, conditionType)
+	if condition == nil && conditionType == AppStudioTestSuceededCondition {
+		condition = meta.FindStatusCondition(snapshot.Status.Conditions, LegacyTestSuceededCondition)
+	}
+	if condition == nil && conditionType == AppStudioIntegrationStatusCondition {
+		condition = meta.FindStatusCondition(snapshot.Status.Conditions, LegacyIntegrationStatusCondition)
+	}
+	if condition == nil || condition.Status != conditionStatus {
+		return false
+	}
+	if reason != "" && reason != condition.Reason {
+		return false
+	}
+	return true
+}
+
 // ValidateImageDigest checks if image url contains valid digest, return error if check fails
 func ValidateImageDigest(imageUrl string) error {
 	_, err := name.NewDigest(imageUrl)


### PR DESCRIPTION
Added checking before the status of snapshot is updated to avoid repetition action
After the snapshot is set to Invalid status, return immediately and avoid to be set to "Passed" or " Failed" again.
 