### PR TITLE
fix(STONEINTG-583): set scenario status to valid if undefined

### DIFF
--- a/controllers/scenario/scenario_adapter.go
+++ b/controllers/scenario/scenario_adapter.go
@@ -130,7 +130,8 @@ func (a *Adapter) EnsureCreatedScenarioIsValid() (controller.OperationResult, er
 
 	}
 
-	if reflect.ValueOf(a.scenario.Status).IsZero() || (meta.IsStatusConditionFalse(a.scenario.Status.Conditions, gitops.IntegrationTestScenarioValid)) {
+	// If the scenario status IntegrationTestScenarioValid condition is not defined or false, we set it to Valid
+	if reflect.ValueOf(a.scenario.Status).IsZero() || !meta.IsStatusConditionTrue(a.scenario.Status.Conditions, gitops.IntegrationTestScenarioValid) {
 		patch := client.MergeFrom(a.scenario.DeepCopy())
 		SetScenarioIntegrationStatusAsValid(a.scenario, "Integration test scenario is Valid.")
 		err := a.client.Status().Patch(a.context, a.scenario, patch)

--- a/controllers/scenario/scenario_adapter_test.go
+++ b/controllers/scenario/scenario_adapter_test.go
@@ -282,6 +282,9 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 
 		expectedLogEntry := "The scenario doesn't have status.conditions set correctly, adding them"
 		Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+		expectedLogEntry = "IntegrationTestScenario marked as Valid"
+		Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+		Expect(meta.IsStatusConditionTrue(integrationTestScenarioMissingConditions.Status.Conditions, gitops.IntegrationTestScenarioValid)).To(BeTrue())
 	})
 
 })


### PR DESCRIPTION
* Change the condition for seting scenario status to valid. The previous condition would return false if the condition was not present, so it would not work for scenarios that were created for e2e or load testing
* See [IsStatusConditionFalse](https://pkg.go.dev/github.com/coderanger/controller-utils/conditions#IsStatusConditionFalse) for more context - it returns false if status condition is not present

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
