### PR TITLE
feat(stoneintg-586): add timeout to detect ephemeral SEB errors

### DIFF
--- a/docs/binding-controller.md
+++ b/docs/binding-controller.md
@@ -36,6 +36,8 @@ predicate_deploy_fail((PREDICATE:  <br>SnapshotEnvironmentBinding<br>fails to de
 
 %% Node definitions
 ensure2(Proceed further if:<br>Snapshot testing <br> not finished yet)
+isSnapshotOldEnough{"Is lastUpdatedTime greater than the threshold?"}
+requeue[/"Requeue environment cleanup after threshold delay"/]
 markSnapshot("Mark snapshot as failed for failure to deploy")
 cleanupDeploymentArtifacts("Delete DeploymentTargetClaim and Environment")
 continueProcessing2[/Controller continues processing.../]
@@ -43,7 +45,9 @@ continueProcessing2[/Controller continues processing.../]
 %% Node connections
 predicate_integration_seb    ---->       predicate_deploy_fail
 predicate_deploy_fail        ---->       |"EnsureEphemeralEnvironmentsCleanedUp()"|ensure2
-ensure2                      ---->       markSnapshot
+ensure2                      ---->       isSnapshotOldEnough
+isSnapshotOldEnough          --No-->     requeue 
+isSnapshotOldEnough          --Yes-->    markSnapshot
 markSnapshot                 ---->       cleanupDeploymentArtifacts
 cleanupDeploymentArtifacts   ---->       continueProcessing2
 


### PR DESCRIPTION
It is not possible to know whether an ephemeral SEB is in an unrecoverable state.  This change implements a workaround wherein if an SEB still has the 'ErrorOccured' condition set to 'True' after five minutes the SEB will be assumed to be unrecoverable and will be cleaned up.

## Maintainers will complete the following section

- [X] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [X] Code coverage from testing does not decrease and new code is covered
- [X] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
