### PR TITLE
feat(STONEINTG-523): Report status of integration tests into snapshot

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -33,6 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const SnapshotEnvironmentBindingErrorTimeoutSeconds float64 = 300
+
 // Adapter holds the objects needed to reconcile a SnapshotEnvironmentBinding.
 type Adapter struct {
 	snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding
@@ -126,20 +128,32 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 	// reasonable time then we assume that the SEB is stuck in an unrecoverable
 	// state and clean it up.  Otherwise we requeue and wait until the timeout
 	// has passed
-	const snapshotEnvironmentBindingErrorTimeoutSeconds float64 = 300
 	var lastTransitionTime time.Time
 	bindingStatus := meta.FindStatusCondition(a.snapshotEnvironmentBinding.Status.BindingConditions, gitops.BindingErrorOccurredStatusConditionType)
 	if bindingStatus != nil {
 		lastTransitionTime = bindingStatus.LastTransitionTime.Time
 	}
 	sinceLastTransition := time.Since(lastTransitionTime).Seconds()
-	if sinceLastTransition < snapshotEnvironmentBindingErrorTimeoutSeconds {
+	if sinceLastTransition < SnapshotEnvironmentBindingErrorTimeoutSeconds {
 		// don't log here, it floods logs
-		return controller.RequeueAfter(time.Duration(snapshotEnvironmentBindingErrorTimeoutSeconds*float64(time.Second)), nil)
-	} else {
-		a.logger.Info(
-			fmt.Sprintf("SEB has been in the error state for more than the threshold time of %f seconds and will be deleted", snapshotEnvironmentBindingErrorTimeoutSeconds),
-		)
+		return controller.RequeueAfter(time.Duration(SnapshotEnvironmentBindingErrorTimeoutSeconds*float64(time.Second)), nil)
+	}
+
+	reasonMsg := "Unknown reason"
+
+	if conditionStatus := gitops.GetBindingConditionStatus(a.snapshotEnvironmentBinding); conditionStatus != nil {
+		reasonMsg = fmt.Sprintf("%s (%s)", conditionStatus.Reason, conditionStatus.Message)
+	}
+	// we don't want to scare users prematurely, report error only after SEB timeout for trying to deploy
+	a.logger.Info(
+		fmt.Sprintf("SEB has been in the error state for more than the threshold time of %f seconds", SnapshotEnvironmentBindingErrorTimeoutSeconds),
+		"reason", reasonMsg,
+	)
+
+	err := a.writeTestStatusIntoSnapshot(gitops.IntegrationTestStatusDeploymentError,
+		fmt.Sprintf("The SnapshotEnvironmentBinding has failed to deploy on ephemeral environment: %s", reasonMsg))
+	if err != nil {
+		return controller.RequeueWithError(fmt.Errorf("failed to update snapshot test status: %w", err))
 	}
 
 	// mark snapshot as failed
@@ -148,7 +162,7 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 	a.logger.Info("The SnapshotEnvironmentBinding encountered an issue deploying snapshot on ephemeral environments",
 		"snapshotEnvironmentBinding.Name", a.snapshotEnvironmentBinding.Name,
 		"message", snapshotErrorMessage)
-	_, err := gitops.MarkSnapshotAsFailed(a.client, a.context, a.snapshot, snapshotErrorMessage)
+	_, err = gitops.MarkSnapshotAsFailed(a.client, a.context, a.snapshot, snapshotErrorMessage)
 	if err != nil {
 		a.logger.Error(err, "Failed to Update Snapshot status")
 		return controller.RequeueWithError(err)
@@ -217,4 +231,19 @@ func (a *Adapter) getDeploymentTargetForEnvironment(environment *applicationapiv
 	}
 
 	return deploymentTarget, nil
+}
+
+// writeTestStatusIntoSnapshot updates test status and instantly writes changes into test result annotation
+func (a *Adapter) writeTestStatusIntoSnapshot(status gitops.IntegrationTestStatus, details string) error {
+	testStatuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(a.snapshot)
+	if err != nil {
+		return err
+	}
+	testStatuses.UpdateTestStatusIfChanged(a.integrationTestScenario.Name, status, details)
+	err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.snapshot, testStatuses, a.client, a.context)
+	if err != nil {
+		return err
+
+	}
+	return nil
 }

--- a/controllers/integrationpipeline/integrationpipeline_controller.go
+++ b/controllers/integrationpipeline/integrationpipeline_controller.go
@@ -108,6 +108,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	adapter := NewAdapter(pipelineRun, component, application, logger, loader, r.Client, ctx)
 
 	return controller.ReconcileHandler([]controller.Operation{
+		adapter.EnsureStatusReportedInSnapshot,
 		adapter.EnsureSnapshotPassedAllTests,
 		adapter.EnsureStatusReported,
 		adapter.EnsureEphemeralEnvironmentsCleanedUp,
@@ -118,6 +119,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 type AdapterInterface interface {
 	EnsureSnapshotPassedAllTests() (controller.OperationResult, error)
 	EnsureStatusReported() (controller.OperationResult, error)
+	EnsureStatusReportedInSnapshot() (controller.OperationResult, error)
 	EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationResult, error)
 }
 

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -603,6 +603,13 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(len(owners) == 1).To(BeTrue())
 			Expect(owners[0].Name).To(Equal(hasApp.Name))
 
+			// Snapshot must have InProgress tests
+			statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(hasSnapshot)
+			Expect(err).To(BeNil())
+			detail, ok := statuses.GetScenarioStatus(integrationTestScenarioWithoutEnv.Name)
+			Expect(ok).To(BeTrue())
+			Expect(detail.Status).To(Equal(gitops.IntegrationTestStatusInProgress))
+
 			err = k8sClient.Delete(ctx, &binding)
 			Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		})

--- a/docs/binding-controller.md
+++ b/docs/binding-controller.md
@@ -38,18 +38,20 @@ predicate_deploy_fail((PREDICATE:  <br>SnapshotEnvironmentBinding<br>fails to de
 ensure2(Proceed further if:<br>Snapshot testing <br> not finished yet)
 isSnapshotOldEnough{"Is lastUpdatedTime greater than the threshold?"}
 requeue[/"Requeue environment cleanup after threshold delay"/]
+reportErrorToSnapshotTestStatus("Report test error into snaphost annotation `test.appstudio.openshift.io/status`")
 markSnapshot("Mark snapshot as failed for failure to deploy")
 cleanupDeploymentArtifacts("Delete DeploymentTargetClaim and Environment")
 continueProcessing2[/Controller continues processing.../]
 
 %% Node connections
-predicate_integration_seb    ---->       predicate_deploy_fail
-predicate_deploy_fail        ---->       |"EnsureEphemeralEnvironmentsCleanedUp()"|ensure2
-ensure2                      ---->       isSnapshotOldEnough
-isSnapshotOldEnough          --No-->     requeue 
-isSnapshotOldEnough          --Yes-->    markSnapshot
-markSnapshot                 ---->       cleanupDeploymentArtifacts
-cleanupDeploymentArtifacts   ---->       continueProcessing2
+predicate_integration_seb       ---->       predicate_deploy_fail
+predicate_deploy_fail           ---->       |"EnsureEphemeralEnvironmentsCleanedUp()"|ensure2
+ensure2                         ---->       isSnapshotOldEnough
+isSnapshotOldEnough             --No-->     requeue
+isSnapshotOldEnough             --Yes-->    reportErrorToSnapshotTestStatus
+reportErrorToSnapshotTestStatus ---->       markSnapshot
+markSnapshot                    ---->       cleanupDeploymentArtifacts
+cleanupDeploymentArtifacts      ---->       continueProcessing2
 
 %% Assigning styles to nodes
 class predicate_deploy_success Amber;

--- a/docs/integration_pipeline_controller.md
+++ b/docs/integration_pipeline_controller.md
@@ -12,9 +12,10 @@ flowchart TD
   %% Node definitions
   predicate((PREDICATE: <br>Integration Pipeline <br> reconciliation))
   get_resources{Get pipeline, <br> component, <br> & application}
+  report_status_snapshot(Report status of the test into snapshot annotation `test.appstudio.openshift.io/status`)
   report_status(Report status if Snapshot was created <br> for Pull requests)
   check_tests{Check Snapshot <br> passed all tests}
-  check_supersede{Does Snapshot need  <br>to be superseded <br> with a composite Snapshot?}  
+  check_supersede{Does Snapshot need  <br>to be superseded <br> with a composite Snapshot?}
   create_snapshot(Create Snapshot)
   update_status(Update status)
   clean_environment(Clean up ephemeral environment <br> if testing finished)
@@ -25,10 +26,11 @@ flowchart TD
   %% Node connections
   predicate                                   --> get_resources
   get_resources     --No                      --> error
-  get_resources     --Yes                     --> report_status
+  get_resources     --Yes                     --> report_status_snapshot
+  report_status_snapshot                    ----> report_status
   report_status     --Yes                     --> check_tests
   check_tests       --No                      --> requeue
-  check_tests       --Yes                     --> check_supersede 
+  check_tests       --Yes                     --> check_supersede
   check_supersede   --yes                     --> create_snapshot
   create_snapshot   --No                      --> requeue
   update_status     --Yes                     --> clean_environment
@@ -36,8 +38,8 @@ flowchart TD
   create_snapshot   --Yes                     --> update_status
   clean_environment --No                      --> requeue
   clean_environment --yes                     ---> continue
-  error                                       --> continue                                  
-  
+  error                                       --> continue
+
   %% Assigning styles to nodes
   class predicate Amber;
   class error,requeue Red;

--- a/docs/snapshot-controller.md
+++ b/docs/snapshot-controller.md
@@ -10,7 +10,7 @@ flowchart TD
 
   predicate((PREDICATE: <br>Snapshot got created OR <br> changed to Finished))
 
-  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureAllIntegrationTestPipelinesExist() function 
+  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureAllIntegrationTestPipelinesExist() function
 
   %% Node definitions
   ensure1(Process further if: Snapshot testing <br>is not finished yet)
@@ -44,7 +44,7 @@ flowchart TD
   mark_snapshot_passed      -->      continue_processing1
 
 
-  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureGlobalCandidateImageUpdated() function 
+  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureGlobalCandidateImageUpdated() function
 
   %% Node definitions
   ensure2(Process further if: Component is not nil & <br>Snapshot testing succeeded & <br>Snapshot was not created by <br>PAC Pull Request Event)
@@ -59,7 +59,7 @@ flowchart TD
   update_last_built_commit -->    continue_processing2
 
 
-  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureAllReleasesExists() function 
+  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureAllReleasesExists() function
 
   %% Node definitions
   ensure3(Process further if: Snapshot is valid & <br>Snapshot testing succeeded & <br>Snapshot was not created by <br>PAC Pull Request Event)
@@ -81,12 +81,13 @@ flowchart TD
   encountered_error32    --Yes--> mark_snapshot_Invalid3
 
 
-  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureCreationOfEnvironment() function 
+  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureCreationOfEnvironment() function
 
   %% Node definitions
   ensure4(Process further if: Snapshot testing <br>is not finished yet)
   step1_fetch_all_ITS(Step 1: Fetch ALL the IntegrationTestScenario <br>for the given Application)
   step2_fetch_all_env(Step 2: Fetch ALL the Environments <br>present in the same namespace)
+  init_test_statuses_snapshot("Initialize test statuses in snapshot.<br>Remove deleted scenarios from snapshot test annotation")
   select_ITS_with_env_defined(For each of the IntegrationTestScenario from Step 1, <br>select the ones that have .spec.environment field defined. <br>And process them in the next steps)
   does_env_already_exists{"Is there any <br>environment (from Step 2), <br>that contains labels with names <br>of current Snapshot and <br>IntegrationTestScenario?"}
   continue_processing4(Controller continues processing...)
@@ -97,14 +98,15 @@ flowchart TD
   predicate                   ---->    |"EnsureCreationOfEnvironment()"|ensure4
   ensure4                     -->      step1_fetch_all_ITS
   step1_fetch_all_ITS         -->      step2_fetch_all_env
-  step2_fetch_all_env         -->      select_ITS_with_env_defined
+  step2_fetch_all_env         -->      init_test_statuses_snapshot
+  init_test_statuses_snapshot -->      select_ITS_with_env_defined
   select_ITS_with_env_defined -->      does_env_already_exists
   does_env_already_exists     --No-->  copy_and_create_eph_env
   does_env_already_exists     --Yes--> continue_processing4
   copy_and_create_eph_env     -->      create_SEB_for_eph_env
 
 
-  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureSnapshotEnvironmentBindingExists() function 
+  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureSnapshotEnvironmentBindingExists() function
 
   %% Node definitions
   ensure5(Process further if: Snapshot is valid & <br>Snapshot testing succeeded & <br>Snapshot was not created by <br>PAC Pull Request Event)
@@ -118,7 +120,7 @@ flowchart TD
 
   %% Node connections
   predicate                  ---->    |"EnsureSnapshotEnvironmentBindingExists()"|ensure5
-  ensure5                    -->      any_existing_non_eph_env 
+  ensure5                    -->      any_existing_non_eph_env
   any_existing_non_eph_env   --Yes--> any_existing_SEB
   any_existing_non_eph_env   --No-->  continue_processing5
   any_existing_SEB           --Yes--> update_existing_SEB

--- a/gitops/binding.go
+++ b/gitops/binding.go
@@ -65,8 +65,13 @@ func NewBindingComponents(components []applicationapiv1alpha1.Component) *[]appl
 	return &bindingComponents
 }
 
-func HaveBindingsFailed(snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding) bool {
+func GetBindingConditionStatus(snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding) *metav1.Condition {
 	bindingStatus := meta.FindStatusCondition(snapshotEnvironmentBinding.Status.BindingConditions, BindingErrorOccurredStatusConditionType)
+	return bindingStatus
+}
+
+func HaveBindingsFailed(snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding) bool {
+	bindingStatus := GetBindingConditionStatus(snapshotEnvironmentBinding)
 	if bindingStatus == nil {
 		return false
 	}

--- a/gitops/binding_test.go
+++ b/gitops/binding_test.go
@@ -201,6 +201,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		}
 
 		Expect(gitops.IsBindingDeployed(hasBinding)).NotTo(BeTrue())
-		Expect(gitops.HaveBindingsFailed(hasBinding)).To(BeTrue())
+		failed := gitops.HaveBindingsFailed(hasBinding)
+		Expect(failed).To(BeTrue())
 	})
 })


### PR DESCRIPTION
An annotation (test.appstudio.openshift.io/status) is added to snapshot and updated when condition of integration tests changes.

This annotation contains metadata of all tests which have been created for the particular snapshot.

Example:
```
test.appstudio.openshift.io/status: [
  {
    "scenario": "scenario-1",
    "Status": "EnvironmentProvisionError",
    "timestamp": "2023-07-26T16:57:49+02:00",
    "details": "Failed ..."
  }
]
```
## TODOs
- [x] agrree on struct/constants/functions naming
- [x] docstrings
- [x] unittest coverage
- [x] devtesting if conflicts are not happening
- [x] missing code: SEB controller, for reporting statuses of SEBs
- [x] missing code: testpipeline controller, for reporting statuses of PLRs
- [x] may we need another status to cover phase when env is being provisioned, but test PLR is not running yet?
- [x] update predicates to ignore annotation changes in snapshot
- [x] performance improvement to prevent fetching test task results too many times 
- [x] update controller diagrams
- [x] remove all `// TODO` comments
- [x] validation of snapshot data loaded from json value
- [x] get details why SEB deployment failed into details

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
