### PR TITLE
fix(STONEINTG_587): check kubernetes manifests is not working

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,6 @@ jobs:
   go:
     name: Check sources
     runs-on: ubuntu-20.04
-    container: fedora:35
     env:
       OPERATOR_SDK_VERSION: v1.18.0
     steps:
@@ -32,8 +31,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Download fedora environment dependencies # Would be nice to cache this somehow
-        run: sudo dnf -y install diffutils findutils gcc wget which jq git
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
         uses: actions/cache@v3
         id: cache-operator-sdk
@@ -91,23 +88,14 @@ jobs:
         with:
           version: "2023.1.3"
           install-go: false
-      - name: Check manifests # make generate manifests touches files even for no changes
-        run: |
-          cp -rp ../integration-service/ /tmp/integration-service/
-          make generate manifests
-          if [[ $(diff -r ../integration-service /tmp/integration-service) ]]
-          then
-            echo "generated sources are not up to date:"
-            diff -r ../integration-service /tmp/integration-service
-            exit 1
-          fi
       - name: Check kubernetes manifests
         run: |
+          set -euo pipefail
           make generate manifests
-          if [[ ! -z $(git status ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen' -s) ]]
+          if [[ ! -z $(git status -s) ]]
           then
             echo "generated sources are not up to date:"
-            git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
+            git --no-pager diff
             exit 1
           fi
       - name: Check RBAC wildcards


### PR DESCRIPTION
1. Use ubuntu directly with removing fedora container
2. Update the task to check the whole dir and remove duplicated task

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
