### PR TITLE
fix(STONEINTG-523): refactor get pipeline outcome method

### DIFF
--- a/status/format_test.go
+++ b/status/format_test.go
@@ -3,7 +3,6 @@ package status_test
 import (
 	"time"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/integration-service/helpers"
@@ -25,7 +24,7 @@ const expectedSummary = `| Task | Duration | Test Suite | Status | Details |
 [^example-task-4]: example note 4`
 
 func newTaskRun(name string, startTime time.Time, completionTime time.Time) *helpers.TaskRun {
-	return helpers.NewTaskRunFromTektonTaskRun(logr.Discard(), name, &tektonv1beta1.TaskRunStatus{
+	return helpers.NewTaskRunFromTektonTaskRun(name, &tektonv1beta1.TaskRunStatus{
 		TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
 			StartTime:      &metav1.Time{Time: startTime},
 			CompletionTime: &metav1.Time{Time: completionTime},
@@ -35,7 +34,7 @@ func newTaskRun(name string, startTime time.Time, completionTime time.Time) *hel
 }
 
 func newTaskRunWithAppStudioTestOutput(name string, startTime time.Time, completionTime time.Time, output string) *helpers.TaskRun {
-	return helpers.NewTaskRunFromTektonTaskRun(logr.Discard(), name, &tektonv1beta1.TaskRunStatus{
+	return helpers.NewTaskRunFromTektonTaskRun(name, &tektonv1beta1.TaskRunStatus{
 		TaskRunStatusFields: tektonv1beta1.TaskRunStatusFields{
 			StartTime:      &metav1.Time{Time: startTime},
 			CompletionTime: &metav1.Time{Time: completionTime},

--- a/status/reporters.go
+++ b/status/reporters.go
@@ -172,13 +172,13 @@ func (r *GitHubReporter) createCheckRunAdapter(k8sClient client.Client, ctx cont
 	if succeeded.IsUnknown() {
 		title = scenario + " has started"
 	} else {
-		outcome, err := helpers.CalculateIntegrationPipelineRunOutcome(k8sClient, ctx, r.logger, pipelineRun)
+		outcome, err := helpers.GetIntegrationPipelineRunOutcome(k8sClient, ctx, pipelineRun)
 
 		if err != nil {
 			return nil, err
 		}
 
-		if outcome {
+		if outcome.HasPipelineRunPassedTesting() {
 			title = scenario + " has succeeded"
 			conclusion = "success"
 		} else {
@@ -187,7 +187,7 @@ func (r *GitHubReporter) createCheckRunAdapter(k8sClient client.Client, ctx cont
 		}
 	}
 
-	taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(r.k8sClient, ctx, r.logger, pipelineRun)
+	taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(r.k8sClient, ctx, pipelineRun)
 	if err != nil {
 		return nil, fmt.Errorf("error while getting all child taskRuns from pipelineRun %s: %w", pipelineRun.Name, err)
 	}
@@ -267,12 +267,12 @@ func (r *GitHubReporter) createCommitStatus(k8sClient client.Client, ctx context
 		state = "pending"
 		description = scenario + " has started"
 	} else {
-		outcome, err := helpers.CalculateIntegrationPipelineRunOutcome(k8sClient, ctx, r.logger, pipelineRun)
+		outcome, err := helpers.GetIntegrationPipelineRunOutcome(k8sClient, ctx, pipelineRun)
 		if err != nil {
 			return err
 		}
 
-		if outcome {
+		if outcome.HasPipelineRunPassedTesting() {
 			state = "success"
 			description = scenario + " has succeeded"
 		} else {
@@ -322,19 +322,19 @@ func (r *GitHubReporter) createComment(k8sClient client.Client, ctx context.Cont
 		return err
 	}
 
-	outcome, err := helpers.CalculateIntegrationPipelineRunOutcome(k8sClient, ctx, r.logger, pipelineRun)
+	outcome, err := helpers.GetIntegrationPipelineRunOutcome(k8sClient, ctx, pipelineRun)
 	if err != nil {
 		return err
 	}
 
 	var title string
-	if outcome {
+	if outcome.HasPipelineRunPassedTesting() {
 		title = scenario + " has succeeded"
 	} else {
 		title = scenario + " has failed"
 	}
 
-	taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(r.k8sClient, ctx, r.logger, pipelineRun)
+	taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(r.k8sClient, ctx, pipelineRun)
 	if err != nil {
 		return fmt.Errorf("error while getting all child taskRuns from pipelineRun %s: %w", pipelineRun.Name, err)
 	}


### PR DESCRIPTION
= Created new function to provide test outcome =

Test outcome is now strcuture which also keeps results for further
processing

In reporters.go this function was called even only half of it was needed
as check if pipeline finished is before this call

= Removing log from task result getter =

Usefulness of this log entry is questionable, getter either returns
result or not, we don't have to log result there.

If log is needed, higher function should do it, not getter.

This also simplifies tests and code as we don't need to pass logger into
such low level structure for single use.

= Removal of excessive logging =

Now only integrationpipeline controller logs status of integration test,
a lot fo log duplication has been avoided by removing logging from
helper functions.

This contoller is also the only one that logs content of tasks. Little
bit more refactoring was need to include also tasks name into log, as
without task name result information was not very useful.

= Splitting for future =
For future work I also need to split former outcome function to be able
differentiate between running and finished pipeline.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
