### PR TITLE
Revert "fix(rhtapbugs-975): point test plr params to source repo"

### DIFF
--- a/controllers/buildpipeline/buildpipeline_adapter_test.go
+++ b/controllers/buildpipeline/buildpipeline_adapter_test.go
@@ -19,9 +19,8 @@ package buildpipeline
 import (
 	"bytes"
 	"reflect"
-	"time"
-
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"time"
 
 	"github.com/redhat-appstudio/integration-service/gitops"
 	"github.com/redhat-appstudio/integration-service/helpers"
@@ -285,18 +284,6 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 							StringVal: SampleImageWithoutDigest,
 						},
 					},
-					{Name: "git-url",
-						Value: tektonv1.ParamValue{
-							Type:      "string",
-							StringVal: "github.com/upstream-user/devfile-sample-go-basic",
-						},
-					},
-					{Name: "revision",
-						Value: tektonv1.ParamValue{
-							Type:      "string",
-							StringVal: SampleCommit,
-						},
-					},
 				},
 			},
 		}
@@ -417,12 +404,28 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			// We don't need to update the underlying resource on the control plane,
 			// so we create a copy and modify its status. This prevents update conflicts in other tests.
 			buildPipelineRunNoSource := buildPipelineRun.DeepCopy()
-			buildPipelineRunNoSource.Spec.Params = []tektonv1.Param{
-				{
-					Name: "output-image",
-					Value: tektonv1.ParamValue{
-						Type:      tektonv1.ParamTypeString,
-						StringVal: SampleImageWithoutDigest,
+			buildPipelineRunNoSource.Status = tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					ChildReferences: []tektonv1.ChildStatusReference{
+						{
+							Name:             successfulTaskRun.Name,
+							PipelineTaskName: "task1",
+						},
+					},
+					Results: []tektonv1.PipelineRunResult{
+						{
+							Name:  "CHAINS-GIT_URL",
+							Value: *tektonv1.NewStructuredValues(SampleRepoLink),
+						},
+					},
+				},
+				Status: v1.Status{
+					Conditions: v1.Conditions{
+						apis.Condition{
+							Reason: "Completed",
+							Status: "True",
+							Type:   apis.ConditionSucceeded,
+						},
 					},
 				},
 			}

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -158,26 +158,26 @@ func GetOutputImageDigest(object client.Object) (string, error) {
 	return "", fmt.Errorf("couldn't find the IMAGE_DIGEST TaskRun result")
 }
 
-// GetComponentSourceGitUrl returns a string containing the git-url params value from a given PipelineRun.
+// GetComponentSourceGitUrl returns a string containing the CHAINS-GIT_URL result value from a given PipelineRun.
 func GetComponentSourceGitUrl(object client.Object) (string, error) {
 	if pipelineRun, ok := object.(*tektonv1.PipelineRun); ok {
-		for _, param := range pipelineRun.Spec.Params {
-			if param.Name == "git-url" {
-				return param.Value.StringVal, nil
+		for _, pipelineResult := range pipelineRun.Status.Results {
+			if pipelineResult.Name == "CHAINS-GIT_URL" {
+				return pipelineResult.Value.StringVal, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("couldn't find the 'git-url' PipelineRun parameter")
+	return "", fmt.Errorf("couldn't find the CHAINS-GIT_URL PipelineRun result")
 }
 
 // GetComponentSourceGitCommit returns a string containing the CHAINS-GIT_COMMIT result value from a given PipelineRun.
 func GetComponentSourceGitCommit(object client.Object) (string, error) {
 	if pipelineRun, ok := object.(*tektonv1.PipelineRun); ok {
-		for _, param := range pipelineRun.Spec.Params {
-			if param.Name == "revision" {
-				return param.Value.StringVal, nil
+		for _, pipelineResult := range pipelineRun.Status.Results {
+			if pipelineResult.Name == "CHAINS-GIT_COMMIT" {
+				return pipelineResult.Value.StringVal, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("couldn't find the 'revision' PipelineRun parameter")
+	return "", fmt.Errorf("couldn't find the CHAINS-GIT_COMMIT PipelineRun result")
 }

--- a/tekton/utils_test.go
+++ b/tekton/utils_test.go
@@ -43,18 +43,6 @@ var _ = Describe("Utils", func() {
 							StringVal: "test-image",
 						},
 					},
-					{
-						Name: "git-url",
-						Value: tektonv1.ParamValue{
-							StringVal: "https://github.com/upstream-user/devfile-sample-java-springboot-basic",
-						},
-					},
-					{
-						Name: "revision",
-						Value: tektonv1.ParamValue{
-							StringVal: "a2ba645d50e471d5f084b",
-						},
-					},
 				},
 			},
 			Status: tektonv1.PipelineRunStatus{
@@ -100,19 +88,19 @@ var _ = Describe("Utils", func() {
 
 	It("can get git-url", func() {
 		git_url, _ := tekton.GetComponentSourceGitUrl(pipelineRun)
-		if git_url != "https://github.com/upstream-user/devfile-sample-java-springboot-basic" {
-			Fail(fmt.Sprintf("Expected git_url is https://github.com/upstream-user/devfile-sample-java-springboot-basic, but got %s", git_url))
+		if git_url != "https://github.com/devfile-samples/devfile-sample-java-springboot-basic" {
+			Fail(fmt.Sprintf("Expected git_url is https://github.com/devfile-samples/devfile-sample-java-springboot-basic, but got %s", git_url))
 		}
 		klog.Infoln("Got expected git_url")
 	})
 
-	It("can return err when can't find result for git-url", func() {
-		pipelineRun.Spec.Params = []tektonv1.Param{}
+	It("can return err when can't find result for CHAINS-GIT_URL", func() {
+		pipelineRun.Status.PipelineRunStatusFields.Results = []tektonv1.PipelineRunResult{}
 		_, err := tekton.GetComponentSourceGitUrl(pipelineRun)
 		Expect(err).ToNot(BeNil())
 	})
 
-	It("can get git revision", func() {
+	It("can get git-commit", func() {
 		commit, _ := tekton.GetComponentSourceGitCommit(pipelineRun)
 		if commit != "a2ba645d50e471d5f084b" {
 			Fail(fmt.Sprintf("Expected commit is a2ba645d50e471d5f084b, but got %s", commit))
@@ -120,8 +108,8 @@ var _ = Describe("Utils", func() {
 		klog.Infoln("Got expected commit")
 	})
 
-	It("can return err when can't find param revision", func() {
-		pipelineRun.Spec.Params = []tektonv1.Param{}
+	It("can return err when can't find result CHAINS-GIT_COMMIT", func() {
+		pipelineRun.Status.PipelineRunStatusFields.Results = []tektonv1.PipelineRunResult{}
 		_, err := tekton.GetComponentSourceGitCommit(pipelineRun)
 		Expect(err).ToNot(BeNil())
 	})


### PR DESCRIPTION
## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
