### PR TITLE
fix(STONEINTG-565): change the condition for HaveBindingsFailed

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -79,6 +79,7 @@ func (a *Adapter) EnsureIntegrationTestPipelineForScenarioExists() (controller.O
 		a.logger.Info("The SnapshotEnvironmentBinding hasn't yet deployed to the ephemeral environment.", "snapshotEnvironmentBinding.Name", a.snapshotEnvironmentBinding.Name)
 		return controller.ContinueProcessing()
 	}
+	a.logger.Info("The SnapshotEnvironmentBinding's deployment succeeded", "snapshotEnvironmentBinding.Name", a.snapshotEnvironmentBinding.Name)
 
 	if a.integrationTestScenario != nil {
 		integrationPipelineRun, err := loader.GetLatestPipelineRunForSnapshotAndScenario(a.client, a.context, a.loader, a.snapshot, a.integrationTestScenario)
@@ -113,7 +114,6 @@ func (a *Adapter) EnsureIntegrationTestPipelineForScenarioExists() (controller.O
 // EnsureEphemeralEnvironmentsCleanedUp will ensure that ephemeral environment(s) associated with the
 // SnapshotEnvironmentBinding are cleaned up.
 func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationResult, error) {
-
 	if !gitops.HaveBindingsFailed(a.snapshotEnvironmentBinding) {
 		return controller.ContinueProcessing()
 	}
@@ -121,6 +121,9 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 	// mark snapshot as failed
 	snapshotErrorMessage := "Encountered issue deploying snapshot on ephemeral environments: " +
 		meta.FindStatusCondition(a.snapshotEnvironmentBinding.Status.BindingConditions, "ErrorOccurred").Message
+	a.logger.Info("The SnapshotEnvironmentBinding encountered an issue deploying snapshot on ephemeral environments",
+		"snapshotEnvironmentBinding.Name", a.snapshotEnvironmentBinding.Name,
+		"message", snapshotErrorMessage)
 	_, err := gitops.MarkSnapshotAsFailed(a.client, a.context, a.snapshot, snapshotErrorMessage)
 	if err != nil {
 		a.logger.Error(err, "Failed to Update Snapshot status")

--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -132,7 +132,8 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 
 	deploymentTargetClaim, err := a.loader.GetDeploymentTargetClaimForEnvironment(a.client, a.context, a.environment)
 	if err != nil {
-		a.logger.Error(err, "failed to find deploymentTargetClaim defined in environment %s", a.environment.Name)
+		a.logger.Error(err, "failed to find deploymentTargetClaim for environment",
+			"environment", a.environment.Name)
 		return controller.RequeueWithError(err)
 	}
 

--- a/controllers/binding/snapshotenvironmentbinding_adapter_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter_test.go
@@ -304,13 +304,13 @@ var _ = Describe("Binding Adapter", Ordered, func() {
 
 		Expect(k8sClient.Status().Update(ctx, hasBinding)).Should(Succeed())
 
-		Eventually(func() error {
+		Eventually(func() bool {
 			err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      hasBinding.Name,
 				Namespace: "default",
 			}, hasBinding)
-			return err
-		}, time.Second*10).ShouldNot(HaveOccurred())
+			return err == nil && gitops.IsBindingDeployed(hasBinding)
+		}, time.Second*20).Should(BeTrue())
 	})
 
 	AfterEach(func() {

--- a/controllers/binding/snapshotenvironmentbinding_adapter_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter_test.go
@@ -292,7 +292,7 @@ var _ = Describe("Binding Adapter", Ordered, func() {
 		Expect(k8sClient.Create(ctx, hasBinding)).Should(Succeed())
 
 		hasBinding.Status = applicationapiv1alpha1.SnapshotEnvironmentBindingStatus{
-			BindingConditions: []metav1.Condition{
+			ComponentDeploymentConditions: []metav1.Condition{
 				{
 					Reason:             "Completed",
 					Status:             "True",
@@ -436,7 +436,7 @@ var _ = Describe("Binding Adapter", Ordered, func() {
 		log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 		hasEnv.Spec.Tags = append(hasEnv.Spec.Tags, "ephemeral")
 		hasBinding.Status = applicationapiv1alpha1.SnapshotEnvironmentBindingStatus{
-			ComponentDeploymentConditions: []metav1.Condition{
+			BindingConditions: []metav1.Condition{
 				{
 					Reason:             "ErrorOccurred",
 					Status:             "True",

--- a/controllers/binding/snapshotenvironmentbinding_controller.go
+++ b/controllers/binding/snapshotenvironmentbinding_controller.go
@@ -23,12 +23,10 @@ import (
 	"github.com/redhat-appstudio/integration-service/helpers"
 	"github.com/redhat-appstudio/integration-service/loader"
 	"github.com/redhat-appstudio/operator-toolkit/controller"
-	"github.com/redhat-appstudio/operator-toolkit/predicates"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -202,8 +200,7 @@ func SetupController(manager ctrl.Manager, log *logr.Logger) error {
 // setupControllerWithManager sets up the controller with the Manager which monitors new SnapshotEnvironmentBindings
 func setupControllerWithManager(manager ctrl.Manager, reconciler *Reconciler) error {
 	return ctrl.NewControllerManagedBy(manager).
-		For(&applicationapiv1alpha1.SnapshotEnvironmentBinding{},
-			builder.WithPredicates(predicates.GenerationUnchangedOnUpdatePredicate{})).
+		For(&applicationapiv1alpha1.SnapshotEnvironmentBinding{}).
 		WithEventFilter(predicate.Or(
 			gitops.DeploymentSucceededForIntegrationBindingPredicate(), gitops.DeploymentFailedForIntegrationBindingPredicate())).
 		Complete(reconciler)

--- a/controllers/binding/snapshotenvironmentbinding_controller.go
+++ b/controllers/binding/snapshotenvironmentbinding_controller.go
@@ -201,7 +201,7 @@ func SetupController(manager ctrl.Manager, log *logr.Logger) error {
 func setupControllerWithManager(manager ctrl.Manager, reconciler *Reconciler) error {
 	return ctrl.NewControllerManagedBy(manager).
 		For(&applicationapiv1alpha1.SnapshotEnvironmentBinding{}).
-		WithEventFilter(predicate.Or(
-			gitops.DeploymentSucceededForIntegrationBindingPredicate(), gitops.DeploymentFailedForIntegrationBindingPredicate())).
+		WithEventFilter(predicate.And(gitops.IntegrationSnapshotEnvironmentBindingPredicate(), predicate.Or(
+			gitops.DeploymentSucceededForIntegrationBindingPredicate(), gitops.DeploymentFailedForIntegrationBindingPredicate()))).
 		Complete(reconciler)
 }

--- a/docs/binding-controller.md
+++ b/docs/binding-controller.md
@@ -6,6 +6,7 @@ flowchart TD
     classDef Amber fill:#FFDEAD;
     classDef Green fill:#BDFFA4;
 
+predicate_integration_seb((PREDICATE: <br>SnapshotEnvironmentBinding<br>is associated with<br>IntegrationTestScenario))
 predicate_deploy_success((PREDICATE:  <br>SnapshotEnvironmentBinding<br>is updated or successfully<br>deployed))
 
 %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureIntegrationTestPipelineForScenarioExists() function
@@ -19,6 +20,7 @@ isPipelineRunExisting{"Does an integration<br>pipelineRun exist?"}
 createNewPipelineRun("Create a new pipelineRun<br>for the snapshot")
 
 %% Node connections
+predicate_integration_seb  ---->       predicate_deploy_success
 predicate_deploy_success   ---->       |"EnsureIntegrationTestPipelineForScenarioExists()"|ensure1
 ensure1                    ---->       isThereAnITS
 isThereAnITS               --No-->     continueProcessing1
@@ -39,6 +41,7 @@ cleanupDeploymentArtifacts("Delete DeploymentTargetClaim and Environment")
 continueProcessing2[/Controller continues processing.../]
 
 %% Node connections
+predicate_integration_seb    ---->       predicate_deploy_fail
 predicate_deploy_fail        ---->       |"EnsureEphemeralEnvironmentsCleanedUp()"|ensure2
 ensure2                      ---->       markSnapshot
 markSnapshot                 ---->       cleanupDeploymentArtifacts
@@ -47,4 +50,5 @@ cleanupDeploymentArtifacts   ---->       continueProcessing2
 %% Assigning styles to nodes
 class predicate_deploy_success Amber;
 class predicate_deploy_fail Amber;
+class predicate_integration_seb Amber;
 ```

--- a/gitops/binding.go
+++ b/gitops/binding.go
@@ -66,7 +66,15 @@ func NewBindingComponents(components []applicationapiv1alpha1.Component) *[]appl
 }
 
 func HaveBindingsFailed(snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding) bool {
-	bindingStatus := meta.FindStatusCondition(snapshotEnvironmentBinding.Status.ComponentDeploymentConditions, BindingErrorOccurredStatusConditionType)
+	bindingStatus := meta.FindStatusCondition(snapshotEnvironmentBinding.Status.BindingConditions, BindingErrorOccurredStatusConditionType)
+	if bindingStatus == nil {
+		return false
+	}
+	return bindingStatus.Status == metav1.ConditionTrue
+}
+
+func IsBindingDeployed(snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding) bool {
+	bindingStatus := meta.FindStatusCondition(snapshotEnvironmentBinding.Status.ComponentDeploymentConditions, BindingDeploymentStatusConditionType)
 	if bindingStatus == nil {
 		return false
 	}

--- a/gitops/predicates.go
+++ b/gitops/predicates.go
@@ -19,13 +19,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// DeploymentFinishedForIntegrationBindingPredicate returns a predicate which filters out update events to a
-// SnapshotEnvironmentBinding that has the IntegrationTestScenario specified in the label and
-// where the component deployment status goes from unknown to true/false.
+// DeploymentSucceededForIntegrationBindingPredicate returns a predicate which filters out update events to a
+// SnapshotEnvironmentBinding whose component deployment status goes from unknown/false to true.
 func DeploymentSucceededForIntegrationBindingPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return hasDeploymentSucceeded(e.ObjectOld, e.ObjectNew) && helpers.HasLabel(e.ObjectNew, SnapshotTestScenarioLabel)
+			return hasDeploymentSucceeded(e.ObjectOld, e.ObjectNew)
 		},
 	}
 }
@@ -36,6 +35,25 @@ func DeploymentFailedForIntegrationBindingPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return hasDeploymentFailed(e.ObjectOld, e.ObjectNew)
+		},
+	}
+}
+
+// IntegrationSnapshotEnvironmentBindingPredicate returns a predicate which filters out update events to a
+// SnapshotEnvironmentBinding associated with an IntegrationTestScenario.
+func IntegrationSnapshotEnvironmentBindingPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return helpers.HasLabel(e.ObjectNew, SnapshotTestScenarioLabel)
 		},
 	}
 }

--- a/gitops/predicates_test.go
+++ b/gitops/predicates_test.go
@@ -168,4 +168,57 @@ var _ = Describe("Predicates", Ordered, func() {
 			Expect(instance.Update(contextEvent)).To(BeTrue())
 		})
 	})
+	Context("when testing IntegrationSnapshotEnvironmentBindingPredicate predicate", func() {
+		instance := gitops.IntegrationSnapshotEnvironmentBindingPredicate()
+		It("returns true when the successfully deployed SEB has the SnapshotTestScenarioLabel set", func() {
+			contextEvent := event.UpdateEvent{
+				ObjectOld: bindingMissingStatus,
+				ObjectNew: bindingTrueStatus,
+			}
+			Expect(instance.Update(contextEvent)).To(BeTrue())
+		})
+
+		It("returns true when the SEB with failed deployment has the SnapshotTestScenarioLabel set", func() {
+			contextEvent := event.UpdateEvent{
+				ObjectOld: bindingMissingStatus,
+				ObjectNew: bindingDeploymentFailedStatus,
+			}
+			Expect(instance.Update(contextEvent)).To(BeTrue())
+		})
+
+		It("returns false when the successfully deployed SEB has the SnapshotTestScenarioLabel not set", func() {
+			bindingTrueStatus.ObjectMeta.Labels = map[string]string{}
+
+			contextEvent := event.UpdateEvent{
+				ObjectOld: bindingMissingStatus,
+				ObjectNew: bindingTrueStatus,
+			}
+			Expect(instance.Update(contextEvent)).To(BeFalse())
+		})
+
+		It("returns false when the SEB with SnapshotTestScenarioLabel is created", func() {
+			bindingMissingStatus.ObjectMeta.Labels = map[string]string{gitops.SnapshotTestScenarioLabel: "test-scenario"}
+
+			contextEvent := event.CreateEvent{
+				Object: bindingMissingStatus,
+			}
+			Expect(instance.Create(contextEvent)).To(BeFalse())
+		})
+		It("returns false when the SEB with SnapshotTestScenarioLabel is deleted", func() {
+			bindingMissingStatus.ObjectMeta.Labels = map[string]string{gitops.SnapshotTestScenarioLabel: "test-scenario"}
+
+			contextEvent := event.DeleteEvent{
+				Object: bindingMissingStatus,
+			}
+			Expect(instance.Delete(contextEvent)).To(BeFalse())
+		})
+		It("returns false when the SEB with SnapshotTestScenarioLabel encounters a generic event", func() {
+			bindingMissingStatus.ObjectMeta.Labels = map[string]string{gitops.SnapshotTestScenarioLabel: "test-scenario"}
+
+			contextEvent := event.GenericEvent{
+				Object: bindingMissingStatus,
+			}
+			Expect(instance.Generic(contextEvent)).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
* The HaveBindingsFailed function was using the wrong condition ComponentDeploymentConditions, changed it to use BindingConditions
* Add additional checks to ensure that EnsureIntegrationTestPipelineForScenarioExists executes correctly
* Add IntegrationSnapshotEnvironmentBindingPredicate to the binding controller to ensure that individual predicates don't filter SEBs that are not for Integration testing
* Cover more of gitops/binding.go with dedicated file
* Add test coverage for updated IsBindingDeployed and HaveBindingsFailed functions

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
