### PR TITLE
hotfix: remove HandleLoaderError from logger struct

### DIFF
--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -103,7 +103,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return err
 	})
 	if err != nil {
-		return logger.HandleLoaderError(err, "Component", "Snapshot")
+		return helpers.HandleLoaderError(logger, err, "Component", "Snapshot")
 	}
 
 	adapter := NewAdapter(snapshot, application, component, logger, loader, r.Client, ctx)

--- a/helpers/errorhandlers.go
+++ b/helpers/errorhandlers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023.
+Copyright 2023 Red Hat Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -20,11 +20,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (l IntegrationLogger) HandleLoaderError(err error, resource, from string) (ctrl.Result, error) {
+func HandleLoaderError(logger IntegrationLogger, err error, resource, from string) (ctrl.Result, error) {
 	if errors.IsNotFound(err) {
-		l.Info(fmt.Sprintf("Could not get %[1]s from %[2]s.  %[1]s may have been removed.  Declining to proceed with reconciliation", resource, from))
+		logger.Info(fmt.Sprintf("Could not get %[1]s from %[2]s.  %[1]s may have been removed.  Declining to proceed with reconciliation", resource, from))
 		return ctrl.Result{}, nil
 	}
-	l.Error(err, fmt.Sprintf("Failed to get %s from the %s", resource, from))
+	logger.Error(err, fmt.Sprintf("Failed to get %s from the %s", resource, from))
 	return ctrl.Result{}, err
 }


### PR DESCRIPTION
Changes part of the fix merged in #329.  Just turns `HandleLoaderError` into a function rather than a method.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
