### PR TITLE
fix(STONEINTG-583): add status conditions when converting to v1beta1

### DIFF
--- a/api/v1alpha1/integrationtestscenario_conversion.go
+++ b/api/v1alpha1/integrationtestscenario_conversion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 
 	"github.com/redhat-appstudio/integration-service/api/v1beta1"
@@ -36,6 +37,8 @@ func (src *IntegrationTestScenario) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1beta1.IntegrationTestScenario)
 	dst.ObjectMeta = src.ObjectMeta
 	dst.Spec.Application = src.Spec.Application
+	dst.Status = v1beta1.IntegrationTestScenarioStatus{Conditions: make([]metav1.Condition, 0)}
+
 	if !reflect.ValueOf(src.Spec.Environment).IsZero() {
 		dst.Spec.Environment = v1beta1.TestEnvironment(src.Spec.Environment)
 	}
@@ -49,6 +52,11 @@ func (src *IntegrationTestScenario) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.Contexts = append(dst.Spec.Contexts, v1beta1.TestContext(par))
 		}
 	}
+
+	if src.Status.Conditions != nil {
+		dst.Status.Conditions = append(dst.Status.Conditions, src.Status.Conditions...)
+	}
+
 	dst.Spec.ResolverRef = v1beta1.ResolverRef{
 		Resolver: "bundles",
 		Params: []v1beta1.ResolverParameter{


### PR DESCRIPTION
* This fix resolves the issue when converting v1alpha1 to v1beta1 IntegrationTestScenarios where the status.conditions is not added to the converted resource, resulting in the "scenario is invalid: status.conditions: Required value" error

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
