### PR TITLE
fix(STONEINTG-523): use SetAnnotation function

### DIFF
--- a/controllers/buildpipeline/buildpipeline_adapter.go
+++ b/controllers/buildpipeline/buildpipeline_adapter.go
@@ -263,10 +263,8 @@ func (a *Adapter) getSucceededBuildPipelineRunsForComponent(component *applicati
 
 func (a *Adapter) annotateBuildPipelineRunWithSnapshot(pipelineRun *tektonv1beta1.PipelineRun, snapshot *applicationapiv1alpha1.Snapshot) (*tektonv1beta1.PipelineRun, error) {
 	patch := client.MergeFrom(pipelineRun.DeepCopy())
-	newAnnotations := map[string]string{}
-	newAnnotations[tekton.SnapshotNameLabel] = snapshot.Name
 
-	_ = metadata.AddAnnotations(&pipelineRun.ObjectMeta, newAnnotations)
+	_ = metadata.SetAnnotation(&pipelineRun.ObjectMeta, tekton.SnapshotNameLabel, snapshot.Name)
 
 	err := a.client.Patch(a.context, pipelineRun, patch)
 	if err != nil {

--- a/gitops/snapshot_integration_tests_status.go
+++ b/gitops/snapshot_integration_tests_status.go
@@ -286,10 +286,7 @@ func WriteIntegrationTestStatusesIntoSnapshot(s *applicationapiv1alpha1.Snapshot
 		return fmt.Errorf("failed to marshal test results into JSON: %w", err)
 	}
 
-	newAnnotations := map[string]string{
-		SnapshotTestsStatusAnnotation: string(value),
-	}
-	if err := metadata.AddAnnotations(&s.ObjectMeta, newAnnotations); err != nil {
+	if err := metadata.SetAnnotation(&s.ObjectMeta, SnapshotTestsStatusAnnotation, string(value)); err != nil {
 		return fmt.Errorf("failed to add annotations: %w", err)
 	}
 

--- a/gitops/snapshot_integration_tests_status_test.go
+++ b/gitops/snapshot_integration_tests_status_test.go
@@ -423,10 +423,7 @@ var _ = Describe("Snapshot integration test statuses", func() {
 		When("Snapshot contains empty test status annotation", func() {
 
 			BeforeEach(func() {
-				err := metadata.AddAnnotations(
-					snapshot,
-					map[string]string{gitops.SnapshotTestsStatusAnnotation: "[]"},
-				)
+				err := metadata.SetAnnotation(snapshot, gitops.SnapshotTestsStatusAnnotation, "[]")
 				Expect(err).To(BeNil())
 			})
 
@@ -442,10 +439,7 @@ var _ = Describe("Snapshot integration test statuses", func() {
 				sits.UpdateTestStatusIfChanged(testScenarioName, gitops.IntegrationTestStatusInProgress, testDetails)
 				testAnnotation, err := json.Marshal(sits)
 				Expect(err).To(BeNil())
-				err = metadata.AddAnnotations(
-					snapshot,
-					map[string]string{gitops.SnapshotTestsStatusAnnotation: string(testAnnotation)},
-				)
+				err = metadata.SetAnnotation(snapshot, gitops.SnapshotTestsStatusAnnotation, string(testAnnotation))
 				Expect(err).To(BeNil())
 
 			})
@@ -465,10 +459,8 @@ var _ = Describe("Snapshot integration test statuses", func() {
 
 		When("Snapshot contains invalid test status annotation", func() {
 			BeforeEach(func() {
-				err := metadata.AddAnnotations(
-					snapshot,
-					map[string]string{gitops.SnapshotTestsStatusAnnotation: "[{\"invalid\":\"data\"}]"},
-				)
+				err := metadata.SetAnnotation(
+					snapshot, gitops.SnapshotTestsStatusAnnotation, "[{\"invalid\":\"data\"}]")
 				Expect(err).To(BeNil())
 			})
 
@@ -480,10 +472,7 @@ var _ = Describe("Snapshot integration test statuses", func() {
 
 		When("Snapshot contains invalid JSON test status annotation", func() {
 			BeforeEach(func() {
-				err := metadata.AddAnnotations(
-					snapshot,
-					map[string]string{gitops.SnapshotTestsStatusAnnotation: "{}"},
-				)
+				err := metadata.SetAnnotation(snapshot, gitops.SnapshotTestsStatusAnnotation, "{}")
 				Expect(err).To(BeNil())
 			})
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openshift-pipelines/pipelines-as-code v0.17.2
 	github.com/prometheus/client_golang v1.16.0
 	github.com/redhat-appstudio/application-api v0.0.0-20230427114540-a91722251e0a
-	github.com/redhat-appstudio/operator-toolkit v0.0.0-20230829074524-440a6e31b5ae
+	github.com/redhat-appstudio/operator-toolkit v0.0.0-20230913085326-6c5e9d368a6a
 	github.com/redhat-appstudio/release-service v0.0.0-20230511145849-bde1cdcbb60b
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/tektoncd/pipeline v0.48.0

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/prometheus/statsd_exporter v0.23.0 h1:GEkriUCmARYh1gSA0gzpvmTg/oHMc5M
 github.com/prometheus/statsd_exporter v0.23.0/go.mod h1:1itCY9XMa2p5pjO5HseGjs5cnaIA5qxLCYmn3OUna58=
 github.com/redhat-appstudio/application-api v0.0.0-20230427114540-a91722251e0a h1:3fLezk9GHkAez0a94EywNVI9bWHAviddjEH8EKj9gRs=
 github.com/redhat-appstudio/application-api v0.0.0-20230427114540-a91722251e0a/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230829074524-440a6e31b5ae h1:NnKMq4zOwc0hdYF8Nvjs6k6S4Q6U9vG+b5r0vZTWCyE=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230829074524-440a6e31b5ae/go.mod h1:7cX2+4KGZLJ4Yoj+1v0iV5hkCGBzbSd9wkNJQjCdDJs=
+github.com/redhat-appstudio/operator-toolkit v0.0.0-20230913085326-6c5e9d368a6a h1:pwTvkRzRF6zyLW1Bb4vEuqaNXlGJOnBtt9n5gNp0/r4=
+github.com/redhat-appstudio/operator-toolkit v0.0.0-20230913085326-6c5e9d368a6a/go.mod h1:7cX2+4KGZLJ4Yoj+1v0iV5hkCGBzbSd9wkNJQjCdDJs=
 github.com/redhat-appstudio/release-service v0.0.0-20230511145849-bde1cdcbb60b h1:96jgqIR8Otx2vrLZscvNo3gFlX2d9P/mkbx5Trkm8tQ=
 github.com/redhat-appstudio/release-service v0.0.0-20230511145849-bde1cdcbb60b/go.mod h1:a2jPi276KqDvkRw0lcjOSV3MFZxEh8BLOPD63vm2oeg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=


### PR DESCRIPTION
We have a regression because function AddAnnotations is only adding new annotations to objects, existing annotations are not updated.

We need to update existing annotations, thus using SetAnnotation function from newer version of operator-toolkit repo.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
