### PR TITLE
fix(STONEINTG-566): run container with read-only root filesystem

### DIFF
--- a/.github/.kube-linter-config.yaml
+++ b/.github/.kube-linter-config.yaml
@@ -5,5 +5,4 @@ checks:
   include: [ ]
   # exclude explicitly excludes checks, by name. exclude has the highest priority: if a check is
   # in exclude, then it is not considered, even if it is in include as well.
-  exclude:
-    - no-read-only-root-fs  # FIXME
+  exclude: [ ]

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -27,6 +27,8 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,7 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Security improvement, containers are not supposed to write to root filesystem

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
