### PR TITLE
feat: new grafana panel for release latency seconds

### DIFF
--- a/config/grafana/dashboards/integration-service-dashboard.json
+++ b/config/grafana/dashboards/integration-service-dashboard.json
@@ -1310,6 +1310,76 @@
       "yBucketBound": "auto",
       "yBucketNumber": null,
       "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": null,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "description": "Measure release creation latency from end of testing to release created",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 28,
+      "legend": {
+        "show": false
+      },
+      "maxDataPoints": 25,
+      "pluginVersion": "7.5.17",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.90, sum(rate(release_latency_seconds_bucket[5m])) by (le)) ",
+          "format": "heatmap",
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latency of Release Creation",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "short",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
     }
 
   ],

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -360,7 +360,29 @@ func HaveAppStudioTestsSucceeded(snapshot *applicationapiv1alpha1.Snapshot) bool
 	if meta.FindStatusCondition(snapshot.Status.Conditions, AppStudioTestSucceededCondition) == nil {
 		return meta.IsStatusConditionTrue(snapshot.Status.Conditions, LegacyTestSucceededCondition)
 	}
+
 	return meta.IsStatusConditionTrue(snapshot.Status.Conditions, AppStudioTestSucceededCondition)
+}
+
+// GetTestSucceededCondition checks status of tests on the snapshot
+func GetTestSucceededCondition(snapshot *applicationapiv1alpha1.Snapshot) (condition *metav1.Condition, ok bool) {
+
+	condition = meta.FindStatusCondition(snapshot.Status.Conditions, AppStudioTestSucceededCondition)
+	if condition == nil {
+		condition = meta.FindStatusCondition(snapshot.Status.Conditions, LegacyTestSucceededCondition)
+	}
+
+	ok = (condition != nil && condition.Status != metav1.ConditionUnknown)
+	return
+}
+
+// GetAppStudioTestsFinishedTime finds the timestamp of tests succeeded condition
+func GetAppStudioTestsFinishedTime(snapshot *applicationapiv1alpha1.Snapshot) (metav1.Time, bool) {
+	condition, ok := GetTestSucceededCondition(snapshot)
+	if ok {
+		return condition.LastTransitionTime, true
+	}
+	return metav1.Time{}, false
 }
 
 // CanSnapshotBePromoted checks if the Snapshot in question can be promoted for deployment and release.

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -227,6 +227,62 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(checkResult).To(BeFalse())
 	})
 
+	It("returns true if only AppStudioTestSucceededCondition is set", func() {
+		appStudioTestSucceededCondition := "AppStudioTestSucceeded" // Local variable
+		condition := metav1.Condition{
+			Type:   appStudioTestSucceededCondition,
+			Status: metav1.ConditionTrue,
+		}
+		meta.SetStatusCondition(&hasSnapshot.Status.Conditions, condition)
+		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
+	})
+
+	It("returns true if only LegacyTestSucceededCondition is set", func() {
+		legacyTestSucceededCondition := "HACBSStudioTestSucceeded" // Local variable
+		condition := metav1.Condition{
+			Type:   legacyTestSucceededCondition,
+			Status: metav1.ConditionTrue,
+		}
+		meta.SetStatusCondition(&hasSnapshot.Status.Conditions, condition)
+		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
+	})
+
+	It("returns the LastTransitionTime when AppStudioTestSucceededCondition is set", func() {
+		appStudioTestSucceededCondition := "AppStudioTestSucceeded" // Local variable
+		testTime := metav1.NewTime(time.Now())
+		condition := metav1.Condition{
+			Type:               appStudioTestSucceededCondition,
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: testTime,
+		}
+		meta.SetStatusCondition(&hasSnapshot.Status.Conditions, condition)
+
+		returnedTime, ok := gitops.GetAppStudioTestsFinishedTime(hasSnapshot)
+		Expect(ok).To(BeTrue())
+		Expect(returnedTime).To(Equal(testTime))
+	})
+
+	It("returns the LastTransitionTime when LegacyTestSucceededCondition is set", func() {
+		legacyTestSucceededCondition := "HACBSStudioTestSucceeded"
+		testTime := metav1.NewTime(time.Now())
+		condition := metav1.Condition{
+			Type:               legacyTestSucceededCondition,
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: testTime,
+		}
+		meta.SetStatusCondition(&hasSnapshot.Status.Conditions, condition)
+
+		returnedTime, ok := gitops.GetAppStudioTestsFinishedTime(hasSnapshot)
+		Expect(ok).To(BeTrue())
+		Expect(returnedTime).To(Equal(testTime))
+	})
+
+	It("returns zero time when neither condition is set", func() {
+		returnedTime, ok := gitops.GetAppStudioTestsFinishedTime(hasSnapshot)
+		Expect(ok).To(BeFalse())
+		Expect(returnedTime).To(Equal(metav1.Time{})) // Empty or zero time
+	})
+
 	It("ensures that a new Snapshots can be successfully created", func() {
 		snapshotComponents := []applicationapiv1alpha1.SnapshotComponent{}
 		createdSnapshot := gitops.NewSnapshot(hasApp, &snapshotComponents)

--- a/metrics/integration.go
+++ b/metrics/integration.go
@@ -17,6 +17,8 @@ limitations under the License.
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -87,6 +89,14 @@ var (
 		},
 		[]string{"type", "reason"},
 	)
+
+	ReleaseLatencySeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "release_latency_seconds",
+			Help:    "Latency between integration tests completion and release creation",
+			Buckets: []float64{0.05, 0.1, 0.5, 1, 2, 3, 4, 5, 10, 15, 30},
+		},
+	)
 )
 
 func RegisterCompletedSnapshot(conditiontype, reason string, startTime metav1.Time, completionTime *metav1.Time) {
@@ -131,6 +141,11 @@ func RegisterNewIntegrationPipelineRun(snapshotCreatedTime metav1.Time, pipeline
 	RegisterPipelineRunStarted(snapshotCreatedTime, pipelineRunStartTime)
 }
 
+func RegisterReleaseLatency(startTime metav1.Time) {
+	latency := time.Since(startTime.Time).Seconds()
+	ReleaseLatencySeconds.Observe(latency)
+}
+
 func init() {
 	metrics.Registry.MustRegister(
 		SnapshotCreatedToPipelineRunStartedSeconds,
@@ -141,5 +156,6 @@ func init() {
 		SnapshotDurationSeconds,
 		SnapshotInvalidTotal,
 		SnapshotTotal,
+		ReleaseLatencySeconds,
 	)
 }


### PR DESCRIPTION
new metric release latency seconds
new grafana panel of same name
measures latency between integration tests
completing and release creation

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
