### PR TITLE
fix(binding-PLR): fix missing PLR builder func calls

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -205,8 +205,10 @@ func (a *Adapter) createIntegrationPipelineRunWithEnvironment(application *appli
 
 	pipelineRun := tekton.NewIntegrationPipelineRun(snapshot.Name, application.Namespace, *integrationTestScenario).
 		WithSnapshot(snapshot).
-		WithApplicationAndComponent(a.application, a.component).
 		WithIntegrationLabels(integrationTestScenario).
+		WithIntegrationAnnotations(integrationTestScenario).
+		WithApplicationAndComponent(a.application, a.component).
+		WithExtraParams(integrationTestScenario.Spec.Params).
 		WithEnvironmentAndDeploymentTarget(deploymentTarget, environment.Name).
 		WithFinalizer(h.IntegrationPipelineRunFinalizer).
 		AsPipelineRun()


### PR DESCRIPTION
Pipeline builder for ephemeral PLR was missing few steps to make all metadata of PLR completed.

Now it's the same asi PLR for static environment

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
