### PR TITLE
refactor(STONEINTG-539): EnsureCreationOfEnvironments

### DIFF
--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -855,6 +855,10 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					ContextKey: loader.RequiredIntegrationTestScenariosContextKey,
 					Resource:   []v1beta1.IntegrationTestScenario{*integrationTestScenario, *integrationTestScenarioWithoutEnv},
 				},
+				{
+					ContextKey: loader.SnapshotEnvironmentBindingContextKey,
+					Resource:   nil,
+				},
 			})
 		})
 
@@ -895,7 +899,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			result, err := adapter.EnsureCreationOfEnvironment()
 			Expect(!result.CancelRequest && err == nil).To(BeTrue())
 
-			expectedLogEntry := "An ephemeral Environment is created for integrationTestScenario"
+			expectedLogEntry := "Ephemeral environment is created for integrationTestScenario"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			expectedLogEntry = "A snapshotEnvironmentbinding is created"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))


### PR DESCRIPTION
Making `EnsureCreationOfEnvironments` reusable for single test creation.

`ensureEphemeralEnvironmentForScenarioExists` contains refactored part that allows to ensure existence of ephemeral env for single scenario

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
