### PR TITLE
fix(updateExistingSnapshotEnvironmentBindingWithSnapshot): segfault

### DIFF
--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -370,7 +370,7 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (controller.OperationR
 			return controller.RequeueWithError(err)
 		}
 		if snapshotEnvironmentBinding != nil {
-			snapshotEnvironmentBinding, err = a.updateExistingSnapshotEnvironmentBindingWithSnapshot(snapshotEnvironmentBinding, a.snapshot, components)
+			err = a.updateExistingSnapshotEnvironmentBindingWithSnapshot(snapshotEnvironmentBinding, a.snapshot, components)
 			if err != nil {
 				a.logger.Error(err, "Failed to update SnapshotEnvironmentBinding",
 					"snapshotEnvironmentBinding.Environment", snapshotEnvironmentBinding.Spec.Environment,
@@ -699,7 +699,7 @@ func (a *Adapter) createSnapshotEnvironmentBindingForSnapshot(application *appli
 // with the given snapshot and components. If it's not possible to patch, an error will be returned.
 func (a *Adapter) updateExistingSnapshotEnvironmentBindingWithSnapshot(snapshotEnvironmentBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding,
 	snapshot *applicationapiv1alpha1.Snapshot,
-	components *[]applicationapiv1alpha1.Component) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error) {
+	components *[]applicationapiv1alpha1.Component) error {
 
 	patch := client.MergeFrom(snapshotEnvironmentBinding.DeepCopy())
 
@@ -709,10 +709,10 @@ func (a *Adapter) updateExistingSnapshotEnvironmentBindingWithSnapshot(snapshotE
 
 	err := a.client.Patch(a.context, snapshotEnvironmentBinding, patch)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to patch snapshotEnvironmentBinding: %w", err)
 	}
 
-	return snapshotEnvironmentBinding, nil
+	return nil
 }
 
 // createCopyOfExistingEnvironment uses existing env as input, specifies namespace where the environment is situated,

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -888,11 +888,20 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				*secondComp,
 			}
 
-			updatedSnapshotEnvironmentBinding, err := adapter.updateExistingSnapshotEnvironmentBindingWithSnapshot(snapshotEnvironmentBinding, hasSnapshot, &componentsUpdate)
+			err = adapter.updateExistingSnapshotEnvironmentBindingWithSnapshot(snapshotEnvironmentBinding, hasSnapshot, &componentsUpdate)
 			Expect(err).To(BeNil())
-			Expect(updatedSnapshotEnvironmentBinding).NotTo(BeNil())
-			Expect(len(updatedSnapshotEnvironmentBinding.Spec.Components) == 1)
-			Expect(updatedSnapshotEnvironmentBinding.Spec.Components[0].Name == secondComp.Spec.ComponentName)
+
+			// get fresh copy to make sure that SEB was updated in k8s
+			updatedSEB := &applicationapiv1alpha1.SnapshotEnvironmentBinding{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: snapshotEnvironmentBinding.Namespace,
+					Name:      snapshotEnvironmentBinding.Name,
+				}, updatedSEB)
+				return err == nil && len(updatedSEB.Spec.Components) == 1
+			}, time.Second*10).Should(BeTrue())
+			Expect(updatedSEB.Spec.Components[0].Name == secondComp.Spec.ComponentName)
+
 			err = k8sClient.Delete(ctx, snapshotEnvironmentBinding)
 			Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		})


### PR DESCRIPTION
Logger is causing segfault from `snapshotEnvironmentBinding.Spec.Environment`, because updateExistingSnapshotEnvironmentBindingWithSnapshot may return nil pointer when patching failed, and logger tries to access to struct values of nil pointer.

At first that function doens't need to return pointer, because it already received a pointer as parameter, and it's exactly the same pointer.

Also unittest has been updated to test, if resource has been really patched.

Segfault traceback:
```
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x118 pc=0x180b176]

goroutine 1638 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:119 +0x1fa
panic({0x19d1520, 0x2d5ba40})
	/opt/hostedtoolcache/go/1.19.13/x64/src/runtime/panic.go:884 +0x212
github.com/redhat-appstudio/integration-service/controllers/snapshot.(*Adapter).EnsureSnapshotEnvironmentBindingExist(0xc000ec7a90)
	/home/runner/work/integration-service/integration-service/controllers/snapshot/snapshot_adapter.go:377 +0x8b6
github.com/redhat-appstudio/operator-toolkit/controller.ReconcileHandler({0xc000ec7a68, 0x5, 0x3fb999999999999a?})
	/home/runner/go/pkg/mod/github.com/redhat-appstudio/operator-toolkit@v0.0.0-20230913085326-6c5e9d368a6a/controller/handler.go:25 +0x49
github.com/redhat-appstudio/integration-service/controllers/snapshot.(*Reconciler).Reconcile(0xc0005412f0, {0x1f2dfd8?, 0xc000d9aba0}, {{{0xc00066f186, 0x7}, {0xc00066f190, 0xf}}})
	/home/runner/work/integration-service/integration-service/controllers/snapshot/snapshot_controller.go:111 +0x845
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1f2dfd8?, {0x1f2dfd8?, 0xc000d9aba0?}, {{{0xc00066f186?, 0x193c820?}, {0xc00066f190?, 0xc000cdf0e0?}}})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0009779a0, {0x1f2df30, 0xc0007c0500}, {0x1a451a0?, 0xc000cdf0e0?})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323 +0x3a5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0009779a0, {0x1f2df30, 0xc0007c0500})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:231 +0x333
```

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
