### PR TITLE
fix(STONEINTG-524): update NS of pipelines-as-code secret

### DIFF
--- a/status/reporters.go
+++ b/status/reporters.go
@@ -69,7 +69,7 @@ func (r *GitHubReporter) getAppCredentials(ctx context.Context, pipelineRun *tek
 
 	// Get the global pipelines as code secret
 	pacSecret := v1.Secret{}
-	err = r.k8sClient.Get(ctx, types.NamespacedName{Namespace: "pipelines-as-code", Name: "pipelines-as-code-secret"}, &pacSecret)
+	err = r.k8sClient.Get(ctx, types.NamespacedName{Namespace: "openshift-pipelines", Name: "pipelines-as-code-secret"}, &pacSecret)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* update NS of pipelines-as-code secret since the NS has been changed to openshift-pipelines

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
