### PR TITLE
fix(stoneintg-579): do not requeue snapshot if component cannot be found

### DIFF
--- a/controllers/snapshot/snapshot_controller_test.go
+++ b/controllers/snapshot/snapshot_controller_test.go
@@ -1,8 +1,9 @@
 package snapshot
 
 import (
-	"k8s.io/apimachinery/pkg/api/errors"
 	"reflect"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -148,6 +149,22 @@ var _ = Describe("SnapshotController", func() {
 		}
 		result, err := snapshotReconciler.Reconcile(ctx, req)
 		Expect(reflect.TypeOf(result)).To(Equal(reflect.TypeOf(reconcile.Result{})))
+		Expect(err).To(BeNil())
+	})
+
+	It("Does not return an error if the component cannot be found", func() {
+		err := k8sClient.Delete(ctx, hasComp)
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: hasComp.ObjectMeta.Namespace,
+				Name:      hasComp.ObjectMeta.Name,
+			}, hasComp)
+			return err != nil
+		}).Should(BeTrue())
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+
+		result, err := snapshotReconciler.Reconcile(ctx, req)
+		Expect(result).To(Equal(ctrl.Result{}))
 		Expect(err).To(BeNil())
 	})
 

--- a/helpers/errorhandlers.go
+++ b/helpers/errorhandlers.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2023.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func (l IntegrationLogger) HandleLoaderError(err error, resource, from string) (ctrl.Result, error) {
+	if errors.IsNotFound(err) {
+		l.Info(fmt.Sprintf("Could not get %[1]s from %[2]s.  %[1]s may have been removed.  Declining to proceed with reconciliation", resource, from))
+		return ctrl.Result{}, nil
+	}
+	l.Error(err, fmt.Sprintf("Failed to get %s from the %s", resource, from))
+	return ctrl.Result{}, err
+}


### PR DESCRIPTION
If the snapshot component cannot be found, we should retry.  If it still cannot be found the snapshot should not be requeued.  This change adds retries to the controller and does not signal the controller to retry if the component cannot be found.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
