### PR TITLE
feat: copy App Studio annotations from ITS to PR

### DIFF
--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -541,6 +541,7 @@ func (a *Adapter) createIntegrationPipelineRun(application *applicationapiv1alph
 	pipelineRun := tekton.NewIntegrationPipelineRun(snapshot.Name, application.Namespace, *integrationTestScenario).
 		WithSnapshot(snapshot).
 		WithIntegrationLabels(integrationTestScenario).
+		WithIntegrationAnnotations(integrationTestScenario).
 		WithApplicationAndComponent(a.application, a.component).
 		WithExtraParams(integrationTestScenario.Spec.Params).
 		AsPipelineRun()

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/api/v1beta1"
@@ -174,6 +175,21 @@ func (r *IntegrationPipelineRun) WithIntegrationLabels(integrationTestScenario *
 
 	if metadata.HasLabel(integrationTestScenario, OptionalLabel) {
 		r.ObjectMeta.Labels[OptionalLabel] = integrationTestScenario.Labels[OptionalLabel]
+	}
+
+	return r
+}
+
+// WithIntegrationAnnotations copies the App Studio annotations from the
+// IntegrationTestScenario to the PipelineRun
+func (r *IntegrationPipelineRun) WithIntegrationAnnotations(its *v1beta1.IntegrationTestScenario) *IntegrationPipelineRun {
+	for k, v := range its.GetAnnotations() {
+		if strings.Contains(k, "appstudio.openshift.io/") {
+			if err := metadata.SetAnnotation(r, k, v); err != nil {
+				// this will only happen if we pass IntegrationPipelineRun as nil
+				panic(err)
+			}
+		}
 	}
 
 	return r


### PR DESCRIPTION
Copies any App Studio annotations, ones that contain the string `appstudio.openshift.io/` in their key, to the Tekton PipelineRun.

Ref. https://issues.redhat.com/browse/HACBS-2548

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
