### PR TITLE
fix(STONTEINTG-573): fix confusing message about failed test

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -333,17 +333,22 @@ func HaveAppStudioTestsSucceeded(snapshot *applicationapiv1alpha1.Snapshot) bool
 func CanSnapshotBePromoted(snapshot *applicationapiv1alpha1.Snapshot) (bool, []string) {
 	canBePromoted := true
 	reasons := make([]string, 0)
-	if !HaveAppStudioTestsSucceeded(snapshot) {
+	if !HaveAppStudioTestsFinished(snapshot) {
 		canBePromoted = false
-		reasons = append(reasons, "the Snapshot hasn't passed all required integration tests")
-	}
-	if !IsSnapshotValid(snapshot) {
-		canBePromoted = false
-		reasons = append(reasons, "the Snapshot is invalid")
-	}
-	if IsSnapshotCreatedByPACPullRequestEvent(snapshot) {
-		canBePromoted = false
-		reasons = append(reasons, "the Snapshot was created for a PaC pull request event")
+		reasons = append(reasons, "the Snapshot has not yet finished testing")
+	} else {
+		if !HaveAppStudioTestsSucceeded(snapshot) {
+			canBePromoted = false
+			reasons = append(reasons, "the Snapshot hasn't passed all required integration tests")
+		}
+		if !IsSnapshotValid(snapshot) {
+			canBePromoted = false
+			reasons = append(reasons, "the Snapshot is invalid")
+		}
+		if IsSnapshotCreatedByPACPullRequestEvent(snapshot) {
+			canBePromoted = false
+			reasons = append(reasons, "the Snapshot was created for a PaC pull request event")
+		}
 	}
 	return canBePromoted, reasons
 }

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -113,6 +113,13 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 	})
 
+	It("ensures the a decision can be made to NOT promote when the snaphot has not been marked as passed/failed", func() {
+		canBePromoted, reasons := gitops.CanSnapshotBePromoted(hasSnapshot)
+		Expect(canBePromoted).To(BeFalse())
+		Expect(reasons).To(HaveLen(1))
+		Expect(reasons[0]).To(Equal("the Snapshot has not yet finished testing"))
+	})
+
 	It("ensures the Snapshots status can be marked as passed", func() {
 		updatedSnapshot, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())


### PR DESCRIPTION
Signed-off-by: Jing Qi <jinqi@redhat.com>

Add checking and update the log message in CanSnapshotBePromoted() in case there are no integration tests

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
