### PR TITLE
chore(CI): add kube-lint

### DIFF
--- a/.github/.kube-linter-config.yaml
+++ b/.github/.kube-linter-config.yaml
@@ -1,0 +1,9 @@
+checks:
+
+  # include explicitly adds checks, by name. You can reference any of the built-in checks.
+  # Note that customChecks defined above are included automatically.
+  include: [ ]
+  # exclude explicitly excludes checks, by name. exclude has the highest priority: if a check is
+  # in exclude, then it is not considered, even if it is in include as well.
+  exclude:
+    - no-read-only-root-fs  # FIXME

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -146,3 +146,23 @@ jobs:
         run: python -m pip install gitlint
       - name: Run gitlint check
         run: gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
+  kube-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # This prepares directory where github/codeql-action/upload-sarif@v1 looks up report files by default.
+      - name: Create ./.kube-linter/ for deployment files
+        shell: bash
+        run: mkdir -p ./.kube-linter/
+      - name: Generate default configuration
+        shell: bash
+        run: kustomize build config/default/ >  ./.kube-linter/deploy-default.yaml
+      - name: Scan yaml files with kube-linter
+        uses: stackrox/kube-linter-action@v1
+        id: kube-linter-action-scan
+        with:
+          # Adjust this directory to the location where your kubernetes resources and helm charts are located.
+          directory: ./.kube-linter/
+          # Adjust this to the location of kube-linter config you're using, or remove the setting if you'd like to use
+          # the default config.
+          config: ./.github/.kube-linter-config.yaml


### PR DESCRIPTION
Kube lint checks for flaws in kubernetes resource definitions

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
