### PR TITLE
feat(STONEINTG-534): add SLI for measuring time from SEB created to ready

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -83,6 +83,8 @@ func (a *Adapter) EnsureIntegrationTestPipelineForScenarioExists() (controller.O
 	}
 	a.logger.Info("The SnapshotEnvironmentBinding's deployment succeeded", "snapshotEnvironmentBinding.Name", a.snapshotEnvironmentBinding.Name)
 
+	gitops.PrepareAndRegisterSEBReady(a.snapshotEnvironmentBinding)
+
 	if a.integrationTestScenario != nil {
 		integrationPipelineRun, err := loader.GetLatestPipelineRunForSnapshotAndScenario(a.client, a.context, a.loader, a.snapshot, a.integrationTestScenario)
 		if err != nil {

--- a/gitops/binding.go
+++ b/gitops/binding.go
@@ -17,7 +17,10 @@ limitations under the License.
 package gitops
 
 import (
+	"time"
+
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/metrics"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -115,4 +118,10 @@ func hasDeploymentFailed(objectOld, objectNew client.Object) bool {
 		}
 	}
 	return (oldCondition == nil || oldCondition.Status != metav1.ConditionTrue) && newCondition.Status == metav1.ConditionTrue
+}
+
+// PrepareAndRegisterSEBReady is to do preparation and register SEBCreatedToReadySeconds
+func PrepareAndRegisterSEBReady(seb *applicationapiv1alpha1.SnapshotEnvironmentBinding) {
+	sebReadyTime := &metav1.Time{Time: time.Now()}
+	go metrics.RegisterSEBCreatedToReady(seb.GetCreationTimestamp(), sebReadyTime)
 }

--- a/gitops/binding_test.go
+++ b/gitops/binding_test.go
@@ -175,6 +175,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 		Expect(gitops.IsBindingDeployed(newSnapshotEnvironmentBinding)).NotTo(BeTrue())
 		Expect(gitops.HaveBindingsFailed(newSnapshotEnvironmentBinding)).NotTo(BeTrue())
+		gitops.PrepareAndRegisterSEBReady(newSnapshotEnvironmentBinding)
 	})
 
 	It("ensures an existing deployed SnapshotEnvironmentBinding conditions are recognized", func() {

--- a/metrics/integration.go
+++ b/metrics/integration.go
@@ -23,6 +23,16 @@ var (
 		},
 	)
 
+	SEBCreatedToReadySeconds = prometheus.NewHistogram(
+		sebCreatedToReadySecondsOpts,
+	)
+
+	sebCreatedToReadySecondsOpts = prometheus.HistogramOpts{
+		Name:    "seb_created_to_ready_seconds",
+		Help:    "Time duration from the moment the snapshotEnvironmentBinding was created till the snapshot is deployed to the environtment",
+		Buckets: []float64{1, 5, 10, 20, 40, 60, 80, 120, 160, 200, 300},
+	}
+
 	IntegrationPipelineRunTotal = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "integration_pipelinerun_total",
@@ -87,6 +97,11 @@ func RegisterPipelineRunStarted(snapshotCreatedTime metav1.Time, pipelineRunStar
 	SnapshotCreatedToPipelineRunStartedSeconds.Observe(pipelineRunStartTime.Sub(snapshotCreatedTime.Time).Seconds())
 }
 
+func RegisterSEBCreatedToReady(sebCreatedTime metav1.Time, sebReadyTime *metav1.Time) {
+	SEBCreatedToReadySeconds.
+		Observe(sebReadyTime.Sub(sebCreatedTime.Time).Seconds())
+}
+
 func RegisterIntegrationResponse(buildPipelineFinishTime metav1.Time, inProgressTime *metav1.Time) {
 	IntegrationSvcResponseSeconds.Observe(inProgressTime.Sub(buildPipelineFinishTime.Time).Seconds())
 }
@@ -103,6 +118,7 @@ func RegisterNewIntegrationPipelineRun(snapshotCreatedTime metav1.Time, pipeline
 func init() {
 	metrics.Registry.MustRegister(
 		SnapshotCreatedToPipelineRunStartedSeconds,
+		SEBCreatedToReadySeconds,
 		IntegrationSvcResponseSeconds,
 		IntegrationPipelineRunTotal,
 		SnapshotConcurrentTotal,


### PR DESCRIPTION


Signed-off-by: Jing Qi <jinqi@redhat.com>

Add metric for measuring the time between SEB is created and SEB is ready to use

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
