### PR TITLE
feat(api): add shortname for ITS

### DIFF
--- a/api/v1beta1/integrationtestscenario_types.go
+++ b/api/v1beta1/integrationtestscenario_types.go
@@ -64,6 +64,7 @@ type TestContext struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=its
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Application",type=string,JSONPath=`.spec.application`
 // +kubebuilder:storageversion

--- a/config/crd/bases/appstudio.redhat.com_integrationtestscenarios.yaml
+++ b/config/crd/bases/appstudio.redhat.com_integrationtestscenarios.yaml
@@ -12,6 +12,8 @@ spec:
     kind: IntegrationTestScenario
     listKind: IntegrationTestScenarioList
     plural: integrationtestscenarios
+    shortNames:
+    - its
     singular: integrationtestscenario
   scope: Namespaced
   versions:


### PR DESCRIPTION
Instead of typying full name IntegrationTestScenario, we can just use `its`.

```
oc get its
NAME           APPLICATION
example-pass   application-sample
```

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
