### PR TITLE
fix(STONEINTG-611): stop extensive logging about failed SEB

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -73,7 +73,7 @@ func (a *Adapter) EnsureIntegrationTestPipelineForScenarioExists() (controller.O
 	}
 
 	if gitops.HaveBindingsFailed(a.snapshotEnvironmentBinding) {
-		a.logger.Info("The SnapshotEnvironmentBinding has failed to deploy on ephemeral environment and will be deleted later.", "snapshotEnvironmentBinding.Name", a.snapshotEnvironmentBinding.Name)
+		// don't log here it floods logs
 		return controller.ContinueProcessing()
 	}
 
@@ -134,12 +134,12 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 	}
 	sinceLastTransition := time.Since(lastTransitionTime).Seconds()
 	if sinceLastTransition < snapshotEnvironmentBindingErrorTimeoutSeconds {
-		a.logger.Info(fmt.Sprintf("SnapshotEnvironmentBinding has been in error state for %f "+
-			"seconds,  which is less than threshold time of %f. Requeueing cleanup after delay.",
-			sinceLastTransition, snapshotEnvironmentBindingErrorTimeoutSeconds))
+		// don't log here, it floods logs
 		return controller.RequeueAfter(time.Duration(snapshotEnvironmentBindingErrorTimeoutSeconds*float64(time.Second)), nil)
 	} else {
-		a.logger.Info(fmt.Sprintf("SEB has been in the error state for more than the threshold time of %f seconds", snapshotEnvironmentBindingErrorTimeoutSeconds))
+		a.logger.Info(
+			fmt.Sprintf("SEB has been in the error state for more than the threshold time of %f seconds and will be deleted", snapshotEnvironmentBindingErrorTimeoutSeconds),
+		)
 	}
 
 	// mark snapshot as failed

--- a/controllers/binding/snapshotenvironmentbinding_adapter_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter_test.go
@@ -518,12 +518,9 @@ var _ = Describe("Binding Adapter", Ordered, func() {
 		Expect(dt).NotTo(BeNil())
 
 		result, err := adapter.EnsureEphemeralEnvironmentsCleanedUp()
-		Expect(!result.CancelRequest && err == nil).To(BeTrue())
+		Expect(!result.CancelRequest && err == nil && result.RequeueDelay != 0).To(BeTrue())
 
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
-
-		expectedLogEntry := "Requeueing cleanup after delay"
-		Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 
 		// Expect the environment and DTC to not have been deleted
 		dtc, _ = adapter.loader.GetDeploymentTargetClaimForEnvironment(k8sClient, adapter.context, hasEnv)


### PR DESCRIPTION
We don't need so many logs about failed SEB provisioning, it floods logs with repetetive errors.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
