### PR TITLE
fix(STONEINTG-668): update the status reporter with new "Deleted" state

### DIFF
--- a/status/reporters.go
+++ b/status/reporters.go
@@ -170,6 +170,8 @@ func generateSummary(state intgteststat.IntegrationTestStatus, snapshotName, sce
 		statusDesc = "experienced an error when provisioning environment"
 	case intgteststat.IntegrationTestStatusDeploymentError:
 		statusDesc = "experienced an error when deploying snapshotEnvironmentBinding"
+	case intgteststat.IntegrationTestStatusDeleted:
+		statusDesc = "was deleted before the pipelineRun could finish"
 	case intgteststat.IntegrationTestStatusTestPassed:
 		statusDesc = "has passed"
 	case intgteststat.IntegrationTestStatusTestFail:
@@ -196,6 +198,8 @@ func generateCheckRunTitle(state intgteststat.IntegrationTestStatus) (string, er
 		title = "Errored"
 	case intgteststat.IntegrationTestStatusDeploymentError:
 		title = "Errored"
+	case intgteststat.IntegrationTestStatusDeleted:
+		title = "Deleted"
 	case intgteststat.IntegrationTestStatusTestPassed:
 		title = "Succeeded"
 	case intgteststat.IntegrationTestStatusTestFail:
@@ -242,7 +246,8 @@ func generateCheckRunConclusion(state intgteststat.IntegrationTestStatus) (strin
 	var conclusion string
 
 	switch state {
-	case intgteststat.IntegrationTestStatusTestFail, intgteststat.IntegrationTestStatusEnvironmentProvisionError, intgteststat.IntegrationTestStatusDeploymentError:
+	case intgteststat.IntegrationTestStatusTestFail, intgteststat.IntegrationTestStatusEnvironmentProvisionError,
+		intgteststat.IntegrationTestStatusDeploymentError, intgteststat.IntegrationTestStatusDeleted:
 		conclusion = gitops.IntegrationTestStatusFailureGithub
 	case intgteststat.IntegrationTestStatusTestPassed:
 		conclusion = gitops.IntegrationTestStatusSuccessGithub
@@ -264,7 +269,8 @@ func generateCommitState(state intgteststat.IntegrationTestStatus) (string, erro
 	switch state {
 	case intgteststat.IntegrationTestStatusTestFail:
 		commitState = gitops.IntegrationTestStatusFailureGithub
-	case intgteststat.IntegrationTestStatusEnvironmentProvisionError, intgteststat.IntegrationTestStatusDeploymentError:
+	case intgteststat.IntegrationTestStatusEnvironmentProvisionError, intgteststat.IntegrationTestStatusDeploymentError,
+		intgteststat.IntegrationTestStatusDeleted:
 		commitState = gitops.IntegrationTestStatusErrorGithub
 	case intgteststat.IntegrationTestStatusTestPassed:
 		commitState = gitops.IntegrationTestStatusSuccessGithub


### PR DESCRIPTION
* Add support for the `Deleted` state in the status reporters, mapping it to report as an error/failure and adding the explanation for the issue in the summary

Example comment:
![image](https://github.com/redhat-appstudio/integration-service/assets/34320458/10ed57d3-d230-495c-aff6-2142f7a284e4)

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
