### PR TITLE
fix(STONEINTG-585): update owner reference to snapshot for SEBs

### DIFF
--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -671,7 +671,7 @@ func (a *Adapter) createSnapshotEnvironmentBindingForSnapshot(application *appli
 			return nil, err
 		}
 	} else {
-		err := ctrl.SetControllerReference(application, snapshotEnvironmentBinding, a.client.Scheme())
+		err := ctrl.SetControllerReference(snapshot, snapshotEnvironmentBinding, a.client.Scheme())
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -723,7 +723,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 			owners := binding.GetOwnerReferences()
 			Expect(len(owners) == 1).To(BeTrue())
-			Expect(owners[0].Name).To(Equal(hasApp.Name))
+			Expect(owners[0].Name).To(Equal(hasSnapshot.Name))
 
 			err = k8sClient.Delete(ctx, &binding)
 			Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())


### PR DESCRIPTION
## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
