### PR TITLE
(STONEINTG-687): add finalizer to component controller

### DIFF
--- a/controllers/component/predicates.go
+++ b/controllers/component/predicates.go
@@ -5,21 +5,42 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// ComponentDeletedPredicate returns a predicate which filters out
-// only deleted component scenarios
-func ComponentDeletedPredicate() predicate.Predicate {
+// ComponentCreatedPredicate returns a predicate which filters out
+// only components that are the result of a create event
+func ComponentCreatedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
-			return false
+			return true
 		},
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
-			return true
+			return false
 		},
 		GenericFunc: func(genericEvent event.GenericEvent) bool {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return false
+		},
+	}
+}
+
+// ComponentDeletedPredicate returns a predicate which filters out
+// only components that have been marked for deletion.
+// This is achieved by watching updates to components with an update to
+// the components DeletionTimestamp has been updated
+func ComponentDeletedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return hasComponentChangedToDeleting(e.ObjectOld, e.ObjectNew)
 		},
 	}
 }

--- a/controllers/scenario/scenario_adapter_test.go
+++ b/controllers/scenario/scenario_adapter_test.go
@@ -364,7 +364,7 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 				return !result.CancelRequest && err == nil
 			}, time.Second*20).Should(BeTrue())
 
-			expectedLogEntry := "Ephemeral environment is deleted and its owning SnapshotEnvironmentBinding is in the process of being deleted"
+			expectedLogEntry := "SnapshotEnvironmentBinding is in the process of being deleted"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			expectedLogEntry = "Removed Finalizer from the IntegrationTestScenario"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))

--- a/helpers/finalizers.go
+++ b/helpers/finalizers.go
@@ -19,3 +19,4 @@ package helpers
 // IntegrationPipelineRunFinalizer is the finalizer name to be added to the Integration PipelineRuns
 const IntegrationPipelineRunFinalizer string = "test.appstudio.openshift.io/pipelinerun"
 const IntegrationTestScenarioFinalizer string = "test.appstudio.openshift.io/scenario"
+const ComponentFinalizer string = "test.appstudio.openshift.io/component"

--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -476,6 +476,37 @@ func AddFinalizerToPipelineRun(adapterClient client.Client, logger IntegrationLo
 
 		logger.LogAuditEvent("Added Finalizer to the Integration PipelineRun", pipelineRun, LogActionUpdate, "finalizer", finalizer)
 	}
+	return nil
+}
+
+// AddFinalizerToComponent adds the finalizer to the component.
+// If finalizer was not added successfully, a non-nil error is returned.
+func AddFinalizerToComponent(adapterClient client.Client, logger IntegrationLogger, ctx context.Context, component *applicationapiv1alpha1.Component, finalizer string) error {
+	patch := client.MergeFrom(component.DeepCopy())
+	if ok := controllerutil.AddFinalizer(component, finalizer); ok {
+		err := adapterClient.Patch(ctx, component, patch)
+		if err != nil {
+			return fmt.Errorf("error occurred while patching the updated component after finalizer addition: %w", err)
+		}
+
+		logger.LogAuditEvent("Added Finalizer to the Component", component, LogActionUpdate, "finalizer", finalizer)
+	}
+
+	return nil
+}
+
+// RemoveFinalizerFromComponent removes the finalizer from the Component.
+// If finalizer was not removed successfully, a non-nil error is returned.
+func RemoveFinalizerFromComponent(adapterClient client.Client, logger IntegrationLogger, ctx context.Context, component *applicationapiv1alpha1.Component, finalizer string) error {
+	patch := client.MergeFrom(component.DeepCopy())
+	if ok := controllerutil.RemoveFinalizer(component, finalizer); ok {
+		err := adapterClient.Patch(ctx, component, patch)
+		if err != nil {
+			return fmt.Errorf("error occurred while patching the updated Component after finalizer removal: %w", err)
+		}
+
+		logger.LogAuditEvent("Removed Finalizer from the Component", component, LogActionDelete, "finalizer", finalizer)
+	}
 
 	return nil
 }

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -1055,4 +1055,21 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		logEntry = "Removed Finalizer from the IntegrationTestScenario"
 		Expect(buf.String()).Should(ContainSubstring(logEntry))
 	})
+
+	It("can add and remove finalizer from a component", func() {
+		var buf bytes.Buffer
+
+		// calling AddFinalizerToComponent() when the Component doesn't contain the finalizer
+		log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+		Expect(helpers.AddFinalizerToComponent(k8sClient, log, ctx, hasComp, helpers.ComponentFinalizer)).To(Succeed())
+		Expect(hasComp.Finalizers).To(ContainElement(ContainSubstring(helpers.ComponentFinalizer)))
+		logEntry := "Added Finalizer to the Component"
+		Expect(buf.String()).Should(ContainSubstring(logEntry))
+
+		// calling RemoveFinalizerFromComponent() when the Component contains the finalizer
+		Expect(helpers.RemoveFinalizerFromComponent(k8sClient, log, ctx, hasComp, helpers.ComponentFinalizer)).To(Succeed())
+		Expect(hasComp.Finalizers).NotTo(ContainElement(ContainSubstring(helpers.ComponentFinalizer)))
+		logEntry = "Removed Finalizer from the Component"
+		Expect(buf.String()).Should(ContainSubstring(logEntry))
+	})
 })


### PR DESCRIPTION
Changes to predicate logic for component controller to react to update events as opposed to deletion events. Alongside the addition of a finalizer ensures that the component controller will be able to accomplish generation of new snapshot for remaining components before the resource is removed from the cluster. 

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)