### PR TITLE
fix(unitest): integrationpipline has wrong type

### DIFF
--- a/controllers/integrationpipeline/integrationpipeline_controller_test.go
+++ b/controllers/integrationpipeline/integrationpipeline_controller_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Integration PipelineController", func() {
 				Name:      "pipelinerun-sample",
 				Namespace: "default",
 				Labels: map[string]string{
-					"pipelines.appstudio.openshift.io/type": "build",
+					"pipelines.appstudio.openshift.io/type": "test",
 					"pipelines.openshift.io/used-by":        "build-cloud",
 					"pipelines.openshift.io/runtime":        "nodejs",
 					"pipelines.openshift.io/strategy":       "s2i",


### PR DESCRIPTION
Integration PLR has a wrong type label in the test suite.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
