### PR TITLE
fix(STONEINTG-641): use snapshot for SEB components directly

### DIFF
--- a/gitops/binding.go
+++ b/gitops/binding.go
@@ -37,8 +37,8 @@ const (
 )
 
 // NewSnapshotEnvironmentBinding creates a new SnapshotEnvironmentBinding using the provided info.
-func NewSnapshotEnvironmentBinding(bindingName string, namespace string, applicationName string, environmentName string, snapshot *applicationapiv1alpha1.Snapshot, components []applicationapiv1alpha1.Component) *applicationapiv1alpha1.SnapshotEnvironmentBinding {
-	bindingComponents := NewBindingComponents(components)
+func NewSnapshotEnvironmentBinding(bindingName string, namespace string, applicationName string, environmentName string, snapshot *applicationapiv1alpha1.Snapshot) *applicationapiv1alpha1.SnapshotEnvironmentBinding {
+	bindingComponents := NewBindingComponents(snapshot)
 
 	snapshotEnvironmentBinding := &applicationapiv1alpha1.SnapshotEnvironmentBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -58,11 +58,11 @@ func NewSnapshotEnvironmentBinding(bindingName string, namespace string, applica
 
 // NewBindingComponents gets all components from the Snapshot and formats them to be used in the
 // SnapshotEnvironmentBinding as BindingComponents.
-func NewBindingComponents(components []applicationapiv1alpha1.Component) *[]applicationapiv1alpha1.BindingComponent {
+func NewBindingComponents(snapshot *applicationapiv1alpha1.Snapshot) *[]applicationapiv1alpha1.BindingComponent {
 	bindingComponents := []applicationapiv1alpha1.BindingComponent{}
-	for _, component := range components {
+	for _, component := range snapshot.Spec.Components {
 		bindingComponents = append(bindingComponents, applicationapiv1alpha1.BindingComponent{
-			Name: component.Spec.ComponentName,
+			Name: component.Name,
 		})
 	}
 	return &bindingComponents

--- a/gitops/binding_test.go
+++ b/gitops/binding_test.go
@@ -177,13 +177,13 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	It("ensures Binding Component is created", func() {
 		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
-		bindingComponents := gitops.NewBindingComponents([]applicationapiv1alpha1.Component{*hasComp})
+		bindingComponents := gitops.NewBindingComponents(hasSnapshot)
 		Expect(bindingComponents).NotTo(BeNil())
 		Expect(hasComp.Spec.Replicas).To(Equal(0))
 	})
 
 	It("ensures a new SnapshotEnvironmentBinding is created", func() {
-		newSnapshotEnvironmentBinding := gitops.NewSnapshotEnvironmentBinding("sample", namespace, hasApp.Name, env.Name, hasSnapshot, []applicationapiv1alpha1.Component{*hasComp})
+		newSnapshotEnvironmentBinding := gitops.NewSnapshotEnvironmentBinding("sample", namespace, hasApp.Name, env.Name, hasSnapshot)
 		Expect(newSnapshotEnvironmentBinding).NotTo(BeNil())
 		Expect(newSnapshotEnvironmentBinding.Spec.Snapshot).To(Equal(hasSnapshot.Name))
 		Expect(newSnapshotEnvironmentBinding.Spec.Environment).To(Equal(env.Name))

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -38,7 +38,6 @@ type ObjectLoader interface {
 	GetAllEnvironments(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Environment, error)
 	GetReleasesWithSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.Release, error)
 	GetAllApplicationComponents(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Component, error)
-	GetAllSnapshotComponents(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*[]applicationapiv1alpha1.Component, error)
 	GetApplicationFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Application, error)
 	GetComponentFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Component, error)
 	GetComponentFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1beta1.PipelineRun) (*applicationapiv1alpha1.Component, error)
@@ -119,27 +118,6 @@ func (l *loader) GetAllApplicationComponents(c client.Client, ctx context.Contex
 	}
 
 	return &applicationComponents.Items, nil
-}
-
-// GetAllSnapshotComponents loads from the cluster all Components associated with the given Snapshot.
-// If the Snapshot doesn't have any Components or this is not found in the cluster, an error will be returned.
-func (l *loader) GetAllSnapshotComponents(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*[]applicationapiv1alpha1.Component, error) {
-	components := []applicationapiv1alpha1.Component{}
-
-	for _, sc := range snapshot.Spec.Components {
-		component := &applicationapiv1alpha1.Component{}
-		err := c.Get(ctx, types.NamespacedName{
-			Namespace: snapshot.Namespace,
-			Name:      sc.Name,
-		}, component)
-		if err != nil {
-			return nil, err
-		}
-
-		components = append(components, *component)
-	}
-
-	return &components, nil
 }
 
 // GetApplicationFromSnapshot loads from the cluster the Application referenced in the given Snapshot.

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -124,15 +124,6 @@ func (l *mockLoader) GetAllApplicationComponents(c client.Client, ctx context.Co
 	return &components, err
 }
 
-// GetAllSnapshotComponents returns the resource and error passed as values of the context.
-func (l *mockLoader) GetAllSnapshotComponents(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*[]applicationapiv1alpha1.Component, error) {
-	if ctx.Value(SnapshotComponentsContextKey) == nil {
-		return l.loader.GetAllSnapshotComponents(c, ctx, snapshot)
-	}
-	components, err := getMockedResourceAndErrorFromContext(ctx, SnapshotComponentsContextKey, []applicationapiv1alpha1.Component{})
-	return &components, err
-}
-
 // GetApplicationFromSnapshot returns the resource and error passed as values of the context.
 func (l *mockLoader) GetApplicationFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Application, error) {
 	if ctx.Value(ApplicationContextKey) == nil {

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -139,21 +139,6 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		})
 	})
 
-	Context("When calling GetAllSnapshotComponents", func() {
-		It("returns resource and error from the context", func() {
-			snapshotComponents := []applicationapiv1alpha1.Component{}
-			mockContext := GetMockedContext(ctx, []MockData{
-				{
-					ContextKey: SnapshotComponentsContextKey,
-					Resource:   snapshotComponents,
-				},
-			})
-			resource, err := loader.GetAllSnapshotComponents(nil, mockContext, nil)
-			Expect(resource).To(Equal(&snapshotComponents))
-			Expect(err).To(BeNil())
-		})
-	})
-
 	Context("When calling GetApplicationFromSnapshot", func() {
 		It("returns resource and error from the context", func() {
 			application := &applicationapiv1alpha1.Application{}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -443,50 +443,6 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(applicationComponents).NotTo(BeNil())
 	})
 
-	It("ensures the Snapshot Components can be found ", func() {
-		snapshotComponents, err := loader.GetAllSnapshotComponents(k8sClient, ctx, hasSnapshot)
-		Expect(err).To(BeNil())
-		Expect(snapshotComponents).NotTo(BeNil())
-	})
-
-	It("ensures GetAllSnapshotComponents does not gather non-snapshot application components ", func() {
-		// otherComp has the same namespace and application as the snapshot,
-		// but does not belong to the snapshot itself.  When creating SEBs
-		// for older snapshots we do not want to accidentally add components
-		// for newer snapshots.
-		otherComp := &applicationapiv1alpha1.Component{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "other-component",
-				Namespace: "default",
-			},
-			Spec: applicationapiv1alpha1.ComponentSpec{
-				ComponentName:  "other-component",
-				Application:    applicationName,
-				ContainerImage: "",
-				Source: applicationapiv1alpha1.ComponentSource{
-					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
-						GitSource: &applicationapiv1alpha1.GitSource{
-							URL: SampleRepoLink,
-						},
-					},
-				},
-			},
-			Status: applicationapiv1alpha1.ComponentStatus{
-				LastBuiltCommit: "",
-			},
-		}
-		Expect(k8sClient.Create(ctx, otherComp)).Should(Succeed())
-		defer k8sClient.Delete(ctx, otherComp)
-
-		snapshotComponents, err := loader.GetAllSnapshotComponents(k8sClient, ctx, hasSnapshot)
-		Expect(err).To(BeNil())
-		Expect(snapshotComponents).NotTo(BeNil())
-		Expect(*snapshotComponents).To(HaveLen(1))
-		for _, comp := range *snapshotComponents {
-			Expect(comp.Name).NotTo(Equal("other-component"))
-		}
-	})
-
 	It("ensures we can get an Application from a Snapshot ", func() {
 		app, err := loader.GetApplicationFromSnapshot(k8sClient, ctx, hasSnapshot)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
* Refactor NewBindingComponents to take components directly from the Snapshot and convert them into bindingComponents by referencing them by the `metadata.name` instead of `spec.componentName`.
* This removes the need for the extra step of fetching Components from the cluster
* Remove the GetAllSnapshotComponents function altogether as it is unused after the above changes
* Remove the now unused components parameter from functions which were creating/updating SEBs

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
