### PR TITLE
refactor(reporters): separate github reporters

### DIFF
--- a/status/reporters.go
+++ b/status/reporters.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
+	ghapi "github.com/google/go-github/v45/github"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/git/github"
@@ -36,6 +37,462 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// StatusUpdater is common interface used by status reporter to update PR status
+type StatusUpdater interface {
+	// Authentication of client
+	Authenticate(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) error
+	// Update status of PR
+	UpdateStatus(ctx context.Context, integrationTestStatusDetail intgteststat.IntegrationTestStatusDetail) error
+}
+
+// CheckRunStatusUpdater updates PR status using CheckRuns (when application integration is enabled in repo)
+type CheckRunStatusUpdater struct {
+	ghClient          github.ClientInterface
+	k8sClient         client.Client
+	logger            *helpers.IntegrationLogger
+	owner             string
+	repo              string
+	sha               string
+	snapshot          *applicationapiv1alpha1.Snapshot
+	creds             *appCredentials
+	allCheckRunsCache []*ghapi.CheckRun
+}
+
+// NewCheckRunStatusUpdater returns a pointer to initialized CheckRunStatusUpdater
+func NewCheckRunStatusUpdater(
+	ghClient github.ClientInterface,
+	k8sClient client.Client,
+	logger *helpers.IntegrationLogger,
+	owner string,
+	repo string,
+	sha string,
+	snapshot *applicationapiv1alpha1.Snapshot,
+) *CheckRunStatusUpdater {
+	return &CheckRunStatusUpdater{
+		ghClient:  ghClient,
+		k8sClient: k8sClient,
+		logger:    logger,
+		owner:     owner,
+		repo:      repo,
+		sha:       sha,
+		snapshot:  snapshot,
+	}
+}
+
+func (cru *CheckRunStatusUpdater) getAppCredentials(ctx context.Context, object client.Object) (*appCredentials, error) {
+	var err error
+	var found bool
+	appInfo := appCredentials{}
+
+	appInfo.InstallationID, err = strconv.ParseInt(object.GetAnnotations()[gitops.PipelineAsCodeInstallationIDAnnotation], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the global pipelines as code secret
+	pacSecret := v1.Secret{}
+	err = cru.k8sClient.Get(ctx, types.NamespacedName{Namespace: "openshift-pipelines", Name: "pipelines-as-code-secret"}, &pacSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the App ID from the secret
+	ghAppIDBytes, found := pacSecret.Data["github-application-id"]
+	if !found {
+		return nil, errors.New("failed to find github-application-id secret key")
+	}
+
+	appInfo.AppID, err = strconv.ParseInt(string(ghAppIDBytes), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the App's private key from the secret
+	appInfo.PrivateKey, found = pacSecret.Data["github-private-key"]
+	if !found {
+		return nil, errors.New("failed to find github-private-key secret key")
+	}
+
+	return &appInfo, nil
+}
+
+// Authenticate Github Client with application credentials
+func (cru *CheckRunStatusUpdater) Authenticate(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) error {
+	creds, err := cru.getAppCredentials(ctx, snapshot)
+	cru.creds = creds
+
+	if err != nil {
+		cru.logger.Error(err, "failed to get app credentials from Snapshot",
+			"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return err
+	}
+
+	token, err := cru.ghClient.CreateAppInstallationToken(ctx, creds.AppID, creds.InstallationID, creds.PrivateKey)
+	if err != nil {
+		cru.logger.Error(err, "failed to create app installation token",
+			"creds.AppID", creds.AppID, "creds.InstallationID", creds.InstallationID)
+		return err
+	}
+
+	cru.ghClient.SetOAuthToken(ctx, token)
+
+	return nil
+}
+
+func (cru *CheckRunStatusUpdater) getAllCheckRuns(ctx context.Context) ([]*ghapi.CheckRun, error) {
+	if len(cru.allCheckRunsCache) == 0 {
+		allCheckRuns, err := cru.ghClient.GetAllCheckRunsForRef(ctx, cru.owner, cru.repo, cru.sha, cru.creds.AppID)
+		if err != nil {
+			cru.logger.Error(err, "failed to get all checkruns for ref",
+				"owner", cru.owner, "repo", cru.repo, "creds.AppID", cru.creds.AppID)
+			return nil, err
+		}
+		cru.allCheckRunsCache = allCheckRuns
+	}
+	return cru.allCheckRunsCache, nil
+}
+
+// createCheckRunAdapterForSnapshot create a CheckRunAdapter for given snapshot, integrationTestStatusDetail, owner, repo and sha to create a checkRun
+// https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run
+func (cru *CheckRunStatusUpdater) createCheckRunAdapterForSnapshot(ctx context.Context, integrationTestStatusDetail intgteststat.IntegrationTestStatusDetail, owner, repo, sha string) (*github.CheckRunAdapter, error) {
+	var text string
+	snapshot := cru.snapshot
+	scenarioName := integrationTestStatusDetail.ScenarioName
+
+	conclusion, err := generateCheckRunConclusion(integrationTestStatusDetail.Status)
+	if err != nil {
+		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
+	}
+
+	title, err := generateCheckRunTitle(integrationTestStatusDetail.Status)
+	if err != nil {
+		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
+	}
+
+	summary, err := generateSummary(integrationTestStatusDetail.Status, snapshot.Name, scenarioName)
+	if err != nil {
+		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
+	}
+
+	text, err = generateCheckRunText(cru.k8sClient, ctx, integrationTestStatusDetail, cru.snapshot.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("experienced error when generating text for checkRun: %w", err)
+	}
+
+	cra := &github.CheckRunAdapter{
+		Owner:      owner,
+		Repository: repo,
+		Name:       NamePrefix + " / " + snapshot.Name + " / " + scenarioName,
+		SHA:        sha,
+		ExternalID: scenarioName,
+		Conclusion: conclusion,
+		Title:      title,
+		Summary:    summary,
+		Text:       text,
+	}
+
+	if start := integrationTestStatusDetail.StartTime; start != nil {
+		cra.StartTime = *start
+	}
+
+	if complete := integrationTestStatusDetail.CompletionTime; complete != nil {
+		cra.CompletionTime = *complete
+	}
+
+	return cra, nil
+}
+
+// UpdateStatus updates CheckRun status of PR
+func (cru *CheckRunStatusUpdater) UpdateStatus(ctx context.Context, integrationTestStatusDetail intgteststat.IntegrationTestStatusDetail) error {
+	if cru.creds == nil {
+		panic("authenticate first")
+	}
+	allCheckRuns, err := cru.getAllCheckRuns(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	checkRun, err := cru.createCheckRunAdapterForSnapshot(ctx, integrationTestStatusDetail, cru.owner, cru.repo, cru.sha)
+	if err != nil {
+		cru.logger.Error(err, "failed to create checkRunAdapter for scenario, skipping update",
+			"snapshot.NameSpace", cru.snapshot.Namespace, "snapshot.Name", cru.snapshot.Name,
+			"scenario.Name", integrationTestStatusDetail.ScenarioName,
+		)
+		return nil
+	}
+
+	existingCheckrun := cru.ghClient.GetExistingCheckRun(allCheckRuns, checkRun)
+
+	if existingCheckrun == nil {
+		cru.logger.Info("creating checkrun for scenario test status of snapshot",
+			"snapshot.NameSpace", cru.snapshot.Namespace, "snapshot.Name", cru.snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName)
+		_, err = cru.ghClient.CreateCheckRun(ctx, checkRun)
+		if err != nil {
+			cru.logger.Error(err, "failed to create checkrun",
+				"checkRun", checkRun)
+			return err
+		}
+	} else {
+		cru.logger.Info("found existing checkrun", "existingCheckRun", existingCheckrun)
+		if cru.ghClient.IsUpdateNeeded(existingCheckrun, checkRun) {
+			cru.logger.Info("found existing check run with the same ExternalID but different conclusion/status, updating checkrun for scenario test status of snapshot",
+				"snapshot.NameSpace", cru.snapshot.Namespace, "snapshot.Name", cru.snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName, "checkrun.ExternalID", checkRun.ExternalID)
+			err = cru.ghClient.UpdateCheckRun(ctx, *existingCheckrun.ID, checkRun)
+			if err != nil {
+				cru.logger.Error(err, "failed to update checkrun",
+					"checkRun", checkRun)
+				return err
+			}
+		} else {
+			cru.logger.Info("found existing check run with the same ExternalID and conclusion/status, no need to update checkrun for scenario test status of snapshot",
+				"snapshot.NameSpace", cru.snapshot.Namespace, "snapshot.Name", cru.snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName, "checkrun.ExternalID", checkRun.ExternalID)
+		}
+	}
+	return nil
+}
+
+// CommitStatusUpdater updates PR using Commit/RepoStatus (without application integration enabled)
+type CommitStatusUpdater struct {
+	ghClient               github.ClientInterface
+	k8sClient              client.Client
+	logger                 *helpers.IntegrationLogger
+	owner                  string
+	repo                   string
+	sha                    string
+	snapshot               *applicationapiv1alpha1.Snapshot
+	allCommitStatusesCache []*ghapi.RepoStatus
+}
+
+// NewCommitStatusUpdater returns a pointer to initialized CommitStatusUpdater
+func NewCommitStatusUpdater(
+	ghClient github.ClientInterface,
+	k8sClient client.Client,
+	logger *helpers.IntegrationLogger,
+	owner string,
+	repo string,
+	sha string,
+	snapshot *applicationapiv1alpha1.Snapshot,
+) *CommitStatusUpdater {
+	return &CommitStatusUpdater{
+		ghClient:  ghClient,
+		k8sClient: k8sClient,
+		logger:    logger,
+		owner:     owner,
+		repo:      repo,
+		sha:       sha,
+		snapshot:  snapshot,
+	}
+}
+
+func (csu *CommitStatusUpdater) getToken(ctx context.Context) (string, error) {
+	var err error
+
+	// List all the Repository CRs in the namespace
+	repos := pacv1alpha1.RepositoryList{}
+	if err = csu.k8sClient.List(ctx, &repos, &client.ListOptions{Namespace: csu.snapshot.Namespace}); err != nil {
+		return "", err
+	}
+
+	// Get the full repo URL
+	url, found := csu.snapshot.GetAnnotations()[gitops.PipelineAsCodeRepoURLAnnotation]
+	if !found {
+		return "", fmt.Errorf("object annotation not found %q", gitops.PipelineAsCodeRepoURLAnnotation)
+	}
+
+	// Find a Repository CR with a matching URL and get its secret details
+	var repoSecret *pacv1alpha1.Secret
+	for _, repo := range repos.Items {
+		if url == repo.Spec.URL {
+			repoSecret = repo.Spec.GitProvider.Secret
+			break
+		}
+	}
+
+	if repoSecret == nil {
+		return "", fmt.Errorf("failed to find a Repository matching URL: %q", url)
+	}
+
+	// Get the pipelines as code secret from the PipelineRun's namespace
+	pacSecret := v1.Secret{}
+	err = csu.k8sClient.Get(ctx, types.NamespacedName{Namespace: csu.snapshot.Namespace, Name: repoSecret.Name}, &pacSecret)
+	if err != nil {
+		return "", err
+	}
+
+	// Get the personal access token from the secret
+	token, found := pacSecret.Data[repoSecret.Key]
+	if !found {
+		return "", fmt.Errorf("failed to find %s secret key", repoSecret.Key)
+	}
+
+	return string(token), nil
+}
+
+func (csu *CommitStatusUpdater) getAllCommitStatuses(ctx context.Context) ([]*ghapi.RepoStatus, error) {
+	if len(csu.allCommitStatusesCache) == 0 {
+		allCommitStatuses, err := csu.ghClient.GetAllCommitStatusesForRef(ctx, csu.owner, csu.repo, csu.sha)
+		if err != nil {
+			csu.logger.Error(err, "failed to get all commitStatuses for snapshot",
+				"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name)
+			return nil, err
+		}
+		csu.allCommitStatusesCache = allCommitStatuses
+	}
+	return csu.allCommitStatusesCache, nil
+}
+
+// Authenticate Github Client with token secret ref defined in snapshot
+func (csu *CommitStatusUpdater) Authenticate(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) error {
+	token, err := csu.getToken(ctx)
+	if err != nil {
+		csu.logger.Error(err, "failed to get token from snapshot",
+			"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return err
+	}
+
+	csu.ghClient.SetOAuthToken(ctx, token)
+	return nil
+}
+
+// createCommitStatusAdapterForSnapshot create a commitStatusAdapter used to create commitStatus on GitHub
+// https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
+func (csu *CommitStatusUpdater) createCommitStatusAdapterForSnapshot(integrationTestStatusDetail intgteststat.IntegrationTestStatusDetail) (*github.CommitStatusAdapter, error) {
+	snapshot := csu.snapshot
+	scenarioName := integrationTestStatusDetail.ScenarioName
+	statusContext := NamePrefix + " / " + snapshot.Name + " / " + scenarioName
+
+	state, err := generateCommitState(integrationTestStatusDetail.Status)
+	if err != nil {
+		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
+	}
+
+	description, err := generateSummary(integrationTestStatusDetail.Status, snapshot.Name, scenarioName)
+	if err != nil {
+		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
+	}
+
+	return &github.CommitStatusAdapter{
+		Owner:       csu.owner,
+		Repository:  csu.repo,
+		SHA:         csu.sha,
+		State:       state,
+		Description: description,
+		Context:     statusContext,
+	}, nil
+}
+
+// updateStatusInComment will create/update a comment in PR which creates snapshot
+func (csu *CommitStatusUpdater) updateStatusInComment(ctx context.Context, integrationTestStatusDetail intgteststat.IntegrationTestStatusDetail) error {
+	issueNumberStr, found := csu.snapshot.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
+	if !found {
+		return fmt.Errorf("pull-request annotation not found %q", gitops.PipelineAsCodePullRequestAnnotation)
+	}
+
+	issueNumber, err := strconv.Atoi(issueNumberStr)
+	if err != nil {
+		return err
+	}
+
+	state := integrationTestStatusDetail.Status
+	title, err := generateSummary(state, csu.snapshot.Name, integrationTestStatusDetail.ScenarioName)
+	if err != nil {
+		return fmt.Errorf(
+			"unknown status %s for integrationTestScenario %s and snapshot %s/%s",
+			integrationTestStatusDetail.Status, integrationTestStatusDetail.ScenarioName, csu.snapshot.Namespace, csu.snapshot.Name)
+	}
+
+	var comment string
+	if state == intgteststat.IntegrationTestStatusTestPassed || state == intgteststat.IntegrationTestStatusTestFail {
+		pipelineRunName := integrationTestStatusDetail.TestPipelineRunName
+		pipelineRun := &tektonv1.PipelineRun{}
+		err := csu.k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: csu.snapshot.Namespace,
+			Name:      pipelineRunName,
+		}, pipelineRun)
+		if err != nil {
+			return fmt.Errorf("error while getting the pipelineRun %s: %w", pipelineRunName, err)
+		}
+
+		taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(csu.k8sClient, ctx, pipelineRun)
+		if err != nil {
+			return fmt.Errorf("error while getting all child taskRuns from pipelineRun %s: %w", pipelineRunName, err)
+		}
+		comment, err = FormatCommentForFinishedPipelineRun(title, taskRuns)
+		if err != nil {
+			return fmt.Errorf("error while formating all child taskRuns from pipelineRun %s: %w", pipelineRun.Name, err)
+		}
+	} else {
+		comment, err = FormatCommentForDetail(title, integrationTestStatusDetail.Details)
+		if err != nil {
+			return err
+		}
+	}
+
+	allComments, err := csu.ghClient.GetAllCommentsForPR(ctx, csu.owner, csu.repo, issueNumber)
+	if err != nil {
+		return fmt.Errorf("error while getting all comments for pull-request %s: %w", issueNumberStr, err)
+	}
+	existingCommentId := csu.ghClient.GetExistingCommentID(allComments, csu.snapshot.Name, integrationTestStatusDetail.ScenarioName)
+	if existingCommentId == nil {
+		_, err = csu.ghClient.CreateComment(ctx, csu.owner, csu.repo, issueNumber, comment)
+		if err != nil {
+			return fmt.Errorf("error while creating comment for pull-request %s: %w", issueNumberStr, err)
+		}
+	} else {
+		_, err = csu.ghClient.EditComment(ctx, csu.owner, csu.repo, *existingCommentId, comment)
+		if err != nil {
+			return fmt.Errorf("error while updating comment for pull-request %s: %w", issueNumberStr, err)
+		}
+	}
+
+	return nil
+}
+
+// UpdateStatus updates commit status in PR
+func (csu *CommitStatusUpdater) UpdateStatus(ctx context.Context, integrationTestStatusDetail intgteststat.IntegrationTestStatusDetail) error {
+
+	allCommitStatuses, err := csu.getAllCommitStatuses(ctx)
+	if err != nil {
+		return err
+	}
+
+	commitStatus, err := csu.createCommitStatusAdapterForSnapshot(integrationTestStatusDetail)
+	if err != nil {
+		csu.logger.Error(err, "failed to create CommitStatusAdapter for scenario, skipping update",
+			"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name,
+			"scenario.Name", integrationTestStatusDetail.ScenarioName,
+		)
+		return nil
+	}
+
+	commitStatusExist, err := csu.ghClient.CommitStatusExists(allCommitStatuses, commitStatus)
+	if err != nil {
+		return err
+	}
+
+	if !commitStatusExist {
+		csu.logger.Info("creating commit status for scenario test status of snapshot",
+			"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName)
+		_, err = csu.ghClient.CreateCommitStatus(ctx, commitStatus.Owner, commitStatus.Repository, commitStatus.SHA, commitStatus.State, commitStatus.Description, commitStatus.Context)
+		if err != nil {
+			return err
+		}
+		// Create a comment when integration test is neither pending nor inprogress since comment for pending/inprogress is less meaningful and there is commitStatus for all statuses
+		if integrationTestStatusDetail.Status != intgteststat.IntegrationTestStatusPending && integrationTestStatusDetail.Status != intgteststat.IntegrationTestStatusInProgress {
+			err = csu.updateStatusInComment(ctx, integrationTestStatusDetail)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		csu.logger.Info("found existing commitStatus for scenario test status of snapshot, no need to create new commit status",
+			"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName)
+	}
+
+	return nil
+}
 
 // GitHubReporter reports status back to GitHub for a Snapshot.
 type GitHubReporter struct {
@@ -72,87 +529,6 @@ type appCredentials struct {
 	AppID          int64
 	InstallationID int64
 	PrivateKey     []byte
-}
-
-func (r *GitHubReporter) getAppCredentials(ctx context.Context, object client.Object) (*appCredentials, error) {
-	var err error
-	var found bool
-	appInfo := appCredentials{}
-
-	appInfo.InstallationID, err = strconv.ParseInt(object.GetAnnotations()[gitops.PipelineAsCodeInstallationIDAnnotation], 10, 64)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get the global pipelines as code secret
-	pacSecret := v1.Secret{}
-	err = r.k8sClient.Get(ctx, types.NamespacedName{Namespace: "openshift-pipelines", Name: "pipelines-as-code-secret"}, &pacSecret)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get the App ID from the secret
-	ghAppIDBytes, found := pacSecret.Data["github-application-id"]
-	if !found {
-		return nil, errors.New("failed to find github-application-id secret key")
-	}
-
-	appInfo.AppID, err = strconv.ParseInt(string(ghAppIDBytes), 10, 64)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get the App's private key from the secret
-	appInfo.PrivateKey, found = pacSecret.Data["github-private-key"]
-	if !found {
-		return nil, errors.New("failed to find github-private-key secret key")
-	}
-
-	return &appInfo, nil
-}
-
-func (r *GitHubReporter) getToken(ctx context.Context, object client.Object, namespace string) (string, error) {
-	var err error
-
-	// List all the Repository CRs in the namespace
-	repos := pacv1alpha1.RepositoryList{}
-	if err = r.k8sClient.List(ctx, &repos, &client.ListOptions{Namespace: namespace}); err != nil {
-		return "", err
-	}
-
-	// Get the full repo URL
-	url, found := object.GetAnnotations()[gitops.PipelineAsCodeRepoURLAnnotation]
-	if !found {
-		return "", fmt.Errorf("object annotation not found %q", gitops.PipelineAsCodeRepoURLAnnotation)
-	}
-
-	// Find a Repository CR with a matching URL and get its secret details
-	var repoSecret *pacv1alpha1.Secret
-	for _, repo := range repos.Items {
-		if url == repo.Spec.URL {
-			repoSecret = repo.Spec.GitProvider.Secret
-			break
-		}
-	}
-
-	if repoSecret == nil {
-		return "", fmt.Errorf("failed to find a Repository matching URL: %q", url)
-	}
-
-	// Get the pipelines as code secret from the PipelineRun's namespace
-	pacSecret := v1.Secret{}
-	err = r.k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: repoSecret.Name}, &pacSecret)
-	if err != nil {
-		return "", err
-	}
-
-	// Get the personal access token from the secret
-	token, found := pacSecret.Data[repoSecret.Key]
-	if !found {
-		return "", fmt.Errorf("failed to find %s secret key", repoSecret.Key)
-	}
-
-	return string(token), nil
 }
 
 // generateSummary generate a summary used in checkRun and commitStatus
@@ -283,151 +659,11 @@ func generateCommitState(state intgteststat.IntegrationTestStatus) (string, erro
 	return commitState, nil
 }
 
-// createCheckRunAdapterForSnapshot create a CheckRunAdapter for given snapshot, integrationTestStatusDetail, owner, repo and sha to create a checkRun
-// https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run
-func (r *GitHubReporter) createCheckRunAdapterForSnapshot(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, integrationTestStatusDetail intgteststat.IntegrationTestStatusDetail, owner, repo, sha string) (*github.CheckRunAdapter, error) {
-	var text string
-	snapshotName := snapshot.Name
-	scenarioName := integrationTestStatusDetail.ScenarioName
-
-	conclusion, err := generateCheckRunConclusion(integrationTestStatusDetail.Status)
-	if err != nil {
-		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
-	}
-
-	title, err := generateCheckRunTitle(integrationTestStatusDetail.Status)
-	if err != nil {
-		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
-	}
-
-	summary, err := generateSummary(integrationTestStatusDetail.Status, snapshotName, scenarioName)
-	if err != nil {
-		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
-	}
-
-	text, err = generateCheckRunText(r.k8sClient, ctx, integrationTestStatusDetail, snapshot.Namespace)
-	if err != nil {
-		return nil, fmt.Errorf("experienced error when generating text for checkRun: %w", err)
-	}
-
-	cra := &github.CheckRunAdapter{
-		Owner:      owner,
-		Repository: repo,
-		Name:       NamePrefix + " / " + snapshotName + " / " + scenarioName,
-		SHA:        sha,
-		ExternalID: scenarioName,
-		Conclusion: conclusion,
-		Title:      title,
-		Summary:    summary,
-		Text:       text,
-	}
-
-	if start := integrationTestStatusDetail.StartTime; start != nil {
-		cra.StartTime = *start
-	}
-
-	if complete := integrationTestStatusDetail.CompletionTime; complete != nil {
-		cra.CompletionTime = *complete
-	}
-
-	return cra, nil
-}
-
-// createCommitStatusAdapterForSnapshot create a commitStatusAdapter used to create commitStatus on GitHub
-// https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
-func (r *GitHubReporter) createCommitStatusAdapterForSnapshot(snapshot *applicationapiv1alpha1.Snapshot, integrationTestStatusDetail intgteststat.IntegrationTestStatusDetail, owner, repo, sha string) (*github.CommitStatusAdapter, error) {
-	snapshotName := snapshot.Name
-	scenarioName := integrationTestStatusDetail.ScenarioName
-	statusContext := NamePrefix + " / " + snapshot.Name + " / " + scenarioName
-
-	state, err := generateCommitState(integrationTestStatusDetail.Status)
-	if err != nil {
-		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
-	}
-
-	description, err := generateSummary(integrationTestStatusDetail.Status, snapshotName, scenarioName)
-	if err != nil {
-		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, scenarioName, snapshot.Namespace, snapshot.Name)
-	}
-
-	return &github.CommitStatusAdapter{
-		Owner:       owner,
-		Repository:  repo,
-		SHA:         sha,
-		State:       state,
-		Description: description,
-		Context:     statusContext,
-	}, nil
-}
-
-// UpdateStatusInComment will create/update a comment in PR which creates snapshot
-func (r *GitHubReporter) UpdateStatusInComment(k8sClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, integrationTestStatusDetail intgteststat.IntegrationTestStatusDetail, repo, owner string) error {
-	issueNumberStr, found := snapshot.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
-	if !found {
-		return fmt.Errorf("pull-request annotation not found %q", gitops.PipelineAsCodePullRequestAnnotation)
-	}
-
-	issueNumber, err := strconv.Atoi(issueNumberStr)
-	if err != nil {
-		return err
-	}
-
-	state := integrationTestStatusDetail.Status
-	title, err := generateSummary(state, snapshot.Name, integrationTestStatusDetail.ScenarioName)
-	if err != nil {
-		return fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", integrationTestStatusDetail.Status, integrationTestStatusDetail.ScenarioName, snapshot.Namespace, snapshot.Name)
-	}
-
-	var comment string
-	if state == intgteststat.IntegrationTestStatusTestPassed || state == intgteststat.IntegrationTestStatusTestFail {
-		pipelineRunName := integrationTestStatusDetail.TestPipelineRunName
-		pipelineRun := &tektonv1.PipelineRun{}
-		err := r.k8sClient.Get(ctx, types.NamespacedName{
-			Namespace: snapshot.Namespace,
-			Name:      pipelineRunName,
-		}, pipelineRun)
-		if err != nil {
-			return fmt.Errorf("error while getting the pipelineRun %s: %w", pipelineRunName, err)
-		}
-
-		taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(r.k8sClient, ctx, pipelineRun)
-		if err != nil {
-			return fmt.Errorf("error while getting all child taskRuns from pipelineRun %s: %w", pipelineRunName, err)
-		}
-		comment, err = FormatCommentForFinishedPipelineRun(title, taskRuns)
-		if err != nil {
-			return fmt.Errorf("error while formating all child taskRuns from pipelineRun %s: %w", pipelineRun.Name, err)
-		}
-	} else {
-		comment, err = FormatCommentForDetail(title, integrationTestStatusDetail.Details)
-		if err != nil {
-			return err
-		}
-	}
-
-	allComments, err := r.client.GetAllCommentsForPR(ctx, owner, repo, issueNumber)
-	if err != nil {
-		return fmt.Errorf("error while getting all comments for pull-request %s: %w", issueNumberStr, err)
-	}
-	existingCommentId := r.client.GetExistingCommentID(allComments, snapshot.Name, integrationTestStatusDetail.ScenarioName)
-	if existingCommentId == nil {
-		_, err = r.client.CreateComment(ctx, owner, repo, issueNumber, comment)
-		if err != nil {
-			return fmt.Errorf("error while creating comment for pull-request %s: %w", issueNumberStr, err)
-		}
-	} else {
-		_, err = r.client.EditComment(ctx, owner, repo, *existingCommentId, comment)
-		if err != nil {
-			return fmt.Errorf("error while updating comment for pull-request %s: %w", issueNumberStr, err)
-		}
-	}
-
-	return nil
-}
-
 // ReportStatusForSnapshot creates CheckRun when using GitHub App integration.
 // When using GitHub webhook integration it creates a commit status and a comment.
 func (r *GitHubReporter) ReportStatusForSnapshot(k8sClient client.Client, ctx context.Context, logger *helpers.IntegrationLogger, snapshot *applicationapiv1alpha1.Snapshot) error {
+	var updater StatusUpdater
+
 	statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(snapshot)
 	if err != nil {
 		logger.Error(err, "failed to get test status annotations from snapshot",
@@ -455,121 +691,18 @@ func (r *GitHubReporter) ReportStatusForSnapshot(k8sClient client.Client, ctx co
 	// Existence of the Pipelines as Code installation ID annotation signals configuration using GitHub App integration.
 	// If it doesn't exist, GitHub webhook integration is configured.
 	if metadata.HasAnnotation(snapshot, gitops.PipelineAsCodeInstallationIDAnnotation) {
-		creds, err := r.getAppCredentials(ctx, snapshot)
-		if err != nil {
-			logger.Error(err, "failed to get app credentials from Snapshot",
-				"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
-			return err
-		}
-
-		token, err := r.client.CreateAppInstallationToken(ctx, creds.AppID, creds.InstallationID, creds.PrivateKey)
-		if err != nil {
-			logger.Error(err, "failed to create app installation token",
-				"creds.AppID", creds.AppID, "creds.InstallationID", creds.InstallationID)
-			return err
-		}
-
-		r.client.SetOAuthToken(ctx, token)
-
-		allCheckRuns, err := r.client.GetAllCheckRunsForRef(ctx, owner, repo, sha, creds.AppID)
-		if err != nil {
-			logger.Error(err, "failed to get all checkruns for ref",
-				"owner", owner, "repo", repo, "creds.AppID", creds.AppID)
-			return err
-		}
-
-		for _, integrationTestStatusDetail := range integrationTestStatusDetails {
-			integrationTestStatusDetail := *integrationTestStatusDetail // G601
-			checkRun, err := r.createCheckRunAdapterForSnapshot(ctx, snapshot, integrationTestStatusDetail, owner, repo, sha)
-			if err != nil {
-				logger.Error(err, "failed to create checkRunAdapter for scenario, skipping update",
-					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name,
-					"scenario.Name", integrationTestStatusDetail.ScenarioName,
-				)
-				continue
-			}
-
-			existingCheckrun := r.client.GetExistingCheckRun(allCheckRuns, checkRun)
-
-			if existingCheckrun == nil {
-				logger.Info("creating checkrun for scenario test status of snapshot",
-					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName)
-				_, err = r.client.CreateCheckRun(ctx, checkRun)
-				if err != nil {
-					logger.Error(err, "failed to create checkrun",
-						"checkRun", checkRun)
-					return err
-				}
-			} else {
-				logger.Info("found existing checkrun", "existingCheckRun", existingCheckrun)
-				if r.client.IsUpdateNeeded(existingCheckrun, checkRun) {
-					logger.Info("found existing check run with the same ExternalID but different conclusion/status, updating checkrun for scenario test status of snapshot",
-						"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName, "checkrun.ExternalID", checkRun.ExternalID)
-					err = r.client.UpdateCheckRun(ctx, *existingCheckrun.ID, checkRun)
-					if err != nil {
-						logger.Error(err, "failed to update checkrun",
-							"checkRun", checkRun)
-						return err
-					}
-				} else {
-					logger.Info("found existing check run with the same ExternalID and conclusion/status, no need to update checkrun for scenario test status of snapshot",
-						"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName, "checkrun.ExternalID", checkRun.ExternalID)
-				}
-			}
-		}
+		updater = NewCheckRunStatusUpdater(r.client, k8sClient, logger, owner, repo, sha, snapshot)
 	} else {
-		token, err := r.getToken(ctx, snapshot, snapshot.Namespace)
-		if err != nil {
-			logger.Error(err, "failed to get token from snapshot",
-				"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
-			return err
-		}
+		updater = NewCommitStatusUpdater(r.client, k8sClient, logger, owner, repo, sha, snapshot)
+	}
 
-		r.client.SetOAuthToken(ctx, token)
+	if err := updater.Authenticate(ctx, snapshot); err != nil {
+		return fmt.Errorf("authentication failed: %w", err)
+	}
 
-		allCommitStatuses, err := r.client.GetAllCommitStatusesForRef(ctx, owner, repo, sha)
-		if err != nil {
-			logger.Error(err, "failed to get all commitStatuses for snapshot",
-				"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
-			return err
-		}
-
-		for _, integrationTestStatusDetail := range integrationTestStatusDetails {
-			integrationTestStatusDetail := *integrationTestStatusDetail //G601
-
-			commitStatus, err := r.createCommitStatusAdapterForSnapshot(snapshot, integrationTestStatusDetail, owner, repo, sha)
-			if err != nil {
-				logger.Error(err, "failed to create CommitStatusAdapter for scenario, skipping update",
-					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name,
-					"scenario.Name", integrationTestStatusDetail.ScenarioName,
-				)
-				continue
-			}
-
-			commitStatusExist, err := r.client.CommitStatusExists(allCommitStatuses, commitStatus)
-			if err != nil {
-				return err
-			}
-
-			if !commitStatusExist {
-				logger.Info("creating commit status for scenario test status of snapshot",
-					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName)
-				_, err = r.client.CreateCommitStatus(ctx, commitStatus.Owner, commitStatus.Repository, commitStatus.SHA, commitStatus.State, commitStatus.Description, commitStatus.Context)
-				if err != nil {
-					return err
-				}
-				// Create a comment when integration test is neither pending nor inprogress since comment for pending/inprogress is less meaningful and there is commitStatus for all statuses
-				if integrationTestStatusDetail.Status != intgteststat.IntegrationTestStatusPending && integrationTestStatusDetail.Status != intgteststat.IntegrationTestStatusInProgress {
-					err = r.UpdateStatusInComment(k8sClient, ctx, snapshot, integrationTestStatusDetail, repo, owner)
-					if err != nil {
-						return err
-					}
-				}
-			} else {
-				logger.Info("found existing commitStatus for scenario test status of snapshot, no need to create new commit status",
-					"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name, "scenarioName", integrationTestStatusDetail.ScenarioName)
-			}
-
+	for _, integrationTestStatusDetail := range integrationTestStatusDetails {
+		if err := updater.UpdateStatus(ctx, *integrationTestStatusDetail); err != nil {
+			return fmt.Errorf("failed to update status: %w", err)
 		}
 	}
 


### PR DESCRIPTION
CheckRun and CommitReporters can be separated into different structs with implementing common interface, to make easier to understand relations and avoid duplicated code.

It makes readability better.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
