### PR TITLE
fix(STONEINTG-689): add PR last update snapshot annotation

### DIFF
--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -19,6 +19,7 @@ package statusreport
 import (
 	"context"
 	"fmt"
+
 	"github.com/redhat-appstudio/integration-service/api/v1beta1"
 	"github.com/redhat-appstudio/integration-service/gitops"
 	"github.com/redhat-appstudio/integration-service/metrics"

--- a/controllers/statusreport/statusreport_adapter_test.go
+++ b/controllers/statusreport/statusreport_adapter_test.go
@@ -20,11 +20,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"reflect"
+	"time"
+
 	"github.com/redhat-appstudio/integration-service/api/v1beta1"
 	"github.com/tonglil/buflogr"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"reflect"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/git/github/github.go
+++ b/git/github/github.go
@@ -99,7 +99,6 @@ type ClientInterface interface {
 	CreateComment(ctx context.Context, owner string, repo string, issueNumber int, body string) (int64, error)
 	CreateCommitStatus(ctx context.Context, owner string, repo string, SHA string, state string, description string, statusContext string) (int64, error)
 	GetAllCheckRunsForRef(ctx context.Context, owner string, repo string, SHA string, appID int64) ([]*ghapi.CheckRun, error)
-	IsUpdateNeeded(existingCheckRun *ghapi.CheckRun, newCheckRun *CheckRunAdapter) bool
 	GetExistingCheckRun(checkRuns []*ghapi.CheckRun, newCheckRun *CheckRunAdapter) *ghapi.CheckRun
 	GetAllCommitStatusesForRef(ctx context.Context, owner, repo, sha string) ([]*ghapi.RepoStatus, error)
 	GetAllCommentsForPR(ctx context.Context, owner string, repo string, pr int) ([]*ghapi.IssueComment, error)
@@ -390,20 +389,6 @@ func (c *Client) GetExistingCommentID(comments []*ghapi.IssueComment, snapshotNa
 	}
 	c.logger.Info("found no comment with a matching scenarioName", "scenarioName", scenarioName)
 	return nil
-}
-
-// IsUpdateNeeded check if check run update is needed
-// according to the text of existingCheckRun and newCheckRun since the details are different every update
-func (c *Client) IsUpdateNeeded(existingCheckRun *ghapi.CheckRun, newCheckRun *CheckRunAdapter) bool {
-	if newCheckRun.Text != *existingCheckRun.Output.Text {
-		// We need to update the existing checkrun if their ExternalID and Text are different
-		c.logger.Info("found CheckRun with a matching ExternalID and status, so need to update", "ExternalID", newCheckRun.ExternalID)
-		return true
-	} else {
-		// We don't need to update the existing checkrun if their ExternalID and Text are the same
-		c.logger.Info("found CheckRun with a matching ExternalID and status, so no need to update", "ExternalID", newCheckRun.ExternalID)
-		return false
-	}
 }
 
 // GetAllCommitStatusesForRef returns all existing GitHub CommitStatuses if a match for the Owner, Repo, and SHA.

--- a/git/github/github_test.go
+++ b/git/github/github_test.go
@@ -285,7 +285,6 @@ var _ = Describe("Client", func() {
 
 		existingCheckRun := client.GetExistingCheckRun(allCheckRuns, checkRunAdapter)
 		Expect(existingCheckRun).NotTo(BeNil())
-		Expect(client.IsUpdateNeeded(existingCheckRun, checkRunAdapter)).To(BeTrue())
 
 		checkRunAdapter = &github.CheckRunAdapter{
 			Name:           "example-name",
@@ -300,7 +299,6 @@ var _ = Describe("Client", func() {
 			StartTime:      time.Now(),
 			CompletionTime: time.Now(),
 		}
-		Expect(client.IsUpdateNeeded(existingCheckRun, checkRunAdapter)).To(BeFalse())
 	})
 
 	It("can check if creating a new commit status is needed", func() {

--- a/status/reporters.go
+++ b/status/reporters.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/go-logr/logr"
 	ghapi "github.com/google/go-github/v45/github"
@@ -236,19 +237,13 @@ func (cru *CheckRunStatusUpdater) UpdateStatus(ctx context.Context, integrationT
 		}
 	} else {
 		cru.logger.Info("found existing checkrun", "existingCheckRun", existingCheckrun)
-		if cru.ghClient.IsUpdateNeeded(existingCheckrun, checkRun) {
-			cru.logger.Info("found existing check run with the same ExternalID but different conclusion/status, updating checkrun for scenario test status of snapshot",
-				"snapshot.NameSpace", cru.snapshot.Namespace, "snapshot.Name", cru.snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName, "checkrun.ExternalID", checkRun.ExternalID)
-			err = cru.ghClient.UpdateCheckRun(ctx, *existingCheckrun.ID, checkRun)
-			if err != nil {
-				cru.logger.Error(err, "failed to update checkrun",
-					"checkRun", checkRun)
-				return err
-			}
-		} else {
-			cru.logger.Info("found existing check run with the same ExternalID and conclusion/status, no need to update checkrun for scenario test status of snapshot",
-				"snapshot.NameSpace", cru.snapshot.Namespace, "snapshot.Name", cru.snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName, "checkrun.ExternalID", checkRun.ExternalID)
+		err = cru.ghClient.UpdateCheckRun(ctx, *existingCheckrun.ID, checkRun)
+		if err != nil {
+			cru.logger.Error(err, "failed to update checkrun",
+				"checkRun", checkRun)
+			return err
 		}
+
 	}
 	return nil
 }
@@ -688,6 +683,14 @@ func (r *GitHubReporter) ReportStatusForSnapshot(k8sClient client.Client, ctx co
 		return fmt.Errorf("sha label not found %q", gitops.PipelineAsCodeSHALabel)
 	}
 	integrationTestStatusDetails := statuses.GetStatuses()
+	latestUpdateTime, err := gitops.GetLatestUpdateTime(snapshot)
+	if err != nil {
+		logger.Error(err, "failed to get latest update annotation for snapshot",
+			"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		latestUpdateTime = time.Time{}
+	}
+	newLatestUpdateTime := latestUpdateTime
+
 	// Existence of the Pipelines as Code installation ID annotation signals configuration using GitHub App integration.
 	// If it doesn't exist, GitHub webhook integration is configured.
 	if metadata.HasAnnotation(snapshot, gitops.PipelineAsCodeInstallationIDAnnotation) {
@@ -701,10 +704,20 @@ func (r *GitHubReporter) ReportStatusForSnapshot(k8sClient client.Client, ctx co
 	}
 
 	for _, integrationTestStatusDetail := range integrationTestStatusDetails {
+		if latestUpdateTime.Before(integrationTestStatusDetail.LastUpdateTime) {
+			logger.Info("Integration Test contains new status updates", "scenario.Name", integrationTestStatusDetail.ScenarioName)
+			if newLatestUpdateTime.Before(integrationTestStatusDetail.LastUpdateTime) {
+				newLatestUpdateTime = integrationTestStatusDetail.LastUpdateTime
+			}
+		} else {
+			//integration test contains no changes
+			continue
+		}
 		if err := updater.UpdateStatus(ctx, *integrationTestStatusDetail); err != nil {
 			return fmt.Errorf("failed to update status: %w", err)
 		}
-	}
 
+	}
+	_ = gitops.SetLatestUpdateTime(snapshot, newLatestUpdateTime)
 	return nil
 }


### PR DESCRIPTION
## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
