### PR TITLE
feat(stoneintg-600): Add finalizers to build pipeline runs

### DIFF
--- a/controllers/buildpipeline/buildpipeline_controller_test.go
+++ b/controllers/buildpipeline/buildpipeline_controller_test.go
@@ -29,6 +29,7 @@ import (
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -229,6 +230,7 @@ var _ = Describe("PipelineController", func() {
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasComp)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		_ = controllerutil.RemoveFinalizer(buildPipelineRun, "build.appstudio.openshift.io/pipelinerun")
 		err = k8sClient.Delete(ctx, buildPipelineRun)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, successfulTaskRun)

--- a/docs/build_pipeline_controller.md
+++ b/docs/build_pipeline_controller.md
@@ -11,16 +11,27 @@ flowchart TD
 
   %% Node definitions
 predicate((PREDICATE: <br> Filter events related to <br> PipelineRuns <br> proccessed by Chains <br> that have <br> succeeded))
-get_pipeline_run{Pipeline found?}
+new_pipeline_run{Pipeline created?}
+get_pipeline_run{Pipeline updated?}
+failed_pipeline_run{Pipeline failed?}
+finalizer_exists{Does the finalizer already exist?}
 retrieve_associated_entity(Retrieve the entity <br> component/application)
 determine_snapshot{Does a snapshot exist?}
 create_snapshot(Gather Application components<br> Add new component  <br> Create snapshot)
 annotate_pipelineRun(Annotate pipeline with <br> name of Snapshot)
+add_finalizer(Add finalizer to build PLR)
+remove_finalizer(Remove finalizer from build PLR)
 error[Return error]
 continue[Continue processing]
 
 %% Node connections
 predicate                        --> get_pipeline_run
+predicate                       -->  new_pipeline_run
+predicate                       -->  failed_pipeline_run
+new_pipeline_run           --Yes-->  finalizer_exists
+finalizer_exists           --No-->   add_finalizer
+add_finalizer                    --> continue
+failed_pipeline_run           --Yes --> remove_finalizer
 get_pipeline_run           --Yes --> retrieve_associated_entity
 get_pipeline_run           --No  --> error
 retrieve_associated_entity --No  --> error
@@ -29,7 +40,8 @@ retrieve_associated_entity --Yes --> determine_snapshot
 determine_snapshot         --Yes --> annotate_pipelineRun
 determine_snapshot         --No  --> create_snapshot
 create_snapshot            --Yes --> annotate_pipelineRun
-annotate_pipelineRun       --Yes --> continue
+annotate_pipelineRun       --Yes --> remove_finalizer
+remove_finalizer                 --> continue
 
 %% Assigning styles to nodes
 class predicate Amber;

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
 	k8s.io/klog/v2 v2.110.1
+	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
 	knative.dev/pkg v0.0.0-20230221145627-8efb3485adcf
 	sigs.k8s.io/controller-runtime v0.16.3
 )
@@ -98,7 +99,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.28.3 // indirect
 	k8s.io/component-base v0.28.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
-	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -423,3 +423,19 @@ func RemoveFinalizerFromPipelineRun(adapterClient client.Client, logger Integrat
 
 	return nil
 }
+
+// AddFinalizerToPipelineRun adds the finalizer to the PipelineRun.
+// If finalizer was not added successfully, a non-nil error is returned.
+func AddFinalizerToPipelineRun(adapterClient client.Client, logger IntegrationLogger, ctx context.Context, pipelineRun *tektonv1.PipelineRun, finalizer string) error {
+	patch := client.MergeFrom(pipelineRun.DeepCopy())
+	if ok := controllerutil.AddFinalizer(pipelineRun, finalizer); ok {
+		err := adapterClient.Patch(ctx, pipelineRun, patch)
+		if err != nil {
+			return fmt.Errorf("error occurred while patching the updated PipelineRun after finalizer addition: %w", err)
+		}
+
+		logger.LogAuditEvent("Added Finalizer to the Integration PipelineRun", pipelineRun, LogActionUpdate, "finalizer", finalizer)
+	}
+
+	return nil
+}

--- a/tekton/predicates.go
+++ b/tekton/predicates.go
@@ -65,3 +65,43 @@ func BuildPipelineRunSignedAndSucceededPredicate() predicate.Predicate {
 		},
 	}
 }
+
+// BuildPipelineRunFailedPredicate returns a predicate which filters out all objects except Build
+// PipelineRuns which have finished and have failed.
+func BuildPipelineRunFailedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return IsBuildPipelineRun(e.ObjectNew) &&
+				isChainsDoneWithPipelineRun(e.ObjectNew) &&
+				!helpers.HasPipelineRunSucceeded(e.ObjectNew)
+		},
+	}
+}
+
+// BuildPipelineRunCreatedPredicate returns a predicate which filters out all objects except
+// Build PipelineRuns which have been created
+func BuildPipelineRunCreatedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return IsBuildPipelineRun(createEvent.Object)
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return false
+		},
+	}
+}


### PR DESCRIPTION
Because of the introduction of more aggressive resource pruning in RHTAP, the integration service must add finalizers to build pipeline runs when they are created.  This will ensure that the integration service can create snapshots of for successful builds.  Once the snapshot is created the finalizer will be removed so that the resource can be cleaned up.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
