### PR TITLE
fix(STONEINTG-689): skip update if *StatusAdapter fails

### DIFF
--- a/status/reporters.go
+++ b/status/reporters.go
@@ -482,9 +482,11 @@ func (r *GitHubReporter) ReportStatusForSnapshot(k8sClient client.Client, ctx co
 			integrationTestStatusDetail := *integrationTestStatusDetail // G601
 			checkRun, err := r.createCheckRunAdapterForSnapshot(ctx, snapshot, integrationTestStatusDetail, owner, repo, sha)
 			if err != nil {
-				logger.Error(err, "failed to create checkRunAdapter for snapshot",
-					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
-				return err
+				logger.Error(err, "failed to create checkRunAdapter for scenario, skipping update",
+					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name,
+					"scenario.Name", integrationTestStatusDetail.ScenarioName,
+				)
+				continue
 			}
 
 			existingCheckrun := r.client.GetExistingCheckRun(allCheckRuns, checkRun)
@@ -537,9 +539,11 @@ func (r *GitHubReporter) ReportStatusForSnapshot(k8sClient client.Client, ctx co
 
 			commitStatus, err := r.createCommitStatusAdapterForSnapshot(snapshot, integrationTestStatusDetail, owner, repo, sha)
 			if err != nil {
-				logger.Error(err, "failed to create CommitStatusAdapter for snapshot",
-					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
-				return err
+				logger.Error(err, "failed to create CommitStatusAdapter for scenario, skipping update",
+					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name,
+					"scenario.Name", integrationTestStatusDetail.ScenarioName,
+				)
+				continue
 			}
 
 			commitStatusExist, err := r.client.CommitStatusExists(allCommitStatuses, commitStatus)


### PR DESCRIPTION
If we fail to create object with *StatusAdapter, we should skip update of PR status. This error is usually non-recoverable it only retriggers reconciliation and blocks other updates.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
