### PR TITLE
feat(stoneintg-628): add histogram panels for pipelinerun latency

### DIFF
--- a/config/grafana/dashboards/integration-service-dashboard.json
+++ b/config/grafana/dashboards/integration-service-dashboard.json
@@ -1341,6 +1341,129 @@
       "yBucketSize": null
     },
     {
+      "id": 31,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 90
+      },
+      "type": "heatmap",
+      "title": "Snapshot Created to PipelineRun With Ephemeral Environment Started Seconds",
+      "pluginVersion": "9.1.6",
+      "maxDataPoints": 25,
+      "description": "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started for pipelineRuns with ephemeral environments",
+      "legend": {
+        "show": false
+      },
+      "cards": {
+        "cardPadding": null,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          }
+        },
+        "overrides": []
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(increase(snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds_bucket[$__interval])) by (le)",
+          "format": "heatmap",
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "decimals": null,
+        "format": "short",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "options": {
+        "calculate": false,
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "min": null,
+          "max": null,
+          "unit": "short",
+          "decimals": null
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "color": {
+          "mode": "scheme",
+          "fill": "#b4ff00",
+          "scale": "exponential",
+          "exponent": 0.5,
+          "scheme": "Oranges",
+          "steps": 128,
+          "reverse": false
+        },
+        "cellGap": 2,
+        "filterValues": {
+          "le": 1e-9
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "legend": {
+          "show": false
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "calculation": {},
+        "cellValues": {},
+        "showValue": "never"
+      },
+      "reverseYBuckets": false,
+      "timeFrom": null,
+      "timeShift": null,
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
       "cards": {
         "cardPadding": null,
         "cardRound": null


### PR DESCRIPTION
Add histogram to show the latency between the time a snapshot is created and the time a pipelineRun is created for pipelineRuns with ephemeral environments

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
