### PR TITLE
feat(STONEINTG-613): remove status report from PLR controller

### DIFF
--- a/controllers/integrationpipeline/integrationpipeline_adapter.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter.go
@@ -61,24 +61,6 @@ func NewAdapter(pipelineRun *tektonv1beta1.PipelineRun, component *applicationap
 	}
 }
 
-// EnsureStatusReported will ensure that integration PipelineRun status is reported to the git provider
-// which (indirectly) triggered its execution.
-func (a *Adapter) EnsureStatusReported() (controller.OperationResult, error) {
-	reporters, err := a.status.GetReporters(a.pipelineRun)
-
-	if err != nil {
-		return controller.RequeueWithError(err)
-	}
-
-	for _, reporter := range reporters {
-		if err := reporter.ReportStatus(a.client, a.context, a.pipelineRun); err != nil {
-			return controller.RequeueWithError(err)
-		}
-	}
-
-	return controller.ContinueProcessing()
-}
-
 // EnsureStatusReportedInSnapshot will ensure that status of the integration test pipelines is reported to snapshot
 // to be consumed by user
 func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, error) {

--- a/controllers/integrationpipeline/integrationpipeline_controller.go
+++ b/controllers/integrationpipeline/integrationpipeline_controller.go
@@ -109,14 +109,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureStatusReportedInSnapshot,
-		adapter.EnsureStatusReported,
 		adapter.EnsureEphemeralEnvironmentsCleanedUp,
 	})
 }
 
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
-	EnsureStatusReported() (controller.OperationResult, error)
 	EnsureStatusReportedInSnapshot() (controller.OperationResult, error)
 	EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationResult, error)
 }

--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -23,7 +23,6 @@ import (
 	"github.com/redhat-appstudio/integration-service/gitops"
 	"github.com/redhat-appstudio/integration-service/metrics"
 	"github.com/redhat-appstudio/operator-toolkit/metadata"
-	"os"
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/helpers"
@@ -34,8 +33,6 @@ import (
 	"github.com/redhat-appstudio/operator-toolkit/controller"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-const FeatureFlagStatusReprotingEnabled = "FEATURE_STATUS_REPORTING_ENABLED"
 
 // Adapter holds the objects needed to reconcile a snapshot's test status report.
 type Adapter struct {
@@ -62,10 +59,10 @@ func NewAdapter(snapshot *applicationapiv1alpha1.Snapshot, application *applicat
 	}
 }
 
-// EnsureSnapshotTestStatusReported will ensure that integration test status including env provision and snapshotEnvironmentBinding error is reported to the git provider
+// EnsureSnapshotTestStatusReportedToGitHub will ensure that integration test status including env provision and snapshotEnvironmentBinding error is reported to the git provider
 // which (indirectly) triggered its execution.
-func (a *Adapter) EnsureSnapshotTestStatusReported() (controller.OperationResult, error) {
-	if !isFeatureEnabled() || !gitops.IsSnapshotCreatedByPACPullRequestEvent(a.snapshot) {
+func (a *Adapter) EnsureSnapshotTestStatusReportedToGitHub() (controller.OperationResult, error) {
+	if !gitops.IsSnapshotCreatedByPACPullRequestEvent(a.snapshot) {
 		return controller.ContinueProcessing()
 	}
 
@@ -83,14 +80,6 @@ func (a *Adapter) EnsureSnapshotTestStatusReported() (controller.OperationResult
 	}
 
 	return controller.ContinueProcessing()
-}
-
-// isFeatureEnabled returns true when the feature flag FEATURE_STATUS_REPORTING_ENABLED has been defined in env vars
-func isFeatureEnabled() bool {
-	if _, found := os.LookupEnv(FeatureFlagStatusReprotingEnabled); found {
-		return true
-	}
-	return false
 }
 
 // EnsureSnapshotFinishedAllTests is an operation that will ensure that a pipeline Snapshot

--- a/controllers/statusreport/statusreport_adapter_test.go
+++ b/controllers/statusreport/statusreport_adapter_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/redhat-appstudio/integration-service/api/v1beta1"
 	"github.com/tonglil/buflogr"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"os"
 	"reflect"
 	"time"
 
@@ -34,7 +33,6 @@ import (
 	"github.com/redhat-appstudio/integration-service/loader"
 	intgteststat "github.com/redhat-appstudio/integration-service/pkg/integrationteststatus"
 	"github.com/redhat-appstudio/integration-service/status"
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -52,11 +50,6 @@ type MockStatusAdapter struct {
 type MockStatusReporter struct {
 	Called            bool
 	ReportStatusError error
-}
-
-func (r *MockStatusReporter) ReportStatus(client.Client, context.Context, *tektonv1beta1.PipelineRun) error {
-	r.Called = true
-	return r.ReportStatusError
 }
 
 func (r *MockStatusReporter) ReportStatusForSnapshot(client.Client, context.Context, *helpers.IntegrationLogger, *applicationapiv1alpha1.Snapshot) error {
@@ -260,10 +253,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, hasSnapshot)).Should(Succeed())
-
-		// enable feature flag for testing
-		err := os.Setenv(FeatureFlagStatusReprotingEnabled, "yes")
-		Expect(err).To(BeNil())
 	})
 
 	AfterEach(func() {
@@ -293,7 +282,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					Resource:   hasPRSnapshot,
 				},
 			})
-			result, err := adapter.EnsureSnapshotTestStatusReported()
+			result, err := adapter.EnsureSnapshotTestStatusReportedToGitHub()
 			fmt.Fprintf(GinkgoWriter, "-------err: %v\n", err)
 			fmt.Fprintf(GinkgoWriter, "-------result: %v\n", result)
 			Expect(!result.CancelRequest && err == nil).To(BeTrue())

--- a/controllers/statusreport/statusreport_controller.go
+++ b/controllers/statusreport/statusreport_controller.go
@@ -81,14 +81,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	adapter := NewAdapter(snapshot, application, logger, loader, r.Client, ctx)
 	return controller.ReconcileHandler([]controller.Operation{
-		adapter.EnsureSnapshotTestStatusReported,
+		adapter.EnsureSnapshotTestStatusReportedToGitHub,
 		adapter.EnsureSnapshotFinishedAllTests,
 	})
 }
 
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
-	EnsureSnapshotTestStatusReported() (controller.OperationResult, error)
+	EnsureSnapshotTestStatusReportedToGitHub() (controller.OperationResult, error)
 	EnsureSnapshotFinishedAllTests() (controller.OperationResult, error)
 }
 

--- a/docs/statusreport-controller.md
+++ b/docs/statusreport-controller.md
@@ -8,7 +8,7 @@ flowchart TD
 
   predicate((PREDICATE: <br>Snapshot has annotation <br>test.appstudio.openshift.io/status <br>changed))
 
-  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureSnapshotTestStatusReported() function 
+  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureSnapshotTestStatusReportedToGitHub() function
 
   %% Node definitions
   ensure(Process further if: Snapshot has label <br>pac.test.appstudio.openshift.io/git-provider:github <br>defined)
@@ -30,11 +30,14 @@ flowchart TD
   create_commitStatusAdapter(Create commitStatusAdapter according to <br>commit owner, repo, SHA <br>and integration test status)
   does_commitStatus_exist{Does commitStatus exist <br>on github already?}
   create_new_commitStatus_on_gh(Create new commitStatus on github)
+  does_comment_exist(Does a comment exist for snapshot and scenario?)
+  update_existing_comment(Update the existing comment for <br>snapshot and scenario</br>)
+  create_new_comment(Create a new comment for <br>snapshot and scenario</br>)
 
   continue_processing(Controller continues processing)
 
   %% Node connections
-  predicate                      ---->    |"EnsureSnapshotTestStatusReported()"|ensure
+  predicate                      ---->    |"EnsureSnapshotTestStatusReportedToGitHub()"|ensure
   ensure                         -->      get_annotation_value
   get_annotation_value           -->      collect_commit_info
   collect_commit_info            --> is_installation_defined
@@ -56,9 +59,13 @@ flowchart TD
   create_commitStatusAdapter     --> does_commitStatus_exist
   does_commitStatus_exist        --Yes--> continue_processing
   does_commitStatus_exist        --No--> create_new_commitStatus_on_gh
-  create_new_commitStatus_on_gh  --> continue_processing
+  create_new_commitStatus_on_gh  --> does_comment_exist
+  does_comment_exist             --Yes--> update_existing_comment
+  does_comment_exist             --No--> create_new_comment
+  update_existing_comment        --> continue_processing
+  create_new_comment             --> continue_processing
 
-%%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureSnapshotTestStatusReported() function 
+%%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureSnapshotFinishedAllTests() function
 
 %% Node definitions
   

--- a/git/github/github_test.go
+++ b/git/github/github_test.go
@@ -110,6 +110,21 @@ func (MockIssuesService) CreateComment(
 	return &ghapi.IssueComment{ID: &id}, nil, nil
 }
 
+// ListComments implements github.IssuesService
+func (MockIssuesService) ListComments(ctx context.Context, owner string, repo string,
+	number int, opts *ghapi.IssueListCommentsOptions) ([]*ghapi.IssueComment, *ghapi.Response, error) {
+	var id int64 = 40
+	var body string = "Integration test for snapshot snapshotName and scenario scenarioName"
+	issueComments := []*ghapi.IssueComment{{ID: &id, Body: &body}}
+	return issueComments, nil, nil
+}
+
+// EditComment implements github.IssuesService
+func (MockIssuesService) EditComment(ctx context.Context, owner string, repo string, number int64, comment *ghapi.IssueComment,
+) (*ghapi.IssueComment, *ghapi.Response, error) {
+	return &ghapi.IssueComment{ID: &number}, nil, nil
+}
+
 type MockRepositoriesService struct{}
 
 // CreateStatus implements github.RepositoriesService
@@ -308,5 +323,20 @@ var _ = Describe("Client", func() {
 		commitStatusExist, err = client.CommitStatusExists(commitStatuses, commitStatusAdapter)
 		Expect(commitStatusExist).To(BeFalse())
 		Expect(err).To(BeNil())
+	})
+
+	It("can get existing comment id", func() {
+		comments, err := client.GetAllCommentsForPR(context.TODO(), "", "", 1)
+		Expect(err).To(BeNil())
+		Expect(len(comments) > 0).To(BeTrue())
+
+		commentID := client.GetExistingCommentID(comments, "snapshotName", "scenarioName")
+		Expect(*commentID).To(Equal(int64(40)))
+	})
+
+	It("can edit comments", func() {
+		id, err := client.EditComment(context.TODO(), "", "", 1, "example-comment")
+		Expect(err).To(BeNil())
+		Expect(id).To(Equal(int64(1)))
 	})
 })

--- a/status/format.go
+++ b/status/format.go
@@ -66,8 +66,8 @@ func FormatSummary(taskRuns []*helpers.TaskRun) (string, error) {
 	return buf.String(), nil
 }
 
-// FormatComment builds a markdown comment for a list of integration TaskRuns.
-func FormatComment(title string, results []*helpers.TaskRun) (string, error) {
+// FormatCommentForFinishedPipelineRun builds a markdown comment for a list of finished integration TaskRuns
+func FormatCommentForFinishedPipelineRun(title string, results []*helpers.TaskRun) (string, error) {
 	summary, err := FormatSummary(results)
 	if err != nil {
 		return "", err
@@ -75,6 +75,17 @@ func FormatComment(title string, results []*helpers.TaskRun) (string, error) {
 
 	buf := bytes.Buffer{}
 	data := CommentTemplateData{Title: title, Summary: summary}
+	t := template.Must(template.New("").Parse(commentTemplate))
+	if err := t.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// FormatCommentForDetail build a markdown comment for the details of unfinished integrationTest
+func FormatCommentForDetail(title, detail string) (string, error) {
+	buf := bytes.Buffer{}
+	data := CommentTemplateData{Title: title, Summary: detail}
 	t := template.Must(template.New("").Parse(commentTemplate))
 	if err := t.Execute(&buf, data); err != nil {
 		return "", err

--- a/status/format_test.go
+++ b/status/format_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Formatters", func() {
 	})
 
 	It("can construct a comment", func() {
-		comment, err := status.FormatComment("example-title", taskRuns)
+		comment, err := status.FormatCommentForFinishedPipelineRun("example-title", taskRuns)
 		Expect(err).To(BeNil())
 		Expect(comment).To(ContainSubstring("### example-title"))
 		Expect(comment).To(ContainSubstring(expectedSummary))

--- a/status/status.go
+++ b/status/status.go
@@ -24,7 +24,6 @@ import (
 	"github.com/redhat-appstudio/integration-service/gitops"
 	"github.com/redhat-appstudio/integration-service/helpers"
 	"github.com/redhat-appstudio/operator-toolkit/metadata"
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,7 +32,6 @@ const NamePrefix = "Red Hat Trusted App Test"
 
 // Reporter is a generic interface all status implementations must follow.
 type Reporter interface {
-	ReportStatus(client.Client, context.Context, *tektonv1beta1.PipelineRun) error
 	ReportStatusForSnapshot(client.Client, context.Context, *helpers.IntegrationLogger, *applicationapiv1alpha1.Snapshot) error
 }
 

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -33,10 +33,6 @@ import (
 
 type MockReporter struct{}
 
-func (r *MockReporter) ReportStatus(client.Client, context.Context, *tektonv1beta1.PipelineRun) error {
-	return nil
-}
-
 func (r *MockReporter) ReportStatusForSnapshot(client.Client, context.Context, *helpers.IntegrationLogger, *applicationapiv1alpha1.Snapshot) error {
 	return nil
 }


### PR DESCRIPTION
* remove status report from integrationPLR controller
* create comment to PR in statusreport controller for github webhook
* add test result to report of statusreport
* update comment if there is one existing comment of snapshot and scenario test status
* update controller diagram

checkRun example: https://github.com/hongliuorg/devfile-sample-go-basic/pull/4/checks?check_run_id=16776195643
commitStatus/comment example: https://github.com/hongweiliu17/devfile-sample-go-basic/pull/2

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
