### PR TITLE
fix(seb-controller): don't set failed status to already failed snapshot

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -30,7 +30,6 @@ import (
 	"github.com/redhat-appstudio/integration-service/loader"
 	"github.com/redhat-appstudio/integration-service/tekton"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -166,7 +165,7 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 		"snapshotEnvironmentBinding.Name", a.snapshotEnvironmentBinding.Name,
 		"message", snapshotErrorMessage)
 
-	if !gitops.IsSnapshotStatusConditionSet(a.snapshot, gitops.AppStudioTestSucceededCondition, metav1.ConditionFalse, "") {
+	if !gitops.IsSnapshotMarkedAsFailed(a.snapshot) {
 		_, err = gitops.MarkSnapshotAsFailed(a.client, a.context, a.snapshot, snapshotErrorMessage)
 		if err != nil {
 			a.logger.Error(err, "Failed to Update Snapshot status")

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -37,7 +37,6 @@ import (
 	"github.com/redhat-appstudio/operator-toolkit/metadata"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -162,7 +161,7 @@ func (a *Adapter) EnsureAllIntegrationTestPipelinesExist() (controller.Operation
 			a.snapshot, h.LogActionUpdate)
 		return controller.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))
 	}
-	if len(*requiredIntegrationTestScenarios) == 0 && !gitops.IsSnapshotStatusConditionSet(a.snapshot, gitops.AppStudioTestSucceededCondition, metav1.ConditionTrue, "") {
+	if len(*requiredIntegrationTestScenarios) == 0 && !gitops.IsSnapshotMarkedAsPassed(a.snapshot) {
 		updatedSnapshot, err := gitops.MarkSnapshotAsPassed(a.client, a.context, a.snapshot, "No required IntegrationTestScenarios found, skipped testing")
 		if err != nil {
 			a.logger.Error(err, "Failed to update Snapshot status")

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -144,6 +144,11 @@ var (
 	SnapshotComponentLabel = tekton.ComponentNameLabel
 )
 
+// IsSnapshotMarkedAsPassed returns true if snapshot is marked as passed
+func IsSnapshotMarkedAsPassed(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	return IsSnapshotStatusConditionSet(snapshot, AppStudioTestSucceededCondition, metav1.ConditionTrue, "")
+}
+
 // MarkSnapshotAsPassed updates the AppStudio Test succeeded condition for the Snapshot to passed.
 // If the patch command fails, an error will be returned.
 func MarkSnapshotAsPassed(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
@@ -166,6 +171,11 @@ func MarkSnapshotAsPassed(adapterClient client.Client, ctx context.Context, snap
 	return snapshot, nil
 }
 
+// IsSnapshotMarkedAsFailed returns true if snapshot is marked as failed
+func IsSnapshotMarkedAsFailed(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	return IsSnapshotStatusConditionSet(snapshot, AppStudioTestSucceededCondition, metav1.ConditionFalse, "")
+}
+
 // MarkSnapshotAsFailed updates the AppStudio Test succeeded condition for the Snapshot to failed.
 // If the patch command fails, an error will be returned.
 func MarkSnapshotAsFailed(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
@@ -186,6 +196,11 @@ func MarkSnapshotAsFailed(adapterClient client.Client, ctx context.Context, snap
 	snapshotCompletionTime := &metav1.Time{Time: time.Now()}
 	go metrics.RegisterCompletedSnapshot(condition.Type, condition.Reason, snapshot.GetCreationTimestamp(), snapshotCompletionTime)
 	return snapshot, nil
+}
+
+// IsSnapshotMarkedAsInvalid returns true if snapshot is marked as failed
+func IsSnapshotMarkedAsInvalid(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	return IsSnapshotStatusConditionSet(snapshot, AppStudioIntegrationStatusCondition, metav1.ConditionFalse, AppStudioIntegrationStatusInvalid)
 }
 
 // SetSnapshotIntegrationStatusAsInvalid sets the AppStudio integration status condition for the Snapshot to invalid.

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(updatedSnapshot).NotTo(BeNil())
 		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.AppStudioTestSucceededCondition)).To(BeTrue())
-		Expect(gitops.IsSnapshotStatusConditionSet(hasSnapshot, gitops.AppStudioTestSucceededCondition, metav1.ConditionTrue, "")).To(BeTrue())
+		Expect(gitops.IsSnapshotMarkedAsPassed(updatedSnapshot)).To(BeTrue())
 	})
 
 	It("ensures the Snapshots LegacyTestSucceededCondition status can be marked as passed", func() {
@@ -144,8 +144,8 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(hasSnapshot).NotTo(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.LegacyTestSucceededCondition)).To(BeTrue())
-		Expect(gitops.IsSnapshotStatusConditionSet(hasSnapshot, gitops.AppStudioTestSucceededCondition, metav1.ConditionTrue, "")).To(BeTrue())
-		Expect(gitops.IsSnapshotStatusConditionSet(hasSnapshot, gitops.AppStudioTestSucceededCondition, metav1.ConditionFalse, "")).To(BeFalse())
+		Expect(gitops.IsSnapshotMarkedAsPassed(hasSnapshot)).To(BeTrue())
+		Expect(gitops.IsSnapshotMarkedAsFailed(hasSnapshot)).To(BeFalse())
 	})
 
 	It("ensures the Snapshots LegacyIntegrationStatusCondition status can be marked as invalid", func() {
@@ -163,7 +163,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(hasSnapshot).NotTo(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.LegacyIntegrationStatusCondition)).To(BeFalse())
-		Expect(gitops.IsSnapshotStatusConditionSet(hasSnapshot, gitops.AppStudioIntegrationStatusCondition, metav1.ConditionFalse, "Invalid")).To(BeTrue())
+		Expect(gitops.IsSnapshotMarkedAsInvalid(hasSnapshot)).To(BeTrue())
 		Expect(gitops.IsSnapshotStatusConditionSet(hasSnapshot, gitops.AppStudioIntegrationStatusCondition, metav1.ConditionFalse, "Valid")).To(BeFalse())
 	})
 
@@ -173,7 +173,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(updatedSnapshot).NotTo(BeNil())
 		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.AppStudioTestSucceededCondition)).To(BeFalse())
-		Expect(gitops.IsSnapshotStatusConditionSet(hasSnapshot, gitops.AppStudioTestSucceededCondition, metav1.ConditionFalse, "")).To(BeTrue())
+		Expect(gitops.IsSnapshotMarkedAsFailed(hasSnapshot)).To(BeTrue())
 	})
 
 	It("ensures the Snapshots status can be marked as error", func() {


### PR DESCRIPTION
Snapshot which is already failed shouldn't be updated to keep original failure time.

First commit addresses the issue.
Second commit does refactoring to improve readability

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
