### PR TITLE
fix(grafana): update SLI title for static env

### DIFF
--- a/config/grafana/dashboards/integration-service-dashboard.json
+++ b/config/grafana/dashboards/integration-service-dashboard.json
@@ -1316,7 +1316,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Snapshot Created to PipelineRun Started Seconds",
+      "title": "Snapshot Created to PipelineRun With Static Environment Started Seconds",
       "tooltip": {
         "show": true,
         "showHistogram": false


### PR DESCRIPTION
Make SLI title explicitly mention static environments

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
