### PR TITLE
fix(STONEINTG-644): log message at info level when one component buil…

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -608,7 +608,7 @@ func PrepareSnapshot(adapterClient client.Client, ctx context.Context, applicati
 		// We omit this not-yet-built component from the snapshot rather than
 		// including a component that is incomplete.
 		if containerImage == "" {
-			log.Error(nil, "component cannot be added to snapshot for application due to missing containerImage", "component.Name", applicationComponent.Name)
+			log.Info("component cannot be added to snapshot for application due to missing containerImage", "component.Name", applicationComponent.Name)
 			continue
 		}
 		// if the containerImage doesn't have a valid digest, the component


### PR DESCRIPTION
log message at info level when one of the component build with no containerImage.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
