### PR TITLE
fix(stoneintg-584): do not requeue SEB if application cannot be found

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_controller_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_controller_test.go
@@ -298,11 +298,19 @@ var _ = Describe("BindingController", func() {
 	})
 
 	It("can fail when Reconcile fails to prepare the adapter when Application is not found", func() {
-		Expect(k8sClient.Delete(ctx, hasApp)).Should(Succeed())
-		Eventually(func() error {
-			_, err := bindingReconciler.Reconcile(ctx, req)
-			return err
-		}).ShouldNot(BeNil())
+		err := k8sClient.Delete(ctx, hasApp)
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: hasComp.ObjectMeta.Namespace,
+				Name:      hasComp.ObjectMeta.Name,
+			}, hasApp)
+			return err != nil && errors.IsNotFound(err)
+		}).Should(BeTrue())
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+
+		result, err := bindingReconciler.Reconcile(ctx, req)
+		Expect(result).To(Equal(ctrl.Result{}))
+		Expect(err).To(BeNil())
 	})
 
 	It("can fail when Reconcile fails to prepare the adapter when Snapshot is not found", func() {


### PR DESCRIPTION
Ordinarilly if the application associated with an SEB cannot be found we fail and requeue the reconciliation for that SEB.  This change adds retries to the retrieval of the application and does away with the requeue if it cannot be found.  This way if the user deletes an application the SEB will not be permanently stuck in a reconcile state.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
