### PR TITLE
chore(workflow): mark size of PRs

### DIFF
--- a/.github/workflows/size.yaml
+++ b/.github/workflows/size.yaml
@@ -1,0 +1,38 @@
+name: Pull request size
+on: pull_request_target
+
+jobs:
+  size-label:
+    name: Size label
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Calculate size
+        run: |
+          #!/usr/bin/bash
+          set -euo pipefail
+
+          additions=$(curl -s "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" | jq '.additions')
+          deletions=$(curl -s "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" | jq '.deletions')
+          size=$((additions + deletions))
+
+          sizelabel=XS
+          if [ ${size} -gt 500 ]; then
+            sizelabel="XXL"
+          elif [ ${size} -gt 200 ]; then
+            sizelabel="XL"
+          elif [ ${size} -gt 100 ]; then
+            sizelabel="L"
+          elif [ ${size} -gt 50 ]; then
+            sizelabel="M"
+          elif [ ${size} -gt 30 ]; then
+            sizelabel="S"
+          fi
+
+          echo "Adding size: ${sizelabel}"
+          curl -s --fail-with-body -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+            -d "[\"size: ${sizelabel}\"]"


### PR DESCRIPTION
Add labels with PR size into PRs based on number of changed lines

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
