### PR TITLE
fix(size): add 20% to thresholds

### DIFF
--- a/.github/workflows/size.yaml
+++ b/.github/workflows/size.yaml
@@ -19,15 +19,15 @@ jobs:
           size=$((additions + deletions))
 
           sizelabel=XS
-          if [ ${size} -gt 500 ]; then
+          if [ ${size} -gt 600 ]; then
             sizelabel="XXL"
-          elif [ ${size} -gt 200 ]; then
+          elif [ ${size} -gt 240 ]; then
             sizelabel="XL"
-          elif [ ${size} -gt 100 ]; then
+          elif [ ${size} -gt 120 ]; then
             sizelabel="L"
-          elif [ ${size} -gt 50 ]; then
+          elif [ ${size} -gt 60 ]; then
             sizelabel="M"
-          elif [ ${size} -gt 30 ]; then
+          elif [ ${size} -gt 35 ]; then
             sizelabel="S"
           fi
 


### PR DESCRIPTION
Just adding unittests makes PR size XL. Increasing thresholds by ~20% to make better estimations.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
