### PR TITLE
fix(STONEINTG-684): remove finalizers if Snapshot can't be found 

### DIFF
--- a/controllers/integrationpipeline/integrationpipeline_adapter_test.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter_test.go
@@ -405,13 +405,13 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 	When("NewAdapter is called", func() {
 		It("creates and return a new adapter", func() {
-			Expect(reflect.TypeOf(NewAdapter(integrationPipelineRunComponent, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
+			Expect(reflect.TypeOf(NewAdapter(integrationPipelineRunComponent, hasApp, hasSnapshot, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
 		})
 	})
 
 	When("Snapshot already exists", func() {
 		BeforeEach(func() {
-			adapter = NewAdapter(integrationPipelineRunComponent, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(integrationPipelineRunComponent, hasApp, hasSnapshot, logger, loader.NewMockLoader(), k8sClient, ctx)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -563,7 +563,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				}
 				Expect(k8sClient.Status().Update(ctx, integrationPipelineRunComponentFailed)).Should(Succeed())
 
-				adapter = NewAdapter(integrationPipelineRunComponentFailed, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+				adapter = NewAdapter(integrationPipelineRunComponentFailed, hasApp, hasSnapshot, logger, loader.NewMockLoader(), k8sClient, ctx)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.ApplicationContextKey,
@@ -682,7 +682,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		It("ensures ephemeral environment is deleted for the given pipelineRun ", func() {
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(integrationPipelineRunComponent, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(integrationPipelineRunComponent, hasApp, hasSnapshot, log, loader.NewMockLoader(), k8sClient, ctx)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -868,7 +868,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			}
 			Expect(k8sClient.Status().Update(ctx, integrationPipelineRunComponentFailed)).Should(Succeed())
 
-			adapter = NewAdapter(integrationPipelineRunComponentFailed, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(integrationPipelineRunComponentFailed, hasApp, hasSnapshot, logger, loader.NewMockLoader(), k8sClient, ctx)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,


### PR DESCRIPTION
* Add the Snapshot to the integrationpipeline adapter
* If the integrationpipeline controller cannot find the Snapshot for that pipelineRun, remove the finalizer for it and let the ownerReference cascading delete it

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
