### PR TITLE
fix(binding-PLR): missing build labels/annotations

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -215,6 +215,10 @@ func (a *Adapter) createIntegrationPipelineRunWithEnvironment(application *appli
 	_ = metadata.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.PipelinesAsCodePrefix)
 	_ = metadata.CopyLabelsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.PipelinesAsCodePrefix)
 
+	// Copy build labels and annotations prefixed with build.appstudio from snapshot to integration test PipelineRuns
+	_ = metadata.CopyLabelsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.BuildPipelineRunPrefix)
+	_ = metadata.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.BuildPipelineRunPrefix)
+
 	err = ctrl.SetControllerReference(snapshot, pipelineRun, a.client.Scheme())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Integration PLRs created with ephemeral environments are missing build labels and annotation. PLR created in static envs have them copied.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
