### PR TITLE
feat(stoneintg-628): metric for time to start plr with ephemeral env

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/redhat-appstudio/operator-toolkit/controller"
 	"github.com/redhat-appstudio/operator-toolkit/metadata"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
@@ -116,6 +117,7 @@ func (a *Adapter) EnsureIntegrationTestPipelineForScenarioExists() (controller.O
 				a.logger.Error(err, "Failed to create pipelineRun for snapshot, environment and scenario")
 				return controller.RequeueWithError(err)
 			}
+			metrics.RegisterPipelineRunWithEphemeralEnvStarted(a.snapshot.CreationTimestamp, metav1.Now())
 			a.logger.LogAuditEvent("PipelineRun for snapshot created", pipelineRun, h.LogActionAdd,
 				"snapshot.Name", a.snapshot.Name)
 		}

--- a/metrics/integration.go
+++ b/metrics/integration.go
@@ -41,6 +41,14 @@ var (
 		},
 	)
 
+	SnapshotCreatedToPipelineRunWithEphemeralEnvStartedSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds",
+			Help:    "The duration measures the time elapsed between the creation of a snapshot resource and the initiation of an integration PipelineRun for pipelines operating within an ephemeral environment.",
+			Buckets: []float64{0.05, 0.1, 0.5, 1, 2, 3, 4, 5, 10, 15, 30},
+		},
+	)
+
 	SEBCreatedToReadySeconds = prometheus.NewHistogram(
 		sebCreatedToReadySecondsOpts,
 	)
@@ -142,6 +150,10 @@ func RegisterPipelineRunStarted(snapshotCreatedTime metav1.Time, pipelineRunStar
 	SnapshotCreatedToPipelineRunStartedSeconds.Observe(pipelineRunStartTime.Sub(snapshotCreatedTime.Time).Seconds())
 }
 
+func RegisterPipelineRunWithEphemeralEnvStarted(snapshotCreatedTime metav1.Time, pipelineRunStartTime metav1.Time) {
+	SnapshotCreatedToPipelineRunWithEphemeralEnvStartedSeconds.Observe(pipelineRunStartTime.Sub(snapshotCreatedTime.Time).Seconds())
+}
+
 func RegisterSEBCreatedToReady(sebCreatedTime metav1.Time, sebReadyTime *metav1.Time) {
 	SEBCreatedToReadySeconds.
 		Observe(sebReadyTime.Sub(sebCreatedTime.Time).Seconds())
@@ -168,6 +180,7 @@ func RegisterReleaseLatency(startTime metav1.Time) {
 func init() {
 	metrics.Registry.MustRegister(
 		SnapshotCreatedToPipelineRunStartedSeconds,
+		SnapshotCreatedToPipelineRunWithEphemeralEnvStartedSeconds,
 		SEBCreatedToReadySeconds,
 		IntegrationSvcResponseSeconds,
 		IntegrationPipelineRunTotal,


### PR DESCRIPTION
## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
