### PR TITLE
fix(STONEINTG-632): accept warning test result as passed

### DIFF
--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -214,7 +214,9 @@ func (ipro *IntegrationPipelineRunOutcome) HasPipelineRunPassedTesting() bool {
 		return false
 	}
 	for _, result := range ipro.results {
-		if result.Result != AppStudioTestOutputSuccess && result.Result != AppStudioTestOutputSkipped {
+		if result.Result != AppStudioTestOutputSuccess &&
+			result.Result != AppStudioTestOutputSkipped &&
+			result.Result != AppStudioTestOutputWarning {
 			return false
 		}
 	}


### PR DESCRIPTION
Integration-service must accept checks with warnings as passed tests. Warning is not a failure.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
