### PR TITLE
fix(codeql): useless assignment to local variable

### DIFF
--- a/controllers/integrationpipeline/integrationpipeline_controller.go
+++ b/controllers/integrationpipeline/integrationpipeline_controller.go
@@ -23,7 +23,6 @@ import (
 	"github.com/redhat-appstudio/integration-service/cache"
 
 	"github.com/go-logr/logr"
-	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/helpers"
 	"github.com/redhat-appstudio/integration-service/loader"
 	"github.com/redhat-appstudio/integration-service/tekton"
@@ -92,8 +91,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	application := &applicationapiv1alpha1.Application{}
-	application, err = loader.GetApplicationFromPipelineRun(r.Client, ctx, pipelineRun)
+	application, err := loader.GetApplicationFromPipelineRun(r.Client, ctx, pipelineRun)
 	if err != nil {
 		logger.Error(err, "Failed to get Application from the integration pipelineRun",
 			"PipelineRun.Name", pipelineRun.Name, "PipelineRun.Namespace", pipelineRun.Namespace)

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -195,8 +195,7 @@ TestScenarioLoop:
 					"integrationScenario.Name", integrationTestScenario.Name)
 
 				//check if the environmentSnapshotBinding exists for this existing environment, create it if it doesn't exist
-				var binding = &applicationapiv1alpha1.SnapshotEnvironmentBinding{}
-				binding, err = a.loader.FindExistingSnapshotEnvironmentBinding(a.client, a.context, a.application, &environment)
+				binding, err := a.loader.FindExistingSnapshotEnvironmentBinding(a.client, a.context, a.application, &environment)
 				if err != nil {
 					a.logger.Error(err, "Failed to find snapshotEnvironmentBinding associated with environment", "environment.Name", environment.Name)
 					return controller.RequeueWithError(err)


### PR DESCRIPTION
Fixing codeql alerts about "Useless assignment to local variable" because it only allocates dead space.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
