### PR TITLE
feat(IntegrationTestStatus): implement IsFinal()

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -144,6 +144,18 @@ var (
 	SnapshotComponentLabel = tekton.ComponentNameLabel
 )
 
+// IsFinal returns true when test status is final
+func (its IntegrationTestStatus) IsFinal() bool {
+	switch its {
+	case IntegrationTestStatusEnvironmentProvisionError,
+		IntegrationTestStatusTestPassed,
+		IntegrationTestStatusTestFail,
+		IntegrationTestStatusDeploymentError:
+		return true
+	}
+	return false
+}
+
 // MarkSnapshotAsPassed updates the AppStudio Test succeeded condition for the Snapshot to passed.
 // If the patch command fails, an error will be returned.
 func MarkSnapshotAsPassed(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -378,6 +378,18 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 			Entry("When status is TestPass", gitops.IntegrationTestStatusTestPassed, "TestPassed"),
 		)
 
+		DescribeTable("Status is final",
+			func(st gitops.IntegrationTestStatus, isFinal bool) {
+				Expect(st.IsFinal()).To(Equal(isFinal))
+			},
+			Entry("When status is Pending", gitops.IntegrationTestStatusPending, false),
+			Entry("When status is InProgress", gitops.IntegrationTestStatusInProgress, false),
+			Entry("When status is EnvironmentProvisionError", gitops.IntegrationTestStatusEnvironmentProvisionError, true),
+			Entry("When status is DeploymentError", gitops.IntegrationTestStatusDeploymentError, true),
+			Entry("When status is TestFail", gitops.IntegrationTestStatusTestFail, true),
+			Entry("When status is TestPass", gitops.IntegrationTestStatusTestPassed, true),
+		)
+
 		It("Invalid status to type fails with error", func() {
 			_, err := gitops.IntegrationTestStatusString("Unknown")
 			Expect(err).NotTo(BeNil())


### PR DESCRIPTION
IsFinal() returns true if status is final, like TestFail, TestPass, and errors

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
