### PR TITLE
fix(snapshot_predicate_test): remove unneeded provisioning

### DIFF
--- a/gitops/snapshot_predicate_test.go
+++ b/gitops/snapshot_predicate_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package gitops_test
 
 import (
-	"context"
 	"github.com/redhat-appstudio/integration-service/gitops"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,7 +26,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -139,12 +137,6 @@ var _ = Describe("Predicates", Ordered, func() {
 				},
 			},
 		}
-		ctx := context.Background()
-
-		Expect(k8sClient.Create(ctx, hasSnapshotUnknownStatus)).Should(Succeed())
-		Expect(k8sClient.Create(ctx, hasSnapshotTrueStatus)).Should(Succeed())
-		Expect(k8sClient.Create(ctx, hasSnapshotAnnotationOld)).Should(Succeed())
-		Expect(k8sClient.Create(ctx, hasSnapshotAnnotationNew)).Should(Succeed())
 
 		// Set the binding statuses after they are created
 		hasSnapshotUnknownStatus.Status.Conditions = []metav1.Condition{
@@ -159,13 +151,6 @@ var _ = Describe("Predicates", Ordered, func() {
 				Status: metav1.ConditionTrue,
 			},
 		}
-	})
-
-	AfterAll(func() {
-		err := k8sClient.Delete(ctx, hasSnapshotUnknownStatus)
-		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
-		err = k8sClient.Delete(ctx, hasSnapshotTrueStatus)
-		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 	})
 
 	Context("when testing IntegrationSnapshotChangePredicate predicate", func() {


### PR DESCRIPTION
Unittest works directly with objects, there is no need for saving them in k8s DB

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
