### PR TITLE
fix(stoneintg-645): failed to get component for build pipeline

### DIFF
--- a/controllers/buildpipeline/buildpipeline_adapter.go
+++ b/controllers/buildpipeline/buildpipeline_adapter.go
@@ -73,10 +73,6 @@ func (a *Adapter) EnsureSnapshotExists() (controller.OperationResult, error) {
 		return controller.ContinueProcessing()
 	}
 
-	if a.component == nil {
-		return a.removeFinalizerAndContinueProcessing()
-	}
-
 	isLatest, err := a.isLatestSucceededBuildPipelineRun()
 	if err != nil {
 		return controller.RequeueWithError(err)

--- a/controllers/buildpipeline/buildpipeline_adapter_test.go
+++ b/controllers/buildpipeline/buildpipeline_adapter_test.go
@@ -19,8 +19,9 @@ package buildpipeline
 import (
 	"bytes"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/redhat-appstudio/integration-service/gitops"
 	"github.com/redhat-appstudio/integration-service/helpers"
@@ -495,17 +496,6 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			_, found = snapshot.GetLabels()["pipelines.appstudio.openshift.io/type"]
 			Expect(found).To(BeFalse())
 
-		})
-	})
-
-	When("Adapter is created but no components defined", func() {
-		It("ensures snapshot creation is skipped when there is no component defined ", func() {
-			adapter = NewAdapter(buildPipelineRun, nil, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
-			Expect(reflect.TypeOf(adapter)).To(Equal(reflect.TypeOf(&Adapter{})))
-
-			result, err := adapter.EnsureSnapshotExists()
-			Expect(!result.CancelRequest).To(BeTrue())
-			Expect(err).To(BeNil())
 		})
 	})
 

--- a/controllers/component/component_controller.go
+++ b/controllers/component/component_controller.go
@@ -65,7 +65,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
Update the component controller log message that is outputted when a build pipeline could not be found.  The new log message is outputted as 'INFO' rather than 'ERROR' and contains more information

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
