### PR TITLE
fix(STONEINTG-523): test race condition with timestamps

### DIFF
--- a/gitops/snapshot_integration_tests_status_test.go
+++ b/gitops/snapshot_integration_tests_status_test.go
@@ -211,6 +211,7 @@ var _ = Describe("Snapshot integration test statuses", func() {
 			originalStartTime := originalDetail.StartTime // copy time, it's all in pointers
 			originalLastUpdateTime := originalDetail.LastUpdateTime
 
+			time.Sleep(time.Duration(100)) // wait 100ns to avoid race condition when test is too quick and timestamp is the same
 			sits.UpdateTestStatusIfChanged(testScenarioName, gitops.IntegrationTestStatusInProgress, newDetails)
 			newDetail, ok := sits.GetScenarioStatus(testScenarioName)
 			Expect(ok).To(BeTrue())


### PR DESCRIPTION
Sometimes test is too quick and the timestamp is the same as before update.
Adding sleep explictily to make sure timestamp differs

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
