### PR TITLE
feat(EC-202): Proceed if Chains could not sign

### DIFF
--- a/docs/build_pipeline_controller.md
+++ b/docs/build_pipeline_controller.md
@@ -8,9 +8,9 @@ flowchart TD
   classDef Red fill:#FF9999;
   classDef Amber fill:#FFDEAD;
   classDef Green fill:#BDFFA4;
- 
+
   %% Node definitions
-predicate((PREDICATE: <br> Filter events related to <br> PipelineRun <br> that are signed <br> and have <br> succeeded))
+predicate((PREDICATE: <br> Filter events related to <br> PipelineRuns <br> proccessed by Chains <br> that have <br> succeeded))
 get_pipeline_run{Pipeline found?}
 retrieve_associated_entity(Retrieve the entity <br> component/application)
 determine_snapshot{Does a snapshot exist?}

--- a/tekton/predicates.go
+++ b/tekton/predicates.go
@@ -59,7 +59,7 @@ func BuildPipelineRunSignedAndSucceededPredicate() predicate.Predicate {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return IsBuildPipelineRun(e.ObjectNew) && isPipelineRunSigned(e.ObjectNew) &&
+			return IsBuildPipelineRun(e.ObjectNew) && isChainsDoneWithPipelineRun(e.ObjectNew) &&
 				helpers.HasPipelineRunSucceeded(e.ObjectNew) &&
 				!metadata.HasAnnotation(e.ObjectNew, SnapshotNameLabel)
 		},

--- a/tekton/predicates_test.go
+++ b/tekton/predicates_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Predicates", func() {
 			Expect(instance.Update(contextEvent)).To(BeFalse())
 		})
 
-		It("should return false when an updated event is received for a succeeded PipelineRun and not signed", func() {
+		It("should return true when an updated event is received for a succeeded PipelineRun with failed chains signing", func() {
 			newPipelineRun.Status.SetCondition(&apis.Condition{
 				Type:   apis.ConditionSucceeded,
 				Status: "True",
@@ -126,8 +126,8 @@ var _ = Describe("Predicates", func() {
 			}
 			Expect(instance.Update(contextEvent)).To(BeFalse())
 
-			newPipelineRun.Annotations["chains.tekton.dev/signed"] = "false"
-			Expect(instance.Update(contextEvent)).To(BeFalse())
+			newPipelineRun.Annotations["chains.tekton.dev/signed"] = "failed"
+			Expect(instance.Update(contextEvent)).To(BeTrue())
 		})
 
 		It("should return false when an updated event is received for a succeeded and signed pipelineRun that was annotated with Snapshot", func() {


### PR DESCRIPTION
This commit changes the controller to no longer wait for the PipelineRun to have the annotation `chains.tekton.dev/signed` be set to the value of `"true"`. Instead, it now only waits for the annotation to be set regardless of its value. This indicates the Chains controller is done processing the PipelineRun and the integration service should move on.

This prevents Chains failures from causing integration tests to never run. Instead, let the integration tests run, and verification tools, e.g. Enterprise Contract, report on unsigned artifacts.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
