### PR TITLE
feat(STONEINTG-635): increase snapshot code coverage

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter_test.go
@@ -30,6 +30,7 @@ import (
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/api/v1beta1"
+	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	releasemetadata "github.com/redhat-appstudio/release-service/metadata"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -352,7 +353,7 @@ var _ = Describe("Binding Adapter", Ordered, func() {
 	It("ensures the integrationTestPipelines are created for a deployed SnapshotEnvironment binding", func() {
 		adapter = NewAdapter(hasBinding, hasSnapshot, hasEnv, hasApp, hasComp, integrationTestScenario, logger, loader.NewMockLoader(), k8sClient, ctx)
 		Expect(reflect.TypeOf(adapter)).To(Equal(reflect.TypeOf(&Adapter{})))
-		adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+		adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 			{
 				ContextKey: loader.ApplicationContextKey,
 				Resource:   hasApp,
@@ -452,7 +453,7 @@ var _ = Describe("Binding Adapter", Ordered, func() {
 		}
 
 		adapter = NewAdapter(hasBinding, hasSnapshot, hasEnv, hasApp, hasComp, integrationTestScenario, log, loader.NewMockLoader(), k8sClient, ctx)
-		adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+		adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 			{
 				ContextKey: loader.ApplicationContextKey,
 				Resource:   hasApp,
@@ -503,7 +504,7 @@ var _ = Describe("Binding Adapter", Ordered, func() {
 		}
 
 		adapter = NewAdapter(hasBinding, hasSnapshot, hasEnv, hasApp, hasComp, integrationTestScenario, log, loader.NewMockLoader(), k8sClient, ctx)
-		adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+		adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 			{
 				ContextKey: loader.ApplicationContextKey,
 				Resource:   hasApp,

--- a/controllers/buildpipeline/buildpipeline_adapter_test.go
+++ b/controllers/buildpipeline/buildpipeline_adapter_test.go
@@ -36,6 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tonglil/buflogr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -316,7 +317,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 	When("NewAdapter is created", func() {
 		BeforeEach(func() {
 			adapter = createAdapter()
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,
@@ -476,7 +477,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 	When("Snapshot already exists", func() {
 		BeforeEach(func() {
 			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,
@@ -585,7 +586,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			// make sure the seocnd pipeline started as second
 			buildPipelineRun2.CreationTimestamp.Time = buildPipelineRun2.CreationTimestamp.Add(2 * time.Hour)
 			adapter = NewAdapter(buildPipelineRun2, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,
@@ -612,7 +613,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			// make sure the first pipeline started as first
 			buildPipelineRun.CreationTimestamp.Time = buildPipelineRun.CreationTimestamp.Add(-2 * time.Hour)
 			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,
@@ -671,7 +672,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			// make sure the first pipeline started as first
 			buildPipelineRun.CreationTimestamp.Time = buildPipelineRun.CreationTimestamp.Add(-2 * time.Hour)
 			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,
@@ -698,7 +699,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		It("can find matching snapshot", func() {
 			// make sure the first pipeline started as first
 			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,

--- a/controllers/component/component_adapter_test.go
+++ b/controllers/component/component_adapter_test.go
@@ -12,6 +12,7 @@ import (
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/loader"
+	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -115,7 +116,7 @@ var _ = Describe("Component Adapter", Ordered, func() {
 
 		log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 		adapter = NewAdapter(hasComp, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
-		adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+		adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 			{
 				ContextKey: loader.ApplicationContextKey,
 				Resource:   hasApp,

--- a/controllers/integrationpipeline/integrationpipeline_adapter_test.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/redhat-appstudio/integration-service/helpers"
 	"github.com/redhat-appstudio/integration-service/loader"
 	intgteststat "github.com/redhat-appstudio/integration-service/pkg/integrationteststatus"
+	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 
 	"knative.dev/pkg/apis"
 	v1 "knative.dev/pkg/apis/duck/v1"
@@ -375,7 +376,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 	When("Snapshot already exists", func() {
 		BeforeEach(func() {
 			adapter = NewAdapter(integrationPipelineRunComponent, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,
@@ -515,7 +516,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				Expect(k8sClient.Status().Update(ctx, integrationPipelineRunComponentFailed)).Should(Succeed())
 
 				adapter = NewAdapter(integrationPipelineRunComponentFailed, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
-				adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.ApplicationContextKey,
 						Resource:   hasApp,
@@ -634,7 +635,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 			adapter = NewAdapter(integrationPipelineRunComponent, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,
@@ -808,7 +809,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(k8sClient.Status().Update(ctx, integrationPipelineRunComponentFailed)).Should(Succeed())
 
 			adapter = NewAdapter(integrationPipelineRunComponentFailed, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,

--- a/controllers/statusreport/statusreport_adapter_test.go
+++ b/controllers/statusreport/statusreport_adapter_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/redhat-appstudio/integration-service/loader"
 	intgteststat "github.com/redhat-appstudio/integration-service/pkg/integrationteststatus"
 	"github.com/redhat-appstudio/integration-service/status"
+	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -272,7 +273,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			statusReporter = &MockStatusReporter{}
 			statusAdapter = &MockStatusAdapter{Reporter: statusReporter}
 			adapter.status = statusAdapter
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,
@@ -301,7 +302,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			adapter = NewAdapter(hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,
@@ -369,7 +370,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			adapter = NewAdapter(hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,
@@ -423,7 +424,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			adapter = NewAdapter(hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,
@@ -487,7 +488,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(compositeSnapshot).NotTo(BeNil())
 
 			// Check if the composite snapshot that was already created above was correctly detected and returned.
-			adapter.context = loader.GetMockedContext(ctx, []loader.MockData{
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
 					Resource:   hasApp,

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -25,6 +25,7 @@ import (
 	"github.com/redhat-appstudio/integration-service/api/v1beta1"
 	"github.com/redhat-appstudio/integration-service/gitops"
 	"github.com/redhat-appstudio/integration-service/tekton"
+	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -62,15 +63,6 @@ type loader struct{}
 func NewLoader() ObjectLoader {
 	return &loader{}
 }
-
-// getObject loads an object from the cluster. This is a generic function that requires the object to be passed as an
-// argument. The object is modified during the invocation.
-// func getObject(name, namespace string, cli client.Client, ctx context.Context, object client.Object) error {
-// 	return cli.Get(ctx, types.NamespacedName{
-// 		Name:      name,
-// 		Namespace: namespace,
-// 	}, object)
-// }
 
 // GetAllEnvironments gets all environments in the namespace
 func (l *loader) GetAllEnvironments(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Environment, error) {
@@ -124,16 +116,7 @@ func (l *loader) GetAllApplicationComponents(c client.Client, ctx context.Contex
 // If the Snapshot doesn't specify an Component or this is not found in the cluster, an error will be returned.
 func (l *loader) GetApplicationFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Application, error) {
 	application := &applicationapiv1alpha1.Application{}
-	err := c.Get(ctx, types.NamespacedName{
-		Namespace: snapshot.Namespace,
-		Name:      snapshot.Spec.Application,
-	}, application)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return application, nil
+	return application, toolkit.GetObject(snapshot.Spec.Application, snapshot.Namespace, c, ctx, application)
 }
 
 // GetComponentFromSnapshot loads from the cluster the Component referenced in the given Snapshot.

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -21,51 +21,36 @@ import (
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/api/v1beta1"
+	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type (
-	contextKey int
-	MockData   struct {
-		ContextKey contextKey
-		Err        error
-		Resource   any
-	}
-	mockLoader struct {
-		loader ObjectLoader
-	}
-)
+type mockLoader struct {
+	loader ObjectLoader
+}
 
 const (
-	ApplicationContextKey                      contextKey = iota
-	ComponentContextKey                        contextKey = iota
-	SnapshotContextKey                         contextKey = iota
-	SnapshotEnvironmentBindingContextKey       contextKey = iota
-	DeploymentTargetContextKey                 contextKey = iota
-	DeploymentTargetClaimContextKey            contextKey = iota
-	IntegrationTestScenarioContextKey          contextKey = iota
-	TaskRunContextKey                          contextKey = iota
-	ApplicationComponentsContextKey            contextKey = iota
-	SnapshotComponentsContextKey               contextKey = iota
-	EnvironmentContextKey                      contextKey = iota
-	ReleaseContextKey                          contextKey = iota
-	PipelineRunsContextKey                     contextKey = iota
-	DeploymentTargetClassContextKey            contextKey = iota
-	AllIntegrationTestScenariosContextKey      contextKey = iota
-	RequiredIntegrationTestScenariosContextKey contextKey = iota
-	AllSnapshotsContextKey                     contextKey = iota
-	AutoReleasePlansContextKey                 contextKey = iota
+	ApplicationContextKey toolkit.ContextKey = iota
+	ComponentContextKey
+	SnapshotContextKey
+	SnapshotEnvironmentBindingContextKey
+	DeploymentTargetContextKey
+	DeploymentTargetClaimContextKey
+	IntegrationTestScenarioContextKey
+	TaskRunContextKey
+	ApplicationComponentsContextKey
+	SnapshotComponentsContextKey
+	EnvironmentContextKey
+	ReleaseContextKey
+	PipelineRunsContextKey
+	DeploymentTargetClassContextKey
+	AllIntegrationTestScenariosContextKey
+	RequiredIntegrationTestScenariosContextKey
+	AllSnapshotsContextKey
+	AutoReleasePlansContextKey
 )
-
-func GetMockedContext(ctx context.Context, data []MockData) context.Context {
-	for _, mockData := range data {
-		ctx = context.WithValue(ctx, mockData.ContextKey, mockData)
-	}
-
-	return ctx
-}
 
 func NewMockLoader() ObjectLoader {
 	return &mockLoader{
@@ -73,36 +58,12 @@ func NewMockLoader() ObjectLoader {
 	}
 }
 
-// getMockedResourceAndErrorFromContext returns the mocked data found in the context passed as an argument. The data is
-// to be found in the contextDataKey key. If not there, a panic will be raised.
-func getMockedResourceAndErrorFromContext[T any](ctx context.Context, contextKey contextKey, _ T) (T, error) {
-	var resource T
-	var err error
-
-	value := ctx.Value(contextKey)
-	if value == nil {
-		panic("Mocked data not found in the context")
-	}
-
-	data, _ := value.(MockData)
-
-	if data.Resource != nil {
-		resource = data.Resource.(T)
-	}
-
-	if data.Err != nil {
-		err = data.Err
-	}
-
-	return resource, err
-}
-
 // GetAllEnvironments returns the resource and error passed as values of the context.
 func (l *mockLoader) GetAllEnvironments(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Environment, error) {
 	if ctx.Value(EnvironmentContextKey) == nil {
 		return l.loader.GetAllEnvironments(c, ctx, application)
 	}
-	environment, err := getMockedResourceAndErrorFromContext(ctx, EnvironmentContextKey, &applicationapiv1alpha1.Environment{})
+	environment, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, EnvironmentContextKey, &applicationapiv1alpha1.Environment{})
 	return &[]applicationapiv1alpha1.Environment{*environment}, err
 }
 
@@ -111,7 +72,7 @@ func (l *mockLoader) GetReleasesWithSnapshot(c client.Client, ctx context.Contex
 	if ctx.Value(ReleaseContextKey) == nil {
 		return l.loader.GetReleasesWithSnapshot(c, ctx, snapshot)
 	}
-	release, err := getMockedResourceAndErrorFromContext(ctx, ReleaseContextKey, &releasev1alpha1.Release{})
+	release, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, ReleaseContextKey, &releasev1alpha1.Release{})
 	return &[]releasev1alpha1.Release{*release}, err
 }
 
@@ -120,7 +81,7 @@ func (l *mockLoader) GetAllApplicationComponents(c client.Client, ctx context.Co
 	if ctx.Value(ApplicationComponentsContextKey) == nil {
 		return l.loader.GetAllApplicationComponents(c, ctx, application)
 	}
-	components, err := getMockedResourceAndErrorFromContext(ctx, ApplicationComponentsContextKey, []applicationapiv1alpha1.Component{})
+	components, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, ApplicationComponentsContextKey, []applicationapiv1alpha1.Component{})
 	return &components, err
 }
 
@@ -129,7 +90,7 @@ func (l *mockLoader) GetApplicationFromSnapshot(c client.Client, ctx context.Con
 	if ctx.Value(ApplicationContextKey) == nil {
 		return l.loader.GetApplicationFromSnapshot(c, ctx, snapshot)
 	}
-	return getMockedResourceAndErrorFromContext(ctx, ApplicationContextKey, &applicationapiv1alpha1.Application{})
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ApplicationContextKey, &applicationapiv1alpha1.Application{})
 }
 
 // GetComponentFromSnapshot returns the resource and error passed as values of the context.
@@ -137,7 +98,7 @@ func (l *mockLoader) GetComponentFromSnapshot(c client.Client, ctx context.Conte
 	if ctx.Value(ComponentContextKey) == nil {
 		return l.loader.GetComponentFromSnapshot(c, ctx, snapshot)
 	}
-	return getMockedResourceAndErrorFromContext(ctx, ComponentContextKey, &applicationapiv1alpha1.Component{})
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ComponentContextKey, &applicationapiv1alpha1.Component{})
 }
 
 // GetComponentFromPipelineRun returns the resource and error passed as values of the context.
@@ -145,7 +106,7 @@ func (l *mockLoader) GetComponentFromPipelineRun(c client.Client, ctx context.Co
 	if ctx.Value(ComponentContextKey) == nil {
 		return l.loader.GetComponentFromPipelineRun(c, ctx, pipelineRun)
 	}
-	return getMockedResourceAndErrorFromContext(ctx, ComponentContextKey, &applicationapiv1alpha1.Component{})
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ComponentContextKey, &applicationapiv1alpha1.Component{})
 }
 
 // GetApplicationFromPipelineRun returns the resource and error passed as values of the context.
@@ -153,7 +114,7 @@ func (l *mockLoader) GetApplicationFromPipelineRun(c client.Client, ctx context.
 	if ctx.Value(ApplicationContextKey) == nil {
 		return l.loader.GetApplicationFromPipelineRun(c, ctx, pipelineRun)
 	}
-	return getMockedResourceAndErrorFromContext(ctx, ApplicationContextKey, &applicationapiv1alpha1.Application{})
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ApplicationContextKey, &applicationapiv1alpha1.Application{})
 }
 
 // GetApplicationFromComponent returns the resource and error passed as values of the context.
@@ -161,7 +122,7 @@ func (l *mockLoader) GetApplicationFromComponent(c client.Client, ctx context.Co
 	if ctx.Value(ApplicationContextKey) == nil {
 		return l.loader.GetApplicationFromComponent(c, ctx, component)
 	}
-	return getMockedResourceAndErrorFromContext(ctx, ApplicationContextKey, &applicationapiv1alpha1.Application{})
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ApplicationContextKey, &applicationapiv1alpha1.Application{})
 }
 
 // GetEnvironmentFromIntegrationPipelineRun returns the resource and error passed as values of the context.
@@ -169,7 +130,7 @@ func (l *mockLoader) GetEnvironmentFromIntegrationPipelineRun(c client.Client, c
 	if ctx.Value(EnvironmentContextKey) == nil {
 		return l.loader.GetEnvironmentFromIntegrationPipelineRun(c, ctx, pipelineRun)
 	}
-	return getMockedResourceAndErrorFromContext(ctx, EnvironmentContextKey, &applicationapiv1alpha1.Environment{})
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, EnvironmentContextKey, &applicationapiv1alpha1.Environment{})
 }
 
 // GetSnapshotFromPipelineRun returns the resource and error passed as values of the context.
@@ -177,7 +138,7 @@ func (l *mockLoader) GetSnapshotFromPipelineRun(c client.Client, ctx context.Con
 	if ctx.Value(SnapshotContextKey) == nil {
 		return l.loader.GetSnapshotFromPipelineRun(c, ctx, pipelineRun)
 	}
-	return getMockedResourceAndErrorFromContext(ctx, SnapshotContextKey, &applicationapiv1alpha1.Snapshot{})
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, SnapshotContextKey, &applicationapiv1alpha1.Snapshot{})
 }
 
 // FindAvailableDeploymentTargetClass returns the resource and error passed as values of the context.
@@ -185,7 +146,7 @@ func (l *mockLoader) FindAvailableDeploymentTargetClass(c client.Client, ctx con
 	if ctx.Value(DeploymentTargetClassContextKey) == nil {
 		return l.loader.FindAvailableDeploymentTargetClass(c, ctx)
 	}
-	return getMockedResourceAndErrorFromContext(ctx, DeploymentTargetClassContextKey, &applicationapiv1alpha1.DeploymentTargetClass{})
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, DeploymentTargetClassContextKey, &applicationapiv1alpha1.DeploymentTargetClass{})
 }
 
 // GetAllIntegrationTestScenariosForApplication returns the resource and error passed as values of the context.
@@ -193,7 +154,7 @@ func (l *mockLoader) GetAllIntegrationTestScenariosForApplication(c client.Clien
 	if ctx.Value(AllIntegrationTestScenariosContextKey) == nil {
 		return l.loader.GetAllIntegrationTestScenariosForApplication(c, ctx, application)
 	}
-	integrationTestScenarios, err := getMockedResourceAndErrorFromContext(ctx, AllIntegrationTestScenariosContextKey, []v1beta1.IntegrationTestScenario{})
+	integrationTestScenarios, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllIntegrationTestScenariosContextKey, []v1beta1.IntegrationTestScenario{})
 	return &integrationTestScenarios, err
 }
 
@@ -202,7 +163,7 @@ func (l *mockLoader) GetRequiredIntegrationTestScenariosForApplication(c client.
 	if ctx.Value(RequiredIntegrationTestScenariosContextKey) == nil {
 		return l.loader.GetRequiredIntegrationTestScenariosForApplication(c, ctx, application)
 	}
-	integrationTestScenarios, err := getMockedResourceAndErrorFromContext(ctx, RequiredIntegrationTestScenariosContextKey, []v1beta1.IntegrationTestScenario{})
+	integrationTestScenarios, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, RequiredIntegrationTestScenariosContextKey, []v1beta1.IntegrationTestScenario{})
 	return &integrationTestScenarios, err
 }
 
@@ -211,7 +172,7 @@ func (l *mockLoader) GetDeploymentTargetClaimForEnvironment(c client.Client, ctx
 	if ctx.Value(DeploymentTargetClaimContextKey) == nil {
 		return l.loader.GetDeploymentTargetClaimForEnvironment(c, ctx, environment)
 	}
-	return getMockedResourceAndErrorFromContext(ctx, DeploymentTargetClaimContextKey, &applicationapiv1alpha1.DeploymentTargetClaim{})
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, DeploymentTargetClaimContextKey, &applicationapiv1alpha1.DeploymentTargetClaim{})
 }
 
 // GetDeploymentTargetForDeploymentTargetClaim returns the resource and error passed as values of the context.
@@ -219,7 +180,7 @@ func (l *mockLoader) GetDeploymentTargetForDeploymentTargetClaim(c client.Client
 	if ctx.Value(DeploymentTargetContextKey) == nil {
 		return l.loader.GetDeploymentTargetForDeploymentTargetClaim(c, ctx, dtc)
 	}
-	return getMockedResourceAndErrorFromContext(ctx, DeploymentTargetContextKey, &applicationapiv1alpha1.DeploymentTarget{})
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, DeploymentTargetContextKey, &applicationapiv1alpha1.DeploymentTarget{})
 }
 
 // FindExistingSnapshotEnvironmentBinding returns the resource and error passed as values of the context.
@@ -227,7 +188,7 @@ func (l *mockLoader) FindExistingSnapshotEnvironmentBinding(c client.Client, ctx
 	if ctx.Value(SnapshotEnvironmentBindingContextKey) == nil {
 		return l.loader.FindExistingSnapshotEnvironmentBinding(c, ctx, application, environment)
 	}
-	return getMockedResourceAndErrorFromContext(ctx, SnapshotEnvironmentBindingContextKey, &applicationapiv1alpha1.SnapshotEnvironmentBinding{})
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, SnapshotEnvironmentBindingContextKey, &applicationapiv1alpha1.SnapshotEnvironmentBinding{})
 }
 
 // GetAllPipelineRunsForSnapshotAndScenario returns the resource and error passed as values of the context.
@@ -235,7 +196,7 @@ func (l *mockLoader) GetAllPipelineRunsForSnapshotAndScenario(c client.Client, c
 	if ctx.Value(PipelineRunsContextKey) == nil {
 		return l.loader.GetAllPipelineRunsForSnapshotAndScenario(c, ctx, snapshot, integrationTestScenario)
 	}
-	pipelineRuns, err := getMockedResourceAndErrorFromContext(ctx, PipelineRunsContextKey, []tektonv1beta1.PipelineRun{})
+	pipelineRuns, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, PipelineRunsContextKey, []tektonv1beta1.PipelineRun{})
 	return &pipelineRuns, err
 }
 
@@ -244,7 +205,7 @@ func (l *mockLoader) GetAllBuildPipelineRunsForComponent(c client.Client, ctx co
 	if ctx.Value(PipelineRunsContextKey) == nil {
 		return l.loader.GetAllBuildPipelineRunsForComponent(c, ctx, component)
 	}
-	pipelineRuns, err := getMockedResourceAndErrorFromContext(ctx, PipelineRunsContextKey, []tektonv1beta1.PipelineRun{})
+	pipelineRuns, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, PipelineRunsContextKey, []tektonv1beta1.PipelineRun{})
 	return &pipelineRuns, err
 }
 
@@ -253,7 +214,7 @@ func (l *mockLoader) GetAllSnapshots(c client.Client, ctx context.Context, appli
 	if ctx.Value(AllSnapshotsContextKey) == nil {
 		return l.loader.GetAllSnapshots(c, ctx, application)
 	}
-	snapshots, err := getMockedResourceAndErrorFromContext(ctx, AllSnapshotsContextKey, []applicationapiv1alpha1.Snapshot{})
+	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllSnapshotsContextKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
 }
 
@@ -262,6 +223,6 @@ func (l *mockLoader) GetAutoReleasePlansForApplication(c client.Client, ctx cont
 	if ctx.Value(AutoReleasePlansContextKey) == nil {
 		return l.loader.GetAutoReleasePlansForApplication(c, ctx, application)
 	}
-	autoReleasePlans, err := getMockedResourceAndErrorFromContext(ctx, AutoReleasePlansContextKey, []releasev1alpha1.ReleasePlan{})
+	autoReleasePlans, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AutoReleasePlansContextKey, []releasev1alpha1.ReleasePlan{})
 	return &autoReleasePlans, err
 }

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package loader
 
 import (
-	"errors"
+	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,7 +25,6 @@ import (
 	"github.com/redhat-appstudio/integration-service/api/v1beta1"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Release Adapter", Ordered, func() {
@@ -37,67 +36,10 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		loader = NewMockLoader()
 	})
 
-	Context("When calling getMockedResourceAndErrorFromContext", func() {
-		contextErr := errors.New("error")
-		contextResource := &releasev1alpha1.Release{
-			ObjectMeta: v12.ObjectMeta{
-				Name:      "pod",
-				Namespace: "default",
-			},
-			Spec: releasev1alpha1.ReleaseSpec{
-				ReleasePlan: "releasePlan",
-				Snapshot:    "snapshot",
-			},
-		}
-
-		It("returns resource from the context", func() {
-			mockContext := GetMockedContext(ctx, []MockData{
-				{
-					ContextKey: ReleaseContextKey,
-					Resource:   contextResource,
-				},
-			})
-			resource, err := getMockedResourceAndErrorFromContext(mockContext, ReleaseContextKey, contextResource)
-			Expect(err).To(BeNil())
-			Expect(resource).To(Equal(contextResource))
-		})
-
-		It("returns error from the context", func() {
-			mockContext := GetMockedContext(ctx, []MockData{
-				{
-					ContextKey: ReleaseContextKey,
-					Err:        contextErr,
-				},
-			})
-			resource, err := getMockedResourceAndErrorFromContext(mockContext, ReleaseContextKey, contextResource)
-			Expect(err).To(Equal(contextErr))
-			Expect(resource).To(BeNil())
-		})
-
-		It("returns resource and the error from the context", func() {
-			mockContext := GetMockedContext(ctx, []MockData{
-				{
-					ContextKey: ReleaseContextKey,
-					Resource:   contextResource,
-					Err:        contextErr,
-				},
-			})
-			resource, err := getMockedResourceAndErrorFromContext(mockContext, ReleaseContextKey, contextResource)
-			Expect(err).To(Equal(contextErr))
-			Expect(resource).To(Equal(contextResource))
-		})
-
-		It("should panic when the mocked data is not present", func() {
-			Expect(func() {
-				_, _ = getMockedResourceAndErrorFromContext(ctx, ReleaseContextKey, contextResource)
-			}).To(Panic())
-		})
-	})
-
 	Context("When calling GetAllEnvironments", func() {
 		It("returns resource and error from the context", func() {
 			environment := &applicationapiv1alpha1.Environment{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: EnvironmentContextKey,
 					Resource:   environment,
@@ -112,7 +54,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetReleasesWithSnapshot", func() {
 		It("returns resource and error from the context", func() {
 			release := &releasev1alpha1.Release{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: ReleaseContextKey,
 					Resource:   release,
@@ -127,7 +69,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetAllApplicationComponents", func() {
 		It("returns resource and error from the context", func() {
 			applicationComponents := []applicationapiv1alpha1.Component{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: ApplicationComponentsContextKey,
 					Resource:   applicationComponents,
@@ -142,7 +84,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetApplicationFromSnapshot", func() {
 		It("returns resource and error from the context", func() {
 			application := &applicationapiv1alpha1.Application{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: ApplicationContextKey,
 					Resource:   application,
@@ -157,7 +99,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetComponentFromSnapshot", func() {
 		It("returns resource and error from the context", func() {
 			component := &applicationapiv1alpha1.Component{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: ComponentContextKey,
 					Resource:   component,
@@ -172,7 +114,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetComponentFromPipelineRun", func() {
 		It("returns resource and error from the context", func() {
 			component := &applicationapiv1alpha1.Component{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: ComponentContextKey,
 					Resource:   component,
@@ -187,7 +129,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetApplicationFromPipelineRun", func() {
 		It("returns resource and error from the context", func() {
 			application := &applicationapiv1alpha1.Application{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: ApplicationContextKey,
 					Resource:   application,
@@ -202,7 +144,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetApplicationFromComponent", func() {
 		It("returns resource and error from the context", func() {
 			application := &applicationapiv1alpha1.Application{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: ApplicationContextKey,
 					Resource:   application,
@@ -217,7 +159,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetEnvironmentFromIntegrationPipelineRun", func() {
 		It("returns resource and error from the context", func() {
 			environment := &applicationapiv1alpha1.Environment{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: EnvironmentContextKey,
 					Resource:   environment,
@@ -232,7 +174,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetSnapshotFromPipelineRun", func() {
 		It("returns resource and error from the context", func() {
 			snapshot := &applicationapiv1alpha1.Snapshot{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: SnapshotContextKey,
 					Resource:   snapshot,
@@ -247,7 +189,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling FindAvailableDeploymentTargetClass", func() {
 		It("returns deploymentTargetClassre source and error from the context", func() {
 			dtcls := &applicationapiv1alpha1.DeploymentTargetClass{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: DeploymentTargetClassContextKey,
 					Resource:   dtcls,
@@ -262,7 +204,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetAllIntegrationTestScenariosForApplication", func() {
 		It("returns all integrationTestScenario and error from the context", func() {
 			scenarios := []v1beta1.IntegrationTestScenario{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: AllIntegrationTestScenariosContextKey,
 					Resource:   scenarios,
@@ -277,7 +219,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetRequiredIntegrationTestScenariosForApplication", func() {
 		It("returns required integrationTestScenario and error from the context", func() {
 			scenarios := []v1beta1.IntegrationTestScenario{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: RequiredIntegrationTestScenariosContextKey,
 					Resource:   scenarios,
@@ -292,7 +234,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetDeploymentTargetClaimForEnvironment", func() {
 		It("returns deploymentTargetClaim and error from the context", func() {
 			dtc := &applicationapiv1alpha1.DeploymentTargetClaim{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: DeploymentTargetClaimContextKey,
 					Resource:   dtc,
@@ -307,7 +249,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetDeploymentTargetForDeploymentTargetClaim", func() {
 		It("returns deploymentTargetClaim and error from the context", func() {
 			dt := &applicationapiv1alpha1.DeploymentTarget{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: DeploymentTargetContextKey,
 					Resource:   dt,
@@ -322,7 +264,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling FindExistingSnapshotEnvironmentBinding", func() {
 		It("returns existing snapshotEnvironmentBinding and error from the context", func() {
 			binding := &applicationapiv1alpha1.SnapshotEnvironmentBinding{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: SnapshotEnvironmentBindingContextKey,
 					Resource:   binding,
@@ -337,7 +279,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetAllPipelineRunsForSnapshotAndScenario", func() {
 		It("returns pipelineRuns and error from the context", func() {
 			prs := []tektonv1beta1.PipelineRun{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: PipelineRunsContextKey,
 					Resource:   prs,
@@ -352,7 +294,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	Context("When calling GetAllSnapshots", func() {
 		It("returns snapshots and error from the context", func() {
 			snapshots := []applicationapiv1alpha1.Snapshot{}
-			mockContext := GetMockedContext(ctx, []MockData{
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: AllSnapshotsContextKey,
 					Resource:   snapshots,
@@ -360,6 +302,36 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			})
 			resource, err := loader.GetAllSnapshots(nil, mockContext, nil)
 			Expect(resource).To(Equal(&snapshots))
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("When calling GetAutoReleasePlansForApplication", func() {
+		It("returns snapshots and error from the context", func() {
+			releasePlans := []releasev1alpha1.ReleasePlan{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: AutoReleasePlansContextKey,
+					Resource:   releasePlans,
+				},
+			})
+			resource, err := loader.GetAutoReleasePlansForApplication(nil, mockContext, nil)
+			Expect(resource).To(Equal(&releasePlans))
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("When calling GetAllBuildPipelineRunsForComponent", func() {
+		It("returns snapshots and error from the context", func() {
+			pipelineRuns := []tektonv1beta1.PipelineRun{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: PipelineRunsContextKey,
+					Resource:   pipelineRuns,
+				},
+			})
+			resource, err := loader.GetAllBuildPipelineRunsForComponent(nil, mockContext, nil)
+			Expect(resource).To(Equal(&pipelineRuns))
 			Expect(err).To(BeNil())
 		})
 	})


### PR DESCRIPTION
* add more unittest in snapshot adapter to increase code coverage by creating data
* migrate to use  operator-toolkit loader
* one example to use toolkit.GetObject(name, namespace string, cli client.Client, ctx context.Context, object client.Object) instead of client.Get()

https://docs.google.com/document/d/1_hMZaaRZFnTm6dXb7mC6GWHgu7WnR4Pc1Du-Rj8zwLk/edit#heading=h.42ifznjra9qa is created as a reference to add UT


## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
