### PR TITLE
fix(STONEINTG-561): bug in naming convention of metrics

### DIFF
--- a/config/grafana/dashboards/integration-service-dashboard.json
+++ b/config/grafana/dashboards/integration-service-dashboard.json
@@ -478,7 +478,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.90, sum(rate(release_latency_seconds_bucket[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(integration_svc_release_latency_seconds_bucket[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": "percentile90",
           "refId": "A",
@@ -616,7 +616,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(release_latency_seconds_bucket{le=\"10\"}[$__rate_interval])) by (job) / sum(rate(release_latency_seconds_count[$__rate_interval])) by (job)*100",
+          "expr": "sum(rate(integration_svc_release_latency_seconds_bucket{le=\"10\"}[$__rate_interval])) by (job) / sum(rate(integration_svc_release_latency_seconds_count[$__rate_interval])) by (job)*100",
           "interval": "",
           "legendFormat": "% of requests within required latency time",
           "range": true,
@@ -1928,7 +1928,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(release_latency_seconds_bucket[$__interval])) by (le)",
+          "expr": "sum(increase(integration_svc_release_latency_seconds_bucket[$__interval])) by (le)",
           "format": "heatmap",
           "interval": "",
           "legendFormat": "{{le}}",

--- a/metrics/integration.go
+++ b/metrics/integration.go
@@ -107,7 +107,7 @@ var (
 
 	ReleaseLatencySeconds = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "release_latency_seconds",
+			Name:    "integration_svc_release_latency_seconds",
 			Help:    "Latency between integration tests completion and release creation",
 			Buckets: []float64{0.05, 0.1, 0.5, 1, 2, 3, 4, 5, 10, 15, 30},
 		},


### PR DESCRIPTION
change name of latency release creation metric by prefixing with integration_service. Bug fix related to [stoneintg-561](https://issues.redhat.com//browse/stoneintg-561)

## Maintainers will complete the following section

- [x ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
