### PR TITLE
fix(STONEINTG-646):  trigger snapshot reconcile for added its

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -714,6 +714,23 @@ func RemoveIntegrationTestRerunLabel(adapterClient client.Client, ctx context.Co
 	return nil
 }
 
+// AddIntegrationTestRerunLabel adding re-run label to snapshot
+func AddIntegrationTestRerunLabel(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, integrationTestScenarioName string) error {
+	patch := client.MergeFrom(snapshot.DeepCopy())
+	newLabel := map[string]string{}
+	newLabel[SnapshotIntegrationTestRun] = integrationTestScenarioName
+	err := metadata.AddLabels(snapshot, newLabel)
+	if err != nil {
+		return fmt.Errorf("failed to add label %s: %w", SnapshotIntegrationTestRun, err)
+	}
+	err = adapterClient.Patch(ctx, snapshot, patch)
+	if err != nil {
+		return fmt.Errorf("failed to patch snapshot: %w", err)
+	}
+
+	return nil
+}
+
 func GetLatestUpdateTime(snapshot *applicationapiv1alpha1.Snapshot) (time.Time, error) {
 	latestUpdateTime := snapshot.GetAnnotations()[SnapshotPRLastUpdate]
 	if latestUpdateTime == "" {

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -500,6 +500,19 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		})
 	})
 
+	Context("AddIntegrationTestRerunLabel tests", func() {
+
+		It("add run label to snapshot", func() {
+			testScenario := "test-scenario"
+			err := gitops.AddIntegrationTestRerunLabel(k8sClient, ctx, hasSnapshot, testScenario)
+			Expect(err).To(BeNil())
+			val, ok := gitops.GetIntegrationTestRunLabelValue(*hasSnapshot)
+			Expect(ok).To(BeTrue())
+			Expect(val).To(Equal(testScenario))
+		})
+
+	})
+
 	Context("RemoveIntegrationTestRerunLabel tests", func() {
 
 		It("won't fail if re-run label is not present", func() {


### PR DESCRIPTION
This PR to fix race condition when adding another IntegrationTestScenario to an application that already running former one, the new one will bot be triggered. 

to fix it, we identify the untriggered ITS  and then we add Re-run label to snapshot and this will trigger the snapshot reconcile .

more details in Jira [STONEINTG-646](https://issues.redhat.com/browse/STONEINTG-646)


## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
