### PR TITLE
fix(STONEINTG-695): set integration_svc as prefix for all metrics

### DIFF
--- a/config/grafana/dashboards/integration-service-dashboard.json
+++ b/config/grafana/dashboards/integration-service-dashboard.json
@@ -280,7 +280,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.90, sum(rate(snapshot_created_to_pipelinerun_with_static_env_started_seconds_bucket[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds_bucket[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": "percentile90",
           "refId": "A"
@@ -419,7 +419,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(snapshot_created_to_pipelinerun_with_static_env_started_seconds_bucket{le=\"5\"}[$__rate_interval])) by (job)\n/\nsum(rate(snapshot_created_to_pipelinerun_with_static_env_started_seconds_count[$__rate_interval]) > 0) by (job)\n*100",
+          "expr": "sum(rate(integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds_bucket{le=\"5\"}[$__rate_interval])) by (job)\n/\nsum(rate(integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds_count[$__rate_interval]) > 0) by (job)\n*100",
           "interval": "",
           "legendFormat": "% of requests within required latency time",
           "refId": "A",
@@ -676,7 +676,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.90, sum(rate(seb_created_to_ready_seconds_bucket[$__interval])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(integration_svc_seb_created_to_ready_seconds_bucket[$__interval])) by (le))",
           "interval": "",
           "legendFormat": "percentile90",
           "range": true,
@@ -812,7 +812,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(seb_created_to_ready_seconds_bucket{le=\"120\"}[$__rate_interval])) by (job) / sum(rate(seb_created_to_ready_seconds_count[$__rate_interval]) > 0) by (job) *100",
+          "expr": "sum(rate(integration_svc_seb_created_to_ready_seconds_bucket{le=\"120\"}[$__rate_interval])) by (job) / sum(rate(integration_svc_seb_created_to_ready_seconds_count[$__rate_interval]) > 0) by (job) *100",
           "interval": "",
           "legendFormat": "% of requests within required latency time",
           "range": true,
@@ -906,7 +906,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "integration_pipelinerun_total",
+          "expr": "integration_svc_integration_pipelinerun_total",
           "interval": "",
           "legendFormat": "{{ pod }}",
           "refId": "A"
@@ -962,7 +962,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "snapshot_attempt_total",
+          "expr": "integration_svc_snapshot_attempt_total",
           "interval": "",
           "legendFormat": "{{ reason }}",
           "refId": "A"
@@ -1058,7 +1058,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "snapshot_attempt_invalid_total",
+          "expr": "integration_svc_snapshot_attempt_invalid_total",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1222,7 +1222,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "snapshot_attempt_concurrent_requests",
+          "expr": "integration_svc_snapshot_attempt_concurrent_requests",
           "instant": false,
           "interval": "",
           "legendFormat": "{{ pod }}",
@@ -1307,7 +1307,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(snapshot_created_to_pipelinerun_with_static_env_started_seconds_bucket[$__interval])) by (le)",
+          "expr": "sum(increase(integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds_bucket[$__interval])) by (le)",
           "format": "heatmap",
           "interval": "",
           "legendFormat": "{{le}}",
@@ -1389,7 +1389,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds_bucket[$__interval])) by (le)",
+          "expr": "sum(increase(integration_svc_snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds_bucket[$__interval])) by (le)",
           "format": "heatmap",
           "interval": "",
           "legendFormat": "{{le}}",
@@ -1500,7 +1500,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(snapshot_attempt_duration_seconds_bucket[$__interval])) by (le)",
+          "expr": "sum(increase(integration_svc_snapshot_attempt_duration_seconds_bucket[$__interval])) by (le)",
           "format": "heatmap",
           "interval": "",
           "legendFormat": "{{le}}",
@@ -1806,7 +1806,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(seb_created_to_ready_seconds_bucket[$__interval])) by (le)",
+          "expr": "sum(increase(integration_svc_seb_created_to_ready_seconds_bucket[$__interval])) by (le)",
           "format": "heatmap",
           "interval": "",
           "legendFormat": "{{le}}",
@@ -2036,7 +2036,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "seb_ephemeral_deployments_total",
+          "expr": "integration_svc_seb_ephemeral_deployments_total",
           "interval": "",
           "legendFormat": "{{ reason }}",
           "refId": "A",

--- a/metrics/integration.go
+++ b/metrics/integration.go
@@ -35,7 +35,7 @@ var (
 
 	SnapshotCreatedToPipelineRunStartedStaticEnvSeconds = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "snapshot_created_to_pipelinerun_with_static_env_started_seconds",
+			Name:    "integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds",
 			Help:    "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started in a static environment",
 			Buckets: []float64{0.05, 0.1, 0.5, 1, 2, 3, 4, 5, 10, 15, 30},
 		},
@@ -43,7 +43,7 @@ var (
 
 	SnapshotCreatedToPipelineRunWithEphemeralEnvStartedSeconds = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds",
+			Name:    "integration_svc_snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds",
 			Help:    "The duration measures the time elapsed between the creation of a snapshot resource and the initiation of an integration PipelineRun for pipelines operating within an ephemeral environment.",
 			Buckets: []float64{0.05, 0.1, 0.5, 1, 2, 3, 4, 5, 10, 15, 30},
 		},
@@ -54,35 +54,35 @@ var (
 	)
 
 	sebCreatedToReadySecondsOpts = prometheus.HistogramOpts{
-		Name:    "seb_created_to_ready_seconds",
-		Help:    "Time duration from the moment the snapshotEnvironmentBinding was created till the snapshot is deployed to the environtment",
+		Name:    "integration_svc_seb_created_to_ready_seconds",
+		Help:    "Time duration from the moment the snapshotEnvironmentBinding was created till the snapshot is deployed to the environment",
 		Buckets: []float64{1, 5, 10, 20, 40, 60, 80, 120, 160, 200, 300},
 	}
 
 	SEBEphemeralDeploymentsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "seb_ephemeral_deployments_total",
+			Name: "integration_svc_seb_ephemeral_deployments_total",
 			Help: "Total number of SEB deployments processed by the operator",
 		}, []string{"reason"},
 	)
 
 	IntegrationPipelineRunTotal = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "integration_pipelinerun_total",
+			Name: "integration_svc_integration_pipelinerun_total",
 			Help: "Total number of integration PipelineRun created",
 		},
 	)
 
 	SnapshotConcurrentTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "snapshot_attempt_concurrent_requests",
+			Name: "integration_svc_snapshot_attempt_concurrent_requests",
 			Help: "Total number of concurrent snapshot attempts",
 		},
 	)
 
 	SnapshotDurationSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "snapshot_attempt_duration_seconds",
+			Name:    "integration_svc_snapshot_attempt_duration_seconds",
 			Help:    "Snapshot durations from the moment the Snapshot was created till the Snapshot is marked as finished",
 			Buckets: []float64{7, 15, 30, 60, 150, 300, 450, 600, 750, 900, 1050},
 		},
@@ -91,7 +91,7 @@ var (
 
 	SnapshotInvalidTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "snapshot_attempt_invalid_total",
+			Name: "integration_svc_snapshot_attempt_invalid_total",
 			Help: "Number of invalid snapshots",
 		},
 		[]string{"reason"},
@@ -99,7 +99,7 @@ var (
 
 	SnapshotTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "snapshot_attempt_total",
+			Name: "integration_svc_snapshot_attempt_total",
 			Help: "Total number of snapshots processed by the operator",
 		},
 		[]string{"type", "reason"},

--- a/metrics/integration_test.go
+++ b/metrics/integration_test.go
@@ -40,19 +40,19 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 
 	var (
 		SnapshotPipelineRunStartedStaticEnvSecondsHeader = inputHeader{
-			Name: "snapshot_created_to_pipelinerun_with_static_env_started_seconds",
+			Name: "integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds",
 			Help: "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started in a static environment",
 		}
 		SnapshotPipelineRunWithEphemeralEnvStartedSecondsHeader = inputHeader{
-			Name: "snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds",
+			Name: "integration_svc_snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds",
 			Help: "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started for pipelines running in an ephemeral environment",
 		}
 		SnapshotDurationSecondsHeader = inputHeader{
-			Name: "snapshot_attempt_duration_seconds",
+			Name: "integration_svc_snapshot_attempt_duration_seconds",
 			Help: "Snapshot durations from the moment the Snapshot was created till the Snapshot is marked as finished",
 		}
 		SnapshotTotalHeader = inputHeader{
-			Name: "snapshot_attempt_total",
+			Name: "integration_svc_snapshot_attempt_total",
 			Help: "Total number of snapshots processed by the operator",
 		}
 	)
@@ -65,14 +65,14 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 			// 'Help' can't be overridden due to 'https://github.com/prometheus/client_golang/blob/83d56b1144a0c2eb10d399e7abbae3333bebc463/prometheus/registry.go#L314'
 			SnapshotCreatedToPipelineRunStartedStaticEnvSeconds = prometheus.NewHistogram(
 				prometheus.HistogramOpts{
-					Name:    "snapshot_created_to_pipelinerun_with_static_env_started_seconds",
+					Name:    "integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds",
 					Help:    "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started in a static environment",
 					Buckets: []float64{1, 5, 10, 30},
 				},
 			)
 			SnapshotConcurrentTotal = prometheus.NewGauge(
 				prometheus.GaugeOpts{
-					Name: "snapshot_attempt_concurrent_requests",
+					Name: "integration_svc_snapshot_attempt_concurrent_requests",
 					Help: "Total number of concurrent snapshot attempts",
 				},
 			)
@@ -87,7 +87,7 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 		inputSeconds := []float64{1, 3, 8, 15}
 		elapsedSeconds := 0.0
 
-		It("increments the 'snapshot_attempt_concurrent_requests'.", func() {
+		It("increments the 'integration_svc_snapshot_attempt_concurrent_requests'.", func() {
 			creationTime := metav1.Time{}
 			for _, seconds := range inputSeconds {
 				RegisterNewSnapshot()
@@ -97,7 +97,7 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 			}
 			Expect(testutil.ToFloat64(SnapshotConcurrentTotal)).To(Equal(float64(len(inputSeconds))))
 		})
-		It("registers a new observation for 'snapshot_created_to_pipelinerun_with_static_env_started_seconds' with the elapsed time from the moment"+
+		It("registers a new observation for 'integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds' with the elapsed time from the moment"+
 			"the snapshot is created to first integration pipelineRun is started.", func() {
 			// Defined buckets for SnapshotCreatedToPipelineRunStartedSeconds
 			timeBuckets := []string{"1", "5", "10", "30"}
@@ -115,7 +115,7 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 			// 'Help' can't be overridden due to 'https://github.com/prometheus/client_golang/blob/83d56b1144a0c2eb10d399e7abbae3333bebc463/prometheus/registry.go#L314'
 			SnapshotCreatedToPipelineRunWithEphemeralEnvStartedSeconds = prometheus.NewHistogram(
 				prometheus.HistogramOpts{
-					Name:    "snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds",
+					Name:    "integration_svc_snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds",
 					Help:    "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started for pipelines running in an ephemeral environment",
 					Buckets: []float64{1, 5, 10, 30},
 				},
@@ -130,7 +130,7 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 		inputSeconds := []float64{1, 3, 8, 15}
 		elapsedSeconds := 0.0
 
-		It("registers a new observation for 'snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds' with the elapsed time from the moment"+
+		It("registers a new observation for 'integration_svc_snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds' with the elapsed time from the moment"+
 			"the snapshot is created to first integration pipelineRun is started.", func() {
 			creationTime := metav1.Time{}
 			for _, seconds := range inputSeconds {
@@ -150,14 +150,14 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 		BeforeAll(func() {
 			SnapshotCreatedToPipelineRunStartedStaticEnvSeconds = prometheus.NewHistogram(
 				prometheus.HistogramOpts{
-					Name:    "snapshot_created_to_pipelinerun_with_static_env_started_seconds",
+					Name:    "integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds",
 					Help:    "Snapshot durations from the moment the snapshot resource was created till a integration pipelineRun is started in static environment",
 					Buckets: []float64{1, 5, 10, 30},
 				},
 			)
 			SnapshotDurationSeconds = prometheus.NewHistogramVec(
 				prometheus.HistogramOpts{
-					Name:    "snapshot_attempt_duration_seconds",
+					Name:    "integration_svc_snapshot_attempt_duration_seconds",
 					Help:    "Snapshot durations from the moment the Snapshot was created till the Snapshot is marked as finished",
 					Buckets: []float64{60, 600, 1800, 3600},
 				},
@@ -166,13 +166,13 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 
 			SnapshotConcurrentTotal = prometheus.NewGauge(
 				prometheus.GaugeOpts{
-					Name: "snapshot_attempt_concurrent_requests",
+					Name: "integration_svc_snapshot_attempt_concurrent_requests",
 					Help: "Total number of concurrent snapshot attempts",
 				},
 			)
 			SnapshotTotal = prometheus.NewCounterVec(
 				prometheus.CounterOpts{
-					Name: "snapshot_attempt_total",
+					Name: "integration_svc_snapshot_attempt_total",
 					Help: "Total number of snapshots processed by the operator",
 				},
 				[]string{"type", "reason"},


### PR DESCRIPTION
* Update all metrics to have the integration_svc as prefix
* This conforms with the prometheus guidelines to have an application prefix relevant to the domain the metric belongs to

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
