### PR TITLE
fix(metrics): don't count PLR re-run into statistics

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -230,6 +230,8 @@ func (a *Adapter) createIntegrationPipelineRunWithEnvironment(application *appli
 		return nil, err
 	}
 
+	go metrics.RegisterNewIntegrationPipelineRun()
+
 	return pipelineRun, nil
 
 }

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -294,10 +294,11 @@ func MarkSnapshotIntegrationStatusAsInProgress(adapterClient client.Client, ctx 
 	return snapshot, nil
 }
 
-// PrepareToRegisterIntegrationPipelineRun is to do preparation before calling RegisterNewIntegrationPipelineRun
-func PrepareToRegisterIntegrationPipelineRun(snapshot *applicationapiv1alpha1.Snapshot) {
+// PrepareToRegisterIntegrationPipelineRunStarted is to do preparation before calling RegisterPipelineRunStarted
+// Don't use this function for PLR re-runs
+func PrepareToRegisterIntegrationPipelineRunStarted(snapshot *applicationapiv1alpha1.Snapshot) {
 	pipelineRunStartTime := &metav1.Time{Time: time.Now()}
-	go metrics.RegisterNewIntegrationPipelineRun(snapshot.GetCreationTimestamp(), pipelineRunStartTime)
+	go metrics.RegisterPipelineRunStarted(snapshot.GetCreationTimestamp(), pipelineRunStartTime)
 }
 
 // SetSnapshotIntegrationStatusAsFinished sets the AppStudio integration status condition for the Snapshot to Finished.

--- a/metrics/integration.go
+++ b/metrics/integration.go
@@ -167,9 +167,8 @@ func RegisterNewSnapshot() {
 	SnapshotConcurrentTotal.Inc()
 }
 
-func RegisterNewIntegrationPipelineRun(snapshotCreatedTime metav1.Time, pipelineRunStartTime *metav1.Time) {
+func RegisterNewIntegrationPipelineRun() {
 	IntegrationPipelineRunTotal.Inc()
-	RegisterPipelineRunStarted(snapshotCreatedTime, pipelineRunStartTime)
 }
 
 func RegisterReleaseLatency(startTime metav1.Time) {


### PR DESCRIPTION
We want to measure only perfomance of automatic creation of PLR after snapshot is created. Manual reruns can be triggered after days and week and gives no usable value for this metric.

Separated counting of created PLRs from measurement of how long it took.

There was also a missing PLR counter in SEB controller.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
