### PR TITLE
fix(SEB): mark snapshot as running tests

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -232,6 +232,16 @@ func (a *Adapter) createIntegrationPipelineRunWithEnvironment(application *appli
 
 	go metrics.RegisterNewIntegrationPipelineRun()
 
+	if gitops.IsSnapshotNotStarted(a.snapshot) {
+		_, err := gitops.MarkSnapshotIntegrationStatusAsInProgress(a.client, a.context, a.snapshot, "Snapshot starts being tested by the integrationPipelineRun")
+		if err != nil {
+			a.logger.Error(err, "Failed to update integration status condition to in progress for snapshot")
+		} else {
+			a.logger.LogAuditEvent("Snapshot integration status marked as In Progress. Snapshot starts being tested by the integrationPipelineRun",
+				a.snapshot, h.LogActionUpdate)
+		}
+	}
+
 	return pipelineRun, nil
 
 }


### PR DESCRIPTION
SEB was not marking snapshot as in-progress. Fixing parity with static env tests.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
