### PR TITLE
fix(STONEINTG-693): stop collisions in buildpipeline adapter tests

### DIFF
--- a/controllers/buildpipeline/buildpipeline_controller_test.go
+++ b/controllers/buildpipeline/buildpipeline_controller_test.go
@@ -231,7 +231,7 @@ var _ = Describe("PipelineController", func() {
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasComp)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
-		_ = controllerutil.RemoveFinalizer(buildPipelineRun, "build.appstudio.openshift.io/pipelinerun")
+		_ = controllerutil.RemoveFinalizer(buildPipelineRun, "test.appstudio.openshift.io/pipelinerun")
 		err = k8sClient.Delete(ctx, buildPipelineRun)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, successfulTaskRun)
@@ -262,19 +262,14 @@ var _ = Describe("PipelineController", func() {
 		Expect(err).To(BeNil())
 	})
 
+	It("can setup a new Controller manager", func() {
+		err := SetupController(manager, &ctrl.Log)
+		Expect(err).To(BeNil())
+	})
+
 	It("can setup a new controller manager with the given reconciler", func() {
 		err := setupControllerWithManager(manager, pipelineReconciler)
 		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("can setup a new Controller manager and start it", func() {
-		err := SetupController(manager, &ctrl.Log)
-		Expect(err).To(BeNil())
-		go func() {
-			defer GinkgoRecover()
-			err = manager.Start(ctx)
-			Expect(err).NotTo(HaveOccurred())
-		}()
 	})
 
 	It("Does not return an error if the component cannot be found", func() {


### PR DESCRIPTION
* Don't start the controller manager in the controller test suite because that causes it to react to creation events in adapter unit tests and causes collisions when it attempts to add a finalizer to all newy created build pipelineRuns
* Wait for the buildPipeline run resource on the control plane to be fully updated and its finalizer removed before ending finalizer tests to prevent create actions in beforeEach from running into conflicts
* Reduce update actions for build pipelineRuns where they don't require testing resources on the control plane

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
