### PR TITLE
feat(STONEINTG-524): Report result of handling ITS to github in a new controller

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/redhat-appstudio/integration-service/controllers/integrationpipeline"
 	"github.com/redhat-appstudio/integration-service/controllers/scenario"
 	"github.com/redhat-appstudio/integration-service/controllers/snapshot"
+	"github.com/redhat-appstudio/integration-service/controllers/statusreport"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -34,6 +35,7 @@ var setupFunctions = []func(manager.Manager, *logr.Logger) error{
 	snapshot.SetupController,
 	scenario.SetupController,
 	binding.SetupController,
+	statusreport.SetupController,
 }
 
 // SetupControllers invoke all SetupController functions defined in setupFunctions, setting all controllers up and

--- a/controllers/integrationpipeline/integrationpipeline_adapter_test.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter_test.go
@@ -60,7 +60,12 @@ func (r *MockStatusReporter) ReportStatus(client.Client, context.Context, *tekto
 	return r.ReportStatusError
 }
 
-func (a *MockStatusAdapter) GetReporters(pipelineRun *tektonv1beta1.PipelineRun) ([]status.Reporter, error) {
+func (r *MockStatusReporter) ReportStatusForSnapshot(client.Client, context.Context, *helpers.IntegrationLogger, *applicationapiv1alpha1.Snapshot) error {
+	r.Called = true
+	return r.ReportStatusError
+}
+
+func (a *MockStatusAdapter) GetReporters(object client.Object) ([]status.Reporter, error) {
 	return []status.Reporter{a.Reporter}, a.GetReportersError
 }
 

--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusreport
+
+import (
+	"context"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/helpers"
+	"github.com/redhat-appstudio/integration-service/status"
+
+	"github.com/redhat-appstudio/integration-service/loader"
+	"github.com/redhat-appstudio/operator-toolkit/controller"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Adapter holds the objects needed to reconcile a snapshot's test status report.
+type Adapter struct {
+	snapshot    *applicationapiv1alpha1.Snapshot
+	application *applicationapiv1alpha1.Application
+	logger      helpers.IntegrationLogger
+	loader      loader.ObjectLoader
+	client      client.Client
+	context     context.Context
+	status      status.Status
+}
+
+// NewAdapter creates and returns an Adapter instance.
+func NewAdapter(snapshot *applicationapiv1alpha1.Snapshot, application *applicationapiv1alpha1.Application, logger helpers.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
+	context context.Context) *Adapter {
+	return &Adapter{
+		snapshot:    snapshot,
+		application: application,
+		logger:      logger,
+		loader:      loader,
+		client:      client,
+		context:     context,
+		status:      status.NewAdapter(logger.Logger, client),
+	}
+}
+
+// EnsureSnapshotTestStatusReported will ensure that integration test status including env provision and snapshotEnvironmentBinding error is reported to the git provider
+// which (indirectly) triggered its execution.
+func (a *Adapter) EnsureSnapshotTestStatusReported() (controller.OperationResult, error) {
+	reporters, err := a.status.GetReporters(a.snapshot)
+	if err != nil {
+		return controller.RequeueWithError(err)
+	}
+
+	for _, reporter := range reporters {
+		if err := reporter.ReportStatusForSnapshot(a.client, a.context, &a.logger, a.snapshot); err != nil {
+			a.logger.Error(err, "failed to report test status to github for snapshot",
+				"snapshot.Namespace", a.snapshot.Namespace, "snapshot.Name", a.snapshot.Name)
+			return controller.RequeueWithError(err)
+		}
+	}
+
+	return controller.ContinueProcessing()
+}

--- a/controllers/statusreport/statusreport_adapter_test.go
+++ b/controllers/statusreport/statusreport_adapter_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusreport
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/loader"
+	"github.com/redhat-appstudio/integration-service/status"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/redhat-appstudio/integration-service/gitops"
+	"github.com/redhat-appstudio/integration-service/helpers"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type MockStatusAdapter struct {
+	Reporter          *MockStatusReporter
+	GetReportersError error
+}
+
+type MockStatusReporter struct {
+	Called            bool
+	ReportStatusError error
+}
+
+func (r *MockStatusReporter) ReportStatus(client.Client, context.Context, *tektonv1beta1.PipelineRun) error {
+	r.Called = true
+	return r.ReportStatusError
+}
+
+func (r *MockStatusReporter) ReportStatusForSnapshot(client.Client, context.Context, *helpers.IntegrationLogger, *applicationapiv1alpha1.Snapshot) error {
+	r.Called = true
+	r.ReportStatusError = nil
+	return r.ReportStatusError
+}
+
+func (a *MockStatusAdapter) GetReporters(object client.Object) ([]status.Reporter, error) {
+	return []status.Reporter{a.Reporter}, a.GetReportersError
+}
+
+var _ = Describe("Snapshot Adapter", Ordered, func() {
+	var (
+		adapter        *Adapter
+		logger         helpers.IntegrationLogger
+		statusAdapter  *MockStatusAdapter
+		statusReporter *MockStatusReporter
+
+		hasApp      *applicationapiv1alpha1.Application
+		hasSnapshot *applicationapiv1alpha1.Snapshot
+	)
+	const (
+		SampleRepoLink  = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		sample_image    = "quay.io/redhat-appstudio/sample-image"
+		sample_revision = "random-value"
+	)
+
+	BeforeAll(func() {
+		hasApp = &applicationapiv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "application-sample",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ApplicationSpec{
+				DisplayName: "application-sample",
+				Description: "This is an example application",
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
+
+		hasSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:                         "component",
+					gitops.SnapshotComponentLabel:                    "component-sample",
+					"build.appstudio.redhat.com/pipeline":            "enterprise-contract",
+					gitops.PipelineAsCodeEventTypeLabel:              "pull_request",
+					"pac.test.appstudio.openshift.io/url-org":        "testorg",
+					"pac.test.appstudio.openshift.io/url-repository": "testrepo",
+					"pac.test.appstudio.openshift.io/sha":            "testsha",
+					gitops.PipelineAsCodeGitProviderLabel:            gitops.PipelineAsCodeGitHubProviderType,
+				},
+				Annotations: map[string]string{
+					gitops.PipelineAsCodeInstallationIDAnnotation:   "123",
+					"build.appstudio.redhat.com/commit_sha":         "6c65b2fcaea3e1a0a92476c8b5dc89e92a85f025",
+					"appstudio.redhat.com/updateComponentOnSuccess": "false",
+					gitops.SnapshotTestsStatusAnnotation:            "[{\"scenario\":\"scenario-1\",\"status\":\"EnvironmentProvisionError\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"completionTime\":\"2023-07-26T17:57:49+02:00\",\"lastUpdateTime\":\"2023-08-26T17:57:49+02:00\",\"details\":\"Failed to find deploymentTargetClass with right provisioner for copy of existingEnvironment\"}]",
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "component-sample",
+						ContainerImage: sample_image,
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{
+									Revision: sample_revision,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasSnapshot)).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		err := k8sClient.Delete(ctx, hasSnapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasApp)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	When("adapter is created", func() {
+		It("can create a new Adapter instance", func() {
+			Expect(reflect.TypeOf(NewAdapter(hasSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
+		})
+
+		It("ensures the statusResport is called", func() {
+			adapter = NewAdapter(hasSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			statusReporter = &MockStatusReporter{}
+			statusAdapter = &MockStatusAdapter{Reporter: statusReporter}
+			adapter.status = statusAdapter
+			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasSnapshot,
+				},
+			})
+			result, err := adapter.EnsureSnapshotTestStatusReported()
+			fmt.Fprintf(GinkgoWriter, "-------err: %v\n", err)
+			fmt.Fprintf(GinkgoWriter, "-------result: %v\n", result)
+			Expect(!result.CancelRequest && err == nil).To(BeTrue())
+		})
+	})
+
+})

--- a/controllers/statusreport/statusreport_controller.go
+++ b/controllers/statusreport/statusreport_controller.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions andF
+limitations under the License.
+*/
+
+package statusreport
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/gitops"
+	"github.com/redhat-appstudio/integration-service/helpers"
+	"github.com/redhat-appstudio/integration-service/loader"
+	"github.com/redhat-appstudio/operator-toolkit/controller"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// Reconciler reconciles an Snapshot object
+type Reconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// NewStatusReportReconciler creates and returns a Reconciler.
+func NewStatusReportReconciler(client client.Client, logger *logr.Logger, scheme *runtime.Scheme) *Reconciler {
+	return &Reconciler{
+		Client: client,
+		Log:    logger.WithName("statusreport"),
+		Scheme: scheme,
+	}
+}
+
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=snapshots,verbs=get;list;watch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=snapshots/status,verbs=get
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications,verbs=get;list;watch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/status,verbs=get
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := helpers.IntegrationLogger{Logger: r.Log.WithValues("snapshot", req.NamespacedName)}
+	loader := loader.NewLoader()
+
+	logger.Info("start to process snapshot test status since there is change in annotation test.appstudio.openshift.io/status", "snapshot", req.NamespacedName)
+
+	snapshot := &applicationapiv1alpha1.Snapshot{}
+	err := r.Get(ctx, req.NamespacedName, snapshot)
+	if err != nil {
+		logger.Error(err, "Failed to get snapshot for", "req", req.NamespacedName)
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, err
+	}
+
+	application, err := loader.GetApplicationFromSnapshot(r.Client, ctx, snapshot)
+	if err != nil {
+		logger.Error(err, "Failed to get Application from the Snapshot")
+		return ctrl.Result{}, err
+	}
+	logger = logger.WithApp(*application)
+
+	adapter := NewAdapter(snapshot, application, logger, loader, r.Client, ctx)
+	return controller.ReconcileHandler([]controller.Operation{
+		adapter.EnsureSnapshotTestStatusReported,
+	})
+}
+
+// AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
+type AdapterInterface interface {
+	EnsureSnapshotTestStatusReported() (controller.OperationResult, error)
+}
+
+// SetupController creates a new Integration controller and adds it to the Manager.
+func SetupController(manager ctrl.Manager, log *logr.Logger) error {
+	return setupControllerWithManager(manager, NewStatusReportReconciler(manager.GetClient(), log, manager.GetScheme()))
+}
+
+// setupControllerWithManager sets up the controller with the Manager which monitors new Snapshots
+func setupControllerWithManager(manager ctrl.Manager, controller *Reconciler) error {
+	return ctrl.NewControllerManagedBy(manager).
+		For(&applicationapiv1alpha1.Snapshot{}).
+		WithEventFilter(predicate.Or(
+			gitops.PRSnapshotTestAnnotationChangePredicate())).
+		Complete(controller)
+}

--- a/controllers/statusreport/statusreport_controller_test.go
+++ b/controllers/statusreport/statusreport_controller_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusreport
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/gitops"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	klog "k8s.io/klog/v2"
+)
+
+var _ = Describe("StatusReportController", func() {
+	var (
+		manager                ctrl.Manager
+		statusReportReconciler *Reconciler
+		scheme                 runtime.Scheme
+		req                    ctrl.Request
+		hasApp                 *applicationapiv1alpha1.Application
+		hasSnapshot            *applicationapiv1alpha1.Snapshot
+	)
+
+	BeforeEach(func() {
+
+		applicationName := "application-sample"
+
+		hasApp = &applicationapiv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      applicationName,
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ApplicationSpec{
+				DisplayName: "application-sample",
+				Description: "This is an example application",
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
+
+		hasSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:      "component",
+					gitops.SnapshotComponentLabel: "component-sample",
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "component-sample",
+						ContainerImage: "testimage",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasSnapshot)).Should(Succeed())
+
+		req = ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "default",
+				Name:      hasSnapshot.Name,
+			},
+		}
+
+		webhookInstallOptions := &testEnv.WebhookInstallOptions
+
+		klog.Info(webhookInstallOptions.LocalServingHost)
+		klog.Info(webhookInstallOptions.LocalServingPort)
+		klog.Info(webhookInstallOptions.LocalServingCertDir)
+
+		var err error
+		manager, err = ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:             clientsetscheme.Scheme,
+			Host:               webhookInstallOptions.LocalServingHost,
+			Port:               webhookInstallOptions.LocalServingPort,
+			CertDir:            webhookInstallOptions.LocalServingCertDir,
+			MetricsBindAddress: "0", // this disables metrics
+			LeaderElection:     false,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(err).To(BeNil())
+
+		statusReportReconciler = NewStatusReportReconciler(k8sClient, &logf.Log, &scheme)
+	})
+	AfterEach(func() {
+		err := k8sClient.Delete(ctx, hasApp)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasSnapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("can create and return a new Reconciler object", func() {
+		Expect(reflect.TypeOf(statusReportReconciler)).To(Equal(reflect.TypeOf(&Reconciler{})))
+	})
+
+	It("can Reconcile when Reconcile fails to prepare the adapter when snapshot is found", func() {
+		Eventually(func() error {
+			_, err := statusReportReconciler.Reconcile(ctx, req)
+			return err
+		}).Should(BeNil())
+	})
+
+	It("can Reconcile function prepare the adapter and return the result of the reconcile handling operation", func() {
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "non-existent",
+				Namespace: "default",
+			},
+		}
+		result, err := statusReportReconciler.Reconcile(ctx, req)
+		Expect(reflect.TypeOf(result)).To(Equal(reflect.TypeOf(reconcile.Result{})))
+		Expect(err).To(BeNil())
+	})
+
+	It("can setup a new controller manager with the given statusReportReconciler", func() {
+		err := setupControllerWithManager(manager, statusReportReconciler)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("can setup a new Controller manager and start it", func() {
+		err := SetupController(manager, &ctrl.Log)
+		Expect(err).To(BeNil())
+		go func() {
+			defer GinkgoRecover()
+			err = manager.Start(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+	})
+
+})

--- a/controllers/statusreport/statusreport_suite_test.go
+++ b/controllers/statusreport/statusreport_suite_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusreport
+
+import (
+	"context"
+	"go/build"
+	"path/filepath"
+	"testing"
+
+	toolkit "github.com/redhat-appstudio/operator-toolkit/test"
+
+	"k8s.io/client-go/rest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/api/v1beta1"
+	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestControllerSnapshot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "StatusReport Controller Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	//adding required CRDs, including tekton for PipelineRun Kind
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", toolkit.GetRelativeDependencyPath("tektoncd/pipeline"), "config",
+			),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", toolkit.GetRelativeDependencyPath("application-api"),
+				"config", "crd", "bases",
+			),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", toolkit.GetRelativeDependencyPath("release-service"), "config", "crd", "bases",
+			),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	Expect(applicationapiv1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(tektonv1beta1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(releasev1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(v1beta1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+
+	k8sManager, _ := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             clientsetscheme.Scheme,
+		MetricsBindAddress: "0", // this disables metrics
+		LeaderElection:     false,
+	})
+
+	k8sClient = k8sManager.GetClient()
+	go func() {
+		defer GinkgoRecover()
+		Expect(k8sManager.Start(ctx)).To(Succeed())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/docs/statusreport-controller.md
+++ b/docs/statusreport-controller.md
@@ -1,0 +1,63 @@
+<div align="center"><h1>StatusReport Controller</h1></div>
+
+```mermaid
+%%{init: {'theme':'forest'}}%%
+flowchart TD
+  %% Defining the styles
+    classDef Amber fill:#FFDEAD;
+
+  predicate((PREDICATE: <br>Snapshot has annotation <br>test.appstudio.openshift.io/status <br>changed))
+
+  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureSnapshotTestStatusReported() function 
+
+  %% Node definitions
+  ensure(Process further if: Snapshot has label <br>pac.test.appstudio.openshift.io/git-provider:github <br>defined)
+  get_annotation_value(Get integration test status from annotation <br>test.appstudio.openshift.io/status <br>from Snapshot)
+  collect_commit_info(Collect commit owner, repo and SHA from Snapshot)
+
+  is_installation_defined{Is annotation <br>pac.test.appstudio.openshift.io/installation-id <br>defined?}
+
+  create_appInstallation_token(Create github application installation token)
+  get_all_checkRuns_from_gh(Get all checkruns from github <br>according to <br>commit owner, repo and SHA)
+  create_checkRunAdapter(Create checkRun adapter according to <br>commit owner, repo, SHA <br>and integration test status)
+  does_checkRun_exist{Does checkRun exist <br>on github already?}
+  create_new_checkRun_on_gh(Create new checkrun on github)
+  is_checkRun_update_needed{Does existing checkRun <br>have different text?}
+  update_existing_checkRun_on_gh(Update existing checkRun on github)
+
+  set_oAuth_token(Get token from Snapshot and set oAuth token)
+  get_all_commitStatuses_from_gh(Get all commitStatuses from github <br>according to commit owner, repo and SHA)
+  create_commitStatusAdapter(Create commitStatusAdapter according to <br>commit owner, repo, SHA <br>and integration test status)
+  does_commitStatus_exist{Does commitStatus exist <br>on github already?}
+  create_new_commitStatus_on_gh(Create new commitStatus on github)
+
+  continue_processing(Controller continues processing)
+
+  %% Node connections
+  predicate                      ---->    |"EnsureSnapshotTestStatusReported()"|ensure
+  ensure                         -->      get_annotation_value
+  get_annotation_value           -->      collect_commit_info
+  collect_commit_info            --> is_installation_defined
+  is_installation_defined        --Yes--> create_appInstallation_token
+  is_installation_defined        --No--> set_oAuth_token
+
+  create_appInstallation_token   --> get_all_checkRuns_from_gh
+  get_all_checkRuns_from_gh      --> create_checkRunAdapter
+  create_checkRunAdapter         --> does_checkRun_exist
+  does_checkRun_exist            --Yes--> is_checkRun_update_needed
+  does_checkRun_exist            --No--> create_new_checkRun_on_gh
+  create_new_checkRun_on_gh      --> continue_processing
+  is_checkRun_update_needed      --Yes--> update_existing_checkRun_on_gh
+  is_checkRun_update_needed      --No--> continue_processing
+  update_existing_checkRun_on_gh --> continue_processing
+
+  set_oAuth_token                --> get_all_commitStatuses_from_gh
+  get_all_commitStatuses_from_gh --> create_commitStatusAdapter
+  create_commitStatusAdapter     --> does_commitStatus_exist
+  does_commitStatus_exist        --Yes--> continue_processing
+  does_commitStatus_exist        --No--> create_new_commitStatus_on_gh
+  create_new_commitStatus_on_gh  --> continue_processing
+
+  %% Assigning styles to nodes
+  class predicate Amber;
+```

--- a/git/github/github_test.go
+++ b/git/github/github_test.go
@@ -55,9 +55,25 @@ func (MockChecksService) ListCheckRunsForRef(
 ) (*ghapi.ListCheckRunsResults, *ghapi.Response, error) {
 	var id int64 = 20
 	var externalID string = "example-external-id"
-	checkRuns := []*ghapi.CheckRun{{ID: &id, ExternalID: &externalID}}
+	var text string = "example-text-update"
+	var checkRunOutput = ghapi.CheckRunOutput{Text: &text}
+	conclusion := "failure"
+	checkRuns := []*ghapi.CheckRun{{ID: &id, ExternalID: &externalID, Conclusion: &conclusion, Output: &checkRunOutput}}
 	total := len(checkRuns)
 	return &ghapi.ListCheckRunsResults{Total: &total, CheckRuns: checkRuns}, nil, nil
+}
+
+// GetAllCheckRunsForRef implements github.ChecksService
+func (MockChecksService) GetAllCheckRunsForRef(
+	ctx context.Context, owner string, repo string, ref string, appID int64,
+) ([]*ghapi.CheckRun, error) {
+	var id int64 = 20
+	var externalID string = "example-external-id"
+	var text string = "example-text-update"
+	var checkRunOutput = ghapi.CheckRunOutput{Text: &text}
+	conclusion := "failure"
+	checkRuns := []*ghapi.CheckRun{{ID: &id, ExternalID: &externalID, Conclusion: &conclusion, Output: &checkRunOutput}}
+	return checkRuns, nil
 }
 
 // UpdateCheckRun implements github.ChecksService
@@ -89,6 +105,18 @@ func (MockRepositoriesService) CreateStatus(
 	return &ghapi.RepoStatus{ID: &id, State: &state}, nil, nil
 }
 
+// ListStatuses implements github.RepositoriesService
+func (MockRepositoriesService) ListStatuses(
+	ctx context.Context, owner string, repo string, ref string, opts *ghapi.ListOptions,
+) ([]*ghapi.RepoStatus, *ghapi.Response, error) {
+	var id int64 = 60
+	var state = "success"
+	var description = "example-description"
+	var context = "example-context"
+	repoStatus := &ghapi.RepoStatus{ID: &id, State: &state, Description: &description, Context: &context}
+	return []*ghapi.RepoStatus{repoStatus}, nil, nil
+}
+
 var _ = Describe("CheckRunAdapter", func() {
 	It("can compute status", func() {
 		adapter := &github.CheckRunAdapter{Conclusion: "success", StartTime: time.Time{}}
@@ -118,12 +146,21 @@ var _ = Describe("Client", func() {
 		Repository:     "example-repo",
 		SHA:            "abcdef1",
 		ExternalID:     "example-external-id",
-		Conclusion:     "success",
+		Conclusion:     "Passed",
 		Title:          "example-title",
 		Summary:        "example-summary",
 		Text:           "example-text",
 		StartTime:      time.Now(),
 		CompletionTime: time.Now(),
+	}
+
+	var commitStatusAdapter = &github.CommitStatusAdapter{
+		Owner:       "example-owner",
+		Repository:  "example-repo",
+		SHA:         "abcdef1",
+		State:       "success",
+		Description: "example-description",
+		Context:     "example-context",
 	}
 
 	BeforeEach(func() {
@@ -194,5 +231,66 @@ var _ = Describe("Client", func() {
 		checkRunID, err = client.GetCheckRunID(context.TODO(), "", "", "", "unknown-external-id", 1)
 		Expect(err).To(BeNil())
 		Expect(checkRunID).To(BeNil())
+	})
+
+	It("can check if check run updated is needed", func() {
+		var checkRunAdapter = &github.CheckRunAdapter{
+			Name:           "example-name",
+			Owner:          "example-owner",
+			Repository:     "example-repo",
+			SHA:            "abcdef1",
+			ExternalID:     "example-external-id",
+			Conclusion:     "success",
+			Title:          "example-title",
+			Summary:        "example-summary",
+			Text:           "example-text",
+			StartTime:      time.Now(),
+			CompletionTime: time.Now(),
+		}
+
+		allCheckRuns, err := client.GetAllCheckRunsForRef(context.TODO(), "", "", "", 1)
+		Expect(err).To(BeNil())
+		Expect(len(allCheckRuns) > 0).To(BeTrue())
+
+		existingCheckRun := client.GetExistingCheckRun(allCheckRuns, checkRunAdapter)
+		Expect(existingCheckRun).NotTo(BeNil())
+		Expect(client.IsUpdateNeeded(existingCheckRun, checkRunAdapter)).To(BeTrue())
+
+		checkRunAdapter = &github.CheckRunAdapter{
+			Name:           "example-name",
+			Owner:          "example-owner",
+			Repository:     "example-repo",
+			SHA:            "abcdef1",
+			ExternalID:     "example-external-id",
+			Conclusion:     "failure",
+			Title:          "example-title",
+			Summary:        "example-summary",
+			Text:           "example-text-update",
+			StartTime:      time.Now(),
+			CompletionTime: time.Now(),
+		}
+		Expect(client.IsUpdateNeeded(existingCheckRun, checkRunAdapter)).To(BeFalse())
+	})
+
+	It("can check if creating a new commit status is needed", func() {
+		commitStatuses, err := client.GetAllCommitStatusesForRef(context.TODO(), "", "", "")
+		Expect(err).To(BeNil())
+		Expect(len(commitStatuses) > 0).To(BeTrue())
+
+		commitStatusExist, err := client.CommitStatusExists(commitStatuses, commitStatusAdapter)
+		Expect(commitStatusExist).To(BeTrue())
+		Expect(err).To(BeNil())
+
+		commitStatusAdapter = &github.CommitStatusAdapter{
+			Owner:       "example-owner",
+			Repository:  "example-repo",
+			SHA:         "abcdef1",
+			State:       "failure",
+			Description: "example-description",
+			Context:     "example-context",
+		}
+		commitStatusExist, err = client.CommitStatusExists(commitStatuses, commitStatusAdapter)
+		Expect(commitStatusExist).To(BeFalse())
+		Expect(err).To(BeNil())
 	})
 })

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -118,6 +118,24 @@ const (
 
 	//AppStudioIntegrationStatusFinished is the reason that's set when the AppStudio tests finish.
 	AppStudioIntegrationStatusFinished = "Finished"
+
+	// the statuses needed to report to GiHub when creating check run or commit status, see doc
+	// https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks?apiVersion=2022-11-28
+	// https://docs.github.com/en/free-pro-team@latest/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run
+	//IntegrationTestStatusPendingGithub is the status reported to github when integration test is in a queue
+	IntegrationTestStatusPendingGithub = "pending"
+
+	//IntegrationTestStatusSuccessGithub is the status reported to github when integration test succeed
+	IntegrationTestStatusSuccessGithub = "success"
+
+	//IntegrationTestStatusFailureGithub is the status reported to github when integration test fail
+	IntegrationTestStatusFailureGithub = "failure"
+
+	//IntegrationTestStatusErrorGithub is the status reported to github when integration test experience error
+	IntegrationTestStatusErrorGithub = "error"
+
+	//IntegrationTestStatusInProgressGithub is the status reported to github when integration test is in progress
+	IntegrationTestStatusInProgressGithub = "in_progress"
 )
 
 // IntegrationTestScenario test runs status
@@ -410,6 +428,26 @@ func HasSnapshotTestingChangedToFinished(objectOld, objectNew client.Object) boo
 	if oldSnapshot, ok := objectOld.(*applicationapiv1alpha1.Snapshot); ok {
 		if newSnapshot, ok := objectNew.(*applicationapiv1alpha1.Snapshot); ok {
 			return !HaveAppStudioTestsFinished(oldSnapshot) && HaveAppStudioTestsFinished(newSnapshot)
+		}
+	}
+	return false
+}
+
+// HasSnapshotTestAnnotationChanged returns a boolean indicating whether the Snapshot annotation has
+// changed. If the objects passed to this function are not Snapshots, the function will return false.
+func HasSnapshotTestAnnotationChanged(objectOld, objectNew client.Object) bool {
+	if oldSnapshot, ok := objectOld.(*applicationapiv1alpha1.Snapshot); ok {
+		if newSnapshot, ok := objectNew.(*applicationapiv1alpha1.Snapshot); ok {
+			if !metadata.HasAnnotation(oldSnapshot, SnapshotTestsStatusAnnotation) && metadata.HasAnnotation(newSnapshot, SnapshotTestsStatusAnnotation) {
+				return true
+			}
+			if old_value, ok := oldSnapshot.GetAnnotations()[SnapshotTestsStatusAnnotation]; ok {
+				if new_value, ok := newSnapshot.GetAnnotations()[SnapshotTestsStatusAnnotation]; ok {
+					if old_value != new_value {
+						return true
+					}
+				}
+			}
 		}
 	}
 	return false

--- a/gitops/snapshot_predicate.go
+++ b/gitops/snapshot_predicate.go
@@ -1,6 +1,7 @@
 package gitops
 
 import (
+	"github.com/redhat-appstudio/operator-toolkit/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -20,6 +21,25 @@ func IntegrationSnapshotChangePredicate() predicate.Predicate {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return HasSnapshotTestingChangedToFinished(e.ObjectOld, e.ObjectNew)
+		},
+	}
+}
+
+// PRSnapshotTestAnnotationChangePredicate returns a predicate which filters out all objects except
+// pull_request snapshot annotation "test.appstudio.openshift.io/status" is changed for update events.
+func PRSnapshotTestAnnotationChangePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return HasSnapshotTestAnnotationChanged(e.ObjectOld, e.ObjectNew) && metadata.HasLabelWithValue(e.ObjectNew, PipelineAsCodeEventTypeLabel, PipelineAsCodePullRequestType)
 		},
 	}
 }

--- a/status/reporters.go
+++ b/status/reporters.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/git/github"
 	"github.com/redhat-appstudio/integration-service/gitops"
 	"github.com/redhat-appstudio/integration-service/helpers"
@@ -57,12 +58,12 @@ type appCredentials struct {
 	PrivateKey     []byte
 }
 
-func (r *GitHubReporter) getAppCredentials(ctx context.Context, pipelineRun *tektonv1beta1.PipelineRun) (*appCredentials, error) {
+func (r *GitHubReporter) getAppCredentials(ctx context.Context, object client.Object) (*appCredentials, error) {
 	var err error
 	var found bool
 	appInfo := appCredentials{}
 
-	appInfo.InstallationID, err = strconv.ParseInt(pipelineRun.GetAnnotations()[gitops.PipelineAsCodeInstallationIDAnnotation], 10, 64)
+	appInfo.InstallationID, err = strconv.ParseInt(object.GetAnnotations()[gitops.PipelineAsCodeInstallationIDAnnotation], 10, 64)
 	if err != nil {
 		return nil, err
 	}
@@ -94,19 +95,19 @@ func (r *GitHubReporter) getAppCredentials(ctx context.Context, pipelineRun *tek
 	return &appInfo, nil
 }
 
-func (r *GitHubReporter) getToken(ctx context.Context, pipelineRun *tektonv1beta1.PipelineRun) (string, error) {
+func (r *GitHubReporter) getToken(ctx context.Context, object client.Object, namespace string) (string, error) {
 	var err error
 
-	// List all the Repository CRs in the PipelineRun's namespace
+	// List all the Repository CRs in the namespace
 	repos := pacv1alpha1.RepositoryList{}
-	if err = r.k8sClient.List(ctx, &repos, &client.ListOptions{Namespace: pipelineRun.Namespace}); err != nil {
+	if err = r.k8sClient.List(ctx, &repos, &client.ListOptions{Namespace: namespace}); err != nil {
 		return "", err
 	}
 
 	// Get the full repo URL
-	url, found := pipelineRun.GetAnnotations()[gitops.PipelineAsCodeRepoURLAnnotation]
+	url, found := object.GetAnnotations()[gitops.PipelineAsCodeRepoURLAnnotation]
 	if !found {
-		return "", fmt.Errorf("PipelineRun annotation not found %q", gitops.PipelineAsCodeRepoURLAnnotation)
+		return "", fmt.Errorf("object annotation not found %q", gitops.PipelineAsCodeRepoURLAnnotation)
 	}
 
 	// Find a Repository CR with a matching URL and get its secret details
@@ -124,7 +125,7 @@ func (r *GitHubReporter) getToken(ctx context.Context, pipelineRun *tektonv1beta
 
 	// Get the pipelines as code secret from the PipelineRun's namespace
 	pacSecret := v1.Secret{}
-	err = r.k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineRun.Namespace, Name: repoSecret.Name}, &pacSecret)
+	err = r.k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: repoSecret.Name}, &pacSecret)
 	if err != nil {
 		return "", err
 	}
@@ -226,6 +227,116 @@ func (r *GitHubReporter) createCheckRunAdapter(k8sClient client.Client, ctx cont
 	}, nil
 }
 
+// generateSummary generate a string for the given state, snapshotName and scenarioName
+func generateSummary(state gitops.IntegrationTestStatus, snapshotName, scenarioName string) (string, error) {
+	var title string
+
+	var statusDesc string = "is unknown"
+
+	switch state {
+	case gitops.IntegrationTestStatusPending:
+		statusDesc = "is pending"
+	case gitops.IntegrationTestStatusInProgress:
+		statusDesc = "is in progress"
+	case gitops.IntegrationTestStatusEnvironmentProvisionError:
+		statusDesc = "experienced an error when provisioning environment"
+	case gitops.IntegrationTestStatusDeploymentError:
+		statusDesc = "experienced an error when deploying snapshotEnvironmentBinding"
+	case gitops.IntegrationTestStatusTestPassed:
+		statusDesc = "has passed"
+	case gitops.IntegrationTestStatusTestFail:
+		statusDesc = "has failed"
+	default:
+		return title, fmt.Errorf("unknown status")
+	}
+
+	title = fmt.Sprintf("Integration test for snapshot %s and scenario %s %s", snapshotName, scenarioName, statusDesc)
+
+	return title, nil
+}
+
+// generateCheckRunConclusion generate a conclusion as the conclusion of CheckRun
+// can be Can be one of: action_required, cancelled, failure, neutral, success, skipped, stale, timed_out
+// https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run
+func generateCheckRunConclusion(state gitops.IntegrationTestStatus) (string, error) {
+	var conclusion string
+
+	switch state {
+	case gitops.IntegrationTestStatusTestFail, gitops.IntegrationTestStatusEnvironmentProvisionError, gitops.IntegrationTestStatusDeploymentError:
+		conclusion = gitops.IntegrationTestStatusFailureGithub
+	case gitops.IntegrationTestStatusTestPassed:
+		conclusion = gitops.IntegrationTestStatusSuccessGithub
+	case gitops.IntegrationTestStatusPending, gitops.IntegrationTestStatusInProgress:
+		conclusion = ""
+	default:
+		return conclusion, fmt.Errorf("unknown status")
+	}
+
+	return conclusion, nil
+}
+
+// generateCommitState generate state of CommitStatus
+// Can be one of: error, failure, pending, success
+// https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
+func generateCommitState(state gitops.IntegrationTestStatus) (string, error) {
+	var commitState string
+
+	switch state {
+	case gitops.IntegrationTestStatusTestFail:
+		commitState = gitops.IntegrationTestStatusFailureGithub
+	case gitops.IntegrationTestStatusEnvironmentProvisionError, gitops.IntegrationTestStatusDeploymentError:
+		commitState = gitops.IntegrationTestStatusErrorGithub
+	case gitops.IntegrationTestStatusTestPassed:
+		commitState = gitops.IntegrationTestStatusSuccessGithub
+	case gitops.IntegrationTestStatusPending, gitops.IntegrationTestStatusInProgress:
+		commitState = gitops.IntegrationTestStatusPendingGithub
+	default:
+		return commitState, fmt.Errorf("unknown status")
+	}
+
+	return commitState, nil
+}
+
+// createCheckRunAdapterForSnapshot create a CheckRunAdapter for given snapshot, integrationTestStatusDetail, owner, repo and sha to create a checkRun
+// https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run
+func (r *GitHubReporter) createCheckRunAdapterForSnapshot(snapshot *applicationapiv1alpha1.Snapshot, integrationTestStatusDetail gitops.IntegrationTestStatusDetail, owner, repo, sha string) (*github.CheckRunAdapter, error) {
+	snapshotName := snapshot.Name
+	scenarioName := integrationTestStatusDetail.ScenarioName
+
+	conclusion, err := generateCheckRunConclusion(integrationTestStatusDetail.Status)
+	if err != nil {
+		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
+	}
+
+	summary, err := generateSummary(integrationTestStatusDetail.Status, snapshotName, scenarioName)
+	if err != nil {
+		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
+	}
+
+	cra := &github.CheckRunAdapter{
+		Owner:      owner,
+		Repository: repo,
+		Name:       NamePrefix + " / " + snapshotName + " / " + scenarioName,
+		SHA:        sha,
+		ExternalID: scenarioName,
+		Conclusion: conclusion,
+		Title:      conclusion,
+		// This summary will be reworked once PLNSRVCE-1295 is implemented in the future
+		Summary: summary,
+		Text:    integrationTestStatusDetail.Details,
+	}
+
+	if start := integrationTestStatusDetail.StartTime; start != nil {
+		cra.StartTime = *start
+	}
+
+	if complete := integrationTestStatusDetail.CompletionTime; complete != nil {
+		cra.CompletionTime = *complete
+	}
+
+	return cra, nil
+}
+
 func (r *GitHubReporter) createCommitStatus(k8sClient client.Client, ctx context.Context, pipelineRun *tektonv1beta1.PipelineRun) error {
 	var (
 		state       string
@@ -287,6 +398,33 @@ func (r *GitHubReporter) createCommitStatus(k8sClient client.Client, ctx context
 	}
 
 	return nil
+}
+
+// createCommitStatusAdapterForSnapshot create a commitStatusAdapter used to create commitStatus on GitHub
+// https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
+func (r *GitHubReporter) createCommitStatusAdapterForSnapshot(snapshot *applicationapiv1alpha1.Snapshot, integrationTestStatusDetail gitops.IntegrationTestStatusDetail, owner, repo, sha string) (*github.CommitStatusAdapter, error) {
+	snapshotName := snapshot.Name
+	scenarioName := integrationTestStatusDetail.ScenarioName
+	statusContext := NamePrefix + " / " + snapshot.Name + " / " + scenarioName
+
+	state, err := generateCommitState(integrationTestStatusDetail.Status)
+	if err != nil {
+		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
+	}
+
+	description, err := generateSummary(integrationTestStatusDetail.Status, snapshotName, scenarioName)
+	if err != nil {
+		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
+	}
+
+	return &github.CommitStatusAdapter{
+		Owner:       owner,
+		Repository:  repo,
+		SHA:         sha,
+		State:       state,
+		Description: description,
+		Context:     statusContext,
+	}, nil
 }
 
 func (r *GitHubReporter) createComment(k8sClient client.Client, ctx context.Context, pipelineRun *tektonv1beta1.PipelineRun) error {
@@ -393,7 +531,7 @@ func (r *GitHubReporter) ReportStatus(k8sClient client.Client, ctx context.Conte
 			return err
 		}
 	} else {
-		token, err := r.getToken(ctx, pipelineRun)
+		token, err := r.getToken(ctx, pipelineRun, pipelineRun.Namespace)
 		if err != nil {
 			return err
 		}
@@ -408,6 +546,145 @@ func (r *GitHubReporter) ReportStatus(k8sClient client.Client, ctx context.Conte
 		err = r.createComment(k8sClient, ctx, pipelineRun)
 		if err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+// ReportStatusForSnapshot creates CheckRun when using GitHub App integration,
+// creates a a commit status when using GitHub webhook integration
+func (r *GitHubReporter) ReportStatusForSnapshot(k8sClient client.Client, ctx context.Context, logger *helpers.IntegrationLogger, snapshot *applicationapiv1alpha1.Snapshot) error {
+	statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(snapshot)
+	if err != nil {
+		logger.Error(err, "failed to get test status annotations from snapshot",
+			"snapshot.Namespace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return err
+	}
+
+	labels := snapshot.GetLabels()
+
+	owner, found := labels[gitops.PipelineAsCodeURLOrgLabel]
+	if !found {
+		return fmt.Errorf("org label not found %q", gitops.PipelineAsCodeURLOrgLabel)
+	}
+
+	repo, found := labels[gitops.PipelineAsCodeURLRepositoryLabel]
+	if !found {
+		return fmt.Errorf("repository label not found %q", gitops.PipelineAsCodeURLRepositoryLabel)
+	}
+
+	sha, found := labels[gitops.PipelineAsCodeSHALabel]
+	if !found {
+		return fmt.Errorf("sha label not found %q", gitops.PipelineAsCodeSHALabel)
+	}
+	integrationTestStatusDetails := statuses.GetStatuses()
+	// Existence of the Pipelines as Code installation ID annotation signals configuration using GitHub App integration.
+	// If it doesn't exist, GitHub webhook integration is configured.
+	if metadata.HasAnnotation(snapshot, gitops.PipelineAsCodeInstallationIDAnnotation) {
+		creds, err := r.getAppCredentials(ctx, snapshot)
+		if err != nil {
+			logger.Error(err, "failed to get app credentials from Snapshot",
+				"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+			return err
+		}
+
+		token, err := r.client.CreateAppInstallationToken(ctx, creds.AppID, creds.InstallationID, creds.PrivateKey)
+		if err != nil {
+			logger.Error(err, "failed to create app installation token",
+				"creds.AppID", creds.AppID, "creds.InstallationID", creds.InstallationID)
+			return err
+		}
+
+		r.client.SetOAuthToken(ctx, token)
+
+		allCheckRuns, err := r.client.GetAllCheckRunsForRef(ctx, owner, repo, sha, creds.AppID)
+		if err != nil {
+			logger.Error(err, "failed to get all checkruns for ref",
+				"owner", owner, "repo", repo, "creds.AppID", creds.AppID)
+			return err
+		}
+
+		for _, integrationTestStatusDetail := range integrationTestStatusDetails {
+			integrationTestStatusDetail := *integrationTestStatusDetail // G601
+			checkRun, err := r.createCheckRunAdapterForSnapshot(snapshot, integrationTestStatusDetail, owner, repo, sha)
+			if err != nil {
+				logger.Error(err, "failed to create checkRunAdapter for snapshot",
+					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+				return err
+			}
+
+			existingCheckrun := r.client.GetExistingCheckRun(allCheckRuns, checkRun)
+
+			if existingCheckrun == nil {
+				logger.Info("creating checkrun for scenario test status of snapshot",
+					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName)
+				_, err = r.client.CreateCheckRun(ctx, checkRun)
+				if err != nil {
+					logger.Error(err, "failed to create checkrun",
+						"checkRun", checkRun)
+					return err
+				}
+			} else {
+				logger.Info("found existing checkrun", "existingCheckRun", existingCheckrun)
+				if r.client.IsUpdateNeeded(existingCheckrun, checkRun) {
+					logger.Info("found existing check run with the same ExternalID but different conclusion/status, updating checkrun for scenario test status of snapshot",
+						"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName, "checkrun.ExternalID", checkRun.ExternalID)
+					err = r.client.UpdateCheckRun(ctx, *existingCheckrun.ID, checkRun)
+					if err != nil {
+						logger.Error(err, "failed to update checkrun",
+							"checkRun", checkRun)
+						return err
+					}
+				} else {
+					logger.Info("found existing check run with the same ExternalID and conclusion/status, no need to update checkrun for scenario test status of snapshot",
+						"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName, "checkrun.ExternalID", checkRun.ExternalID)
+				}
+			}
+		}
+	} else {
+		token, err := r.getToken(ctx, snapshot, snapshot.Namespace)
+		if err != nil {
+			logger.Error(err, "failed to get token from snapshot",
+				"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+			return err
+		}
+
+		r.client.SetOAuthToken(ctx, token)
+
+		allCommitStatuses, err := r.client.GetAllCommitStatusesForRef(ctx, owner, repo, sha)
+		if err != nil {
+			logger.Error(err, "failed to get all commitStatuses for snapshot",
+				"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+			return err
+		}
+
+		for _, integrationTestStatusDetail := range integrationTestStatusDetails {
+			integrationTestStatusDetail := *integrationTestStatusDetail //G601
+			commitStatus, err := r.createCommitStatusAdapterForSnapshot(snapshot, integrationTestStatusDetail, owner, repo, sha)
+			if err != nil {
+				logger.Error(err, "failed to create CommitStatusAdapter for snapshot",
+					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+				return err
+			}
+
+			commitStatusExist, err := r.client.CommitStatusExists(allCommitStatuses, commitStatus)
+			if err != nil {
+				return err
+			}
+
+			if !commitStatusExist {
+				logger.Info("creating commit status for scenario test status of snapshot",
+					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName)
+				_, err = r.client.CreateCommitStatus(ctx, commitStatus.Owner, commitStatus.Repository, commitStatus.SHA, commitStatus.State, commitStatus.Description, commitStatus.Context)
+				if err != nil {
+					return err
+				}
+			} else {
+				logger.Info("found existing commitStatus for scenario test status of snapshot, no need to create new commit status",
+					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName)
+			}
+
 		}
 	}
 

--- a/status/status.go
+++ b/status/status.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/gitops"
+	"github.com/redhat-appstudio/integration-service/helpers"
 	"github.com/redhat-appstudio/operator-toolkit/metadata"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,11 +18,12 @@ const NamePrefix = "Red Hat Trusted App Test"
 // Reporter is a generic interface all status implementations must follow.
 type Reporter interface {
 	ReportStatus(client.Client, context.Context, *tektonv1beta1.PipelineRun) error
+	ReportStatusForSnapshot(client.Client, context.Context, *helpers.IntegrationLogger, *applicationapiv1alpha1.Snapshot) error
 }
 
 // Status is the interface of the main status Adapter.
 type Status interface {
-	GetReporters(*tektonv1beta1.PipelineRun) ([]Reporter, error)
+	GetReporters(client.Object) ([]Reporter, error)
 }
 
 // Adapter is responsible for discovering supported Reporter implementations.
@@ -57,10 +60,10 @@ func NewAdapter(logger logr.Logger, k8sClient client.Client, opts ...AdapterOpti
 
 // GetReporters returns a list of enabled/supported status reporters for a PipelineRun.
 // All potential reporters must be added to this function for them to be utilized.
-func (a *Adapter) GetReporters(pipelineRun *tektonv1beta1.PipelineRun) ([]Reporter, error) {
+func (a *Adapter) GetReporters(object client.Object) ([]Reporter, error) {
 	var reporters []Reporter
 
-	if metadata.HasLabelWithValue(pipelineRun, gitops.PipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeGitHubProviderType) {
+	if metadata.HasLabelWithValue(object, gitops.PipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeGitHubProviderType) {
 		reporters = append(reporters, a.githubReporter)
 	}
 

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -5,6 +5,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/helpers"
 	"github.com/redhat-appstudio/integration-service/status"
 
 	"github.com/go-logr/logr"
@@ -16,6 +18,10 @@ import (
 type MockReporter struct{}
 
 func (r *MockReporter) ReportStatus(client.Client, context.Context, *tektonv1beta1.PipelineRun) error {
+	return nil
+}
+
+func (r *MockReporter) ReportStatusForSnapshot(client.Client, context.Context, *helpers.IntegrationLogger, *applicationapiv1alpha1.Snapshot) error {
 	return nil
 }
 


### PR DESCRIPTION
* Create function to get credential from snapshot
* Create function to report for result of handle ITSes for snapshot
* The old [EnsureStatusReported()](https://github.com/redhat-appstudio/integration-service/blob/main/controllers/integrationpipeline/integrationpipeline_adapter.go#L177) in integration pipeline controller is kept since we don't know yet how to get the test result for integration pipeline runs after [PLNSRVCE-1295](https://issues.redhat.com/browse/PLNSRVCE-1295)
* The controller will get all checkRuns and then compare with the checkRun to be created/updated to if the action is needed before performing the action
* The controller will get all commitStatuses and then compare with the commitStatus to be created to see if the action is needed before performing the action
* The new report won't include the testResult and we can do it when we need to remove the [current report](https://github.com/redhat-appstudio/integration-service/blob/main/controllers/integrationpipeline/integrationpipeline_adapter.go#L177) in integration PLR adapter after [PLNSRVCE-1295](https://issues.redhat.com/browse/PLNSRVCE-1295) is implemented.

Checkrun examples in github https://github.com/hongliuorg/devfile-sample-go-basic/pull/3/checks?check_run_id=16739942606

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
