### PR TITLE
docs: remove unnecessary node

### DIFF
--- a/docs/integration_pipeline_controller.md
+++ b/docs/integration_pipeline_controller.md
@@ -13,14 +13,14 @@ flowchart TD
   predicate((PREDICATE: <br>Integration Pipeline just got<br> Started OR Finished<br> OR marked for Deletion))
   get_resources{Get pipeline, <br> component, <br> & application}
   report_status_snapshot(Report status of the test <br> into snapshot annotation <br> `test.appstudio.openshift.io/status`)
-  report_status(Report status <br> if Snapshot was created <br> for Pull requests)
   is_snapshot_of_pr_event{Is <br> Snapshot created<br> for Pull requests?}
   is_plr_finished_or_getting_deleted{Is <br> Integration PLR <br> finished or marked for<br> deletion?}
   remove_finalizer(Remove <br> `test.appstudio.openshift.io/pipelinerun`<br> finalizer)
   clean_environment(Clean up ephemeral environment <br> if testing finished)
   error(Return error)
   requeue(Requeue)
-  continue(Continue processing)
+  continue1(Continue processing)
+  continue2(Continue processing)
 
   %% Node connections
   predicate                                   --> get_resources
@@ -28,13 +28,13 @@ flowchart TD
   get_resources     --No                      --> error
   get_resources     --Yes                     --> report_status_snapshot
   report_status_snapshot                      --> is_snapshot_of_pr_event
-  is_snapshot_of_pr_event            --Yes    --> report_status
+  is_snapshot_of_pr_event            --Yes    --> continue1
   is_snapshot_of_pr_event            --No     --> is_plr_finished_or_getting_deleted
   is_plr_finished_or_getting_deleted --Yes    --> remove_finalizer
-  is_plr_finished_or_getting_deleted --No     --> report_status
-  remove_finalizer                            --> report_status
+  is_plr_finished_or_getting_deleted --No     --> continue1
+  remove_finalizer                            --> continue1
   clean_environment --No                      --> requeue
-  clean_environment --yes                     ---> continue
+  clean_environment --yes                     ---> continue2
 
   %% Assigning styles to nodes
   class predicate Amber;


### PR DESCRIPTION
This PR is triggered by a [discussion within a PR](https://github.com/redhat-appstudio/integration-service/pull/341#discussion_r1374533710).

* This commit removes the "Report status if Snapshot..." node from the integration_pipeline diagram.
* Because integrationpipeline controller is not responsible for reporting statuses for PR events.
* This is the responsiblity of statusreport controller. It's diagram is correct.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
