### PR TITLE
WIP: fix(STONEINTG-631): remove genericEvent from Snapshot predicate

### DIFF
--- a/gitops/snapshot_predicate.go
+++ b/gitops/snapshot_predicate.go
@@ -22,7 +22,7 @@ import (
 )
 
 // IntegrationSnapshotChangePredicate returns a predicate which filters out all objects except
-// snapshot is deleted and requires HasSnapshotTestingChangedToFinished for update events.
+// snapshot is created and requires HasSnapshotTestingChangedToFinished for update events.
 func IntegrationSnapshotChangePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
@@ -32,7 +32,7 @@ func IntegrationSnapshotChangePredicate() predicate.Predicate {
 			return false
 		},
 		GenericFunc: func(genericEvent event.GenericEvent) bool {
-			return true
+			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return HasSnapshotTestingChangedToFinished(e.ObjectOld, e.ObjectNew)

--- a/gitops/snapshot_predicate_test.go
+++ b/gitops/snapshot_predicate_test.go
@@ -139,5 +139,11 @@ var _ = Describe("Predicates", Ordered, func() {
 			}
 			Expect(instance.Delete(contextEvent)).To(BeFalse())
 		})
+		It("returns false when the Snapshot encounters a generic event", func() {
+			contextEvent := event.GenericEvent{
+				Object: hasSnapshotUnknownStatus,
+			}
+			Expect(instance.Generic(contextEvent)).To(BeFalse())
+		})
 	})
 })


### PR DESCRIPTION
* The Snapshot controller shouldn't react to genericEvents

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
