### PR TITLE
fix(STONEINTG-488): call SetupController func for Component Controller

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/redhat-appstudio/integration-service/controllers/binding"
 	"github.com/redhat-appstudio/integration-service/controllers/buildpipeline"
+	"github.com/redhat-appstudio/integration-service/controllers/component"
 	"github.com/redhat-appstudio/integration-service/controllers/integrationpipeline"
 	"github.com/redhat-appstudio/integration-service/controllers/scenario"
 	"github.com/redhat-appstudio/integration-service/controllers/snapshot"
@@ -36,6 +37,7 @@ var setupFunctions = []func(manager.Manager, *logr.Logger) error{
 	scenario.SetupController,
 	binding.SetupController,
 	statusreport.SetupController,
+	component.SetupController,
 }
 
 // SetupControllers invoke all SetupController functions defined in setupFunctions, setting all controllers up and


### PR DESCRIPTION
Add missing call required for component controller to setup correctly on a cluster.
Signed-off-by: Josh Everett <jeverett@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
