### PR TITLE
fix(STONEINTG-581): global candidate list update conflict

### DIFF
--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -348,6 +348,7 @@ func (a *Adapter) EnsureGlobalCandidateImageUpdated() (controller.OperationResul
 					a.component, h.LogActionUpdate,
 					"containerImage", component.ContainerImage)
 				if reflect.ValueOf(component.Source).IsValid() && component.Source.GitSource != nil && component.Source.GitSource.Revision != "" {
+					patch := client.MergeFrom(a.component.DeepCopy())
 					a.component.Status.LastBuiltCommit = component.Source.GitSource.Revision
 					err = a.client.Status().Patch(a.context, a.component, patch)
 					if err != nil {

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -426,20 +426,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(hasComp.Status.LastBuiltCommit).To(Equal(""))
 		})
 
-		It("ensures global Component Image updated when AppStudio Tests succeeded", func() {
-			gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
-			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
-			adapter.snapshot = hasSnapshot
-
-			Eventually(func() bool {
-				result, err := adapter.EnsureGlobalCandidateImageUpdated()
-				return !result.CancelRequest && err == nil
-			}, time.Second*10).Should(BeTrue())
-
-			Expect(hasComp.Spec.ContainerImage).To(Equal(sample_image))
-			Expect(hasComp.Status.LastBuiltCommit).To(Equal(sample_revision))
-		})
-
 		It("no error from ensuring global Component Image updated when AppStudio Tests failed", func() {
 			gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
@@ -447,6 +433,22 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			result, err := adapter.EnsureGlobalCandidateImageUpdated()
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
+
+			Expect(hasComp.Spec.ContainerImage).To(Equal(""))
+			Expect(hasComp.Status.LastBuiltCommit).To(Equal(""))
+		})
+
+		It("ensures global Component Image updated when AppStudio Tests succeeded", func() {
+			gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
+			adapter.snapshot = hasSnapshot
+
+			result, err := adapter.EnsureGlobalCandidateImageUpdated()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+
+			Expect(hasComp.Spec.ContainerImage).To(Equal(sample_image))
+			Expect(hasComp.Status.LastBuiltCommit).To(Equal(sample_revision))
 		})
 
 		It("ensures Release created successfully", func() {


### PR DESCRIPTION
* Create new patch before updating status to prevent update conflicts
* Update unit tests to catch such failure in case of regression

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
