### PR TITLE
fix(STONEINTG-649): remove component in integrationpipeline controller

### DIFF
--- a/controllers/integrationpipeline/integrationpipeline_adapter.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter.go
@@ -37,7 +37,6 @@ import (
 // Adapter holds the objects needed to reconcile an integration PipelineRun.
 type Adapter struct {
 	pipelineRun *tektonv1beta1.PipelineRun
-	component   *applicationapiv1alpha1.Component
 	application *applicationapiv1alpha1.Application
 	loader      loader.ObjectLoader
 	logger      h.IntegrationLogger
@@ -47,11 +46,10 @@ type Adapter struct {
 }
 
 // NewAdapter creates and returns an Adapter instance.
-func NewAdapter(pipelineRun *tektonv1beta1.PipelineRun, component *applicationapiv1alpha1.Component, application *applicationapiv1alpha1.Application, logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
+func NewAdapter(pipelineRun *tektonv1beta1.PipelineRun, application *applicationapiv1alpha1.Application, logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
 	context context.Context) *Adapter {
 	return &Adapter{
 		pipelineRun: pipelineRun,
-		component:   component,
 		application: application,
 		logger:      logger,
 		loader:      loader,

--- a/controllers/integrationpipeline/integrationpipeline_adapter_test.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter_test.go
@@ -368,13 +368,13 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 	When("NewAdapter is called", func() {
 		It("creates and return a new adapter", func() {
-			Expect(reflect.TypeOf(NewAdapter(integrationPipelineRunComponent, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
+			Expect(reflect.TypeOf(NewAdapter(integrationPipelineRunComponent, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
 		})
 	})
 
 	When("Snapshot already exists", func() {
 		BeforeEach(func() {
-			adapter = NewAdapter(integrationPipelineRunComponent, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(integrationPipelineRunComponent, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
 			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -514,7 +514,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				}
 				Expect(k8sClient.Status().Update(ctx, integrationPipelineRunComponentFailed)).Should(Succeed())
 
-				adapter = NewAdapter(integrationPipelineRunComponentFailed, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+				adapter = NewAdapter(integrationPipelineRunComponentFailed, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
 				adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
 					{
 						ContextKey: loader.ApplicationContextKey,
@@ -633,7 +633,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		It("ensures ephemeral environment is deleted for the given pipelineRun ", func() {
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(integrationPipelineRunComponent, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(integrationPipelineRunComponent, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
 			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -807,7 +807,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			}
 			Expect(k8sClient.Status().Update(ctx, integrationPipelineRunComponentFailed)).Should(Succeed())
 
-			adapter = NewAdapter(integrationPipelineRunComponentFailed, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(integrationPipelineRunComponentFailed, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
 			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,

--- a/controllers/integrationpipeline/integrationpipeline_controller.go
+++ b/controllers/integrationpipeline/integrationpipeline_controller.go
@@ -19,7 +19,6 @@ package integrationpipeline
 import (
 	"context"
 	"fmt"
-
 	"github.com/redhat-appstudio/integration-service/cache"
 
 	"github.com/go-logr/logr"
@@ -84,13 +83,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	component, err := loader.GetComponentFromPipelineRun(r.Client, ctx, pipelineRun)
-	if err != nil {
-		logger.Error(err, "Failed to get Component for",
-			"PipelineRun.Name", pipelineRun.Name, "PipelineRun.Namespace", pipelineRun.Namespace)
-		return ctrl.Result{}, err
-	}
-
 	application, err := loader.GetApplicationFromPipelineRun(r.Client, ctx, pipelineRun)
 	if err != nil {
 		logger.Error(err, "Failed to get Application from the integration pipelineRun",
@@ -105,7 +97,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	logger = logger.WithApp(*application)
 
-	adapter := NewAdapter(pipelineRun, component, application, logger, loader, r.Client, ctx)
+	adapter := NewAdapter(pipelineRun, application, logger, loader, r.Client, ctx)
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureStatusReportedInSnapshot,
@@ -127,10 +119,6 @@ func SetupController(manager ctrl.Manager, log *logr.Logger) error {
 // setupCache indexes fields for each of the resources used in the pipeline adapter in those cases where filtering by
 // field is required.
 func setupCache(mgr ctrl.Manager) error {
-	if err := cache.SetupApplicationComponentCache(mgr); err != nil {
-		return err
-	}
-
 	if err := cache.SetupSnapshotCache(mgr); err != nil {
 		return err
 	}


### PR DESCRIPTION
* Stop fetching the component in integrationpipeline controller because integration pipelineRuns do not necessarily need to reference a component in their labels - e.g. ones created to test composite Snapshots
* Move SetupApplicationComponentCache to the buildpipeline controller to align with the above change
* Update controller and adapter tests accordingly

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
