### PR TITLE
chore(grafana): don't update grafana in infra-deployments

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -18,7 +18,9 @@ spec:
     - name: infra-deployment-update-script
       value: |
         sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/integration/kustomization.yaml
-        sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
+
+        # Temporary disabled grafana updates
+        # sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
   pipelineRef:
     params:
       - name: bundle


### PR DESCRIPTION
Temporary disable grafana updates into infra-deployments due to non-technical reasons.

Devs must link grafana changes manaully now

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
