### PR TITLE
feat(statusreporting): add feature flag

### DIFF
--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -18,6 +18,7 @@ package statusreport
 
 import (
 	"context"
+	"os"
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/helpers"
@@ -27,6 +28,8 @@ import (
 	"github.com/redhat-appstudio/operator-toolkit/controller"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const FeatureFlagStatusReprotingEnabled = "FEATURE_STATUS_REPORTING_ENABLED"
 
 // Adapter holds the objects needed to reconcile a snapshot's test status report.
 type Adapter struct {
@@ -56,6 +59,10 @@ func NewAdapter(snapshot *applicationapiv1alpha1.Snapshot, application *applicat
 // EnsureSnapshotTestStatusReported will ensure that integration test status including env provision and snapshotEnvironmentBinding error is reported to the git provider
 // which (indirectly) triggered its execution.
 func (a *Adapter) EnsureSnapshotTestStatusReported() (controller.OperationResult, error) {
+	if !isFeatureEnabled() {
+		return controller.ContinueProcessing()
+	}
+
 	reporters, err := a.status.GetReporters(a.snapshot)
 	if err != nil {
 		return controller.RequeueWithError(err)
@@ -70,4 +77,12 @@ func (a *Adapter) EnsureSnapshotTestStatusReported() (controller.OperationResult
 	}
 
 	return controller.ContinueProcessing()
+}
+
+// isFeatureEnabled returns true when the feature flag FEATURE_STATUS_REPORTING_ENABLED has been defined in env vars
+func isFeatureEnabled() bool {
+	if _, found := os.LookupEnv(FeatureFlagStatusReprotingEnabled); found {
+		return true
+	}
+	return false
 }

--- a/controllers/statusreport/statusreport_adapter_test.go
+++ b/controllers/statusreport/statusreport_adapter_test.go
@@ -19,6 +19,7 @@ package statusreport
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -130,6 +131,10 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, hasSnapshot)).Should(Succeed())
+
+		// enable feature flag for testing
+		err := os.Setenv(FeatureFlagStatusReprotingEnabled, "yes")
+		Expect(err).To(BeNil())
 	})
 
 	AfterAll(func() {
@@ -137,6 +142,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasApp)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+
+		_ = os.Unsetenv(FeatureFlagStatusReprotingEnabled)
 	})
 
 	When("adapter is created", func() {


### PR DESCRIPTION
Adding feature flag FEATURE_STATUS_REPORTING_ENABLED to enable feature for reporting tests statuses into pull requestes. Featue is not ready yet, thus is disabled by default.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
