### PR TITLE
fix(STONEINTG-693): don't start controllers in unit tests

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_controller_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_controller_test.go
@@ -369,11 +369,6 @@ var _ = Describe("BindingController", func() {
 	It("can setup a new Controller manager and start it", func() {
 		err := SetupController(manager, &ctrl.Log)
 		Expect(err).To(BeNil())
-		go func() {
-			defer GinkgoRecover()
-			err = manager.Start(ctx)
-			Expect(err).NotTo(HaveOccurred())
-		}()
 	})
 
 })

--- a/controllers/component/component_controller_test.go
+++ b/controllers/component/component_controller_test.go
@@ -149,11 +149,6 @@ var _ = Describe("ComponentController", func() {
 	It("can setup a new Controller manager and start it", func() {
 		err := SetupController(manager, &ctrl.Log)
 		Expect(err).To(BeNil())
-		go func() {
-			defer GinkgoRecover()
-			err = manager.Start(ctx)
-			Expect(err).NotTo(HaveOccurred())
-		}()
 	})
 
 })

--- a/controllers/integrationpipeline/integrationpipeline_controller_test.go
+++ b/controllers/integrationpipeline/integrationpipeline_controller_test.go
@@ -319,11 +319,6 @@ var _ = Describe("Integration PipelineController", func() {
 	It("can setup a new Controller manager and start it", func() {
 		err := SetupController(manager, &ctrl.Log)
 		Expect(err).To(BeNil())
-		go func() {
-			defer GinkgoRecover()
-			err = manager.Start(ctx)
-			Expect(err).NotTo(HaveOccurred())
-		}()
 	})
 
 	It("Does not return an error if the snapshot cannot be found", func() {

--- a/controllers/scenario/scenario_controller_test.go
+++ b/controllers/scenario/scenario_controller_test.go
@@ -217,11 +217,6 @@ var _ = Describe("ScenarioController", func() {
 	It("can setup a new Controller manager and start it", func() {
 		err := SetupController(manager, &ctrl.Log)
 		Expect(err).To(BeNil())
-		go func() {
-			defer GinkgoRecover()
-			err = manager.Start(ctx)
-			Expect(err).NotTo(HaveOccurred())
-		}()
 	})
 
 })

--- a/controllers/snapshot/snapshot_controller_test.go
+++ b/controllers/snapshot/snapshot_controller_test.go
@@ -227,11 +227,6 @@ var _ = Describe("SnapshotController", func() {
 	It("can setup a new Controller manager and start it", func() {
 		err := SetupController(manager, &ctrl.Log)
 		Expect(err).To(BeNil())
-		go func() {
-			defer GinkgoRecover()
-			err = manager.Start(ctx)
-			Expect(err).NotTo(HaveOccurred())
-		}()
 	})
 
 })

--- a/controllers/statusreport/statusreport_controller_test.go
+++ b/controllers/statusreport/statusreport_controller_test.go
@@ -157,11 +157,6 @@ var _ = Describe("StatusReportController", func() {
 	It("can setup a new Controller manager and start it", func() {
 		err := SetupController(manager, &ctrl.Log)
 		Expect(err).To(BeNil())
-		go func() {
-			defer GinkgoRecover()
-			err = manager.Start(ctx)
-			Expect(err).NotTo(HaveOccurred())
-		}()
 	})
 
 })


### PR DESCRIPTION
* Don't start the controller manager in the controller test suite because that causes it to react to creation events in adapter unit tests and causes potential collisions and unexpected behavior

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
