### PR TITLE
fix(STONEINTG-692): wait for backup labels in unit tests

### DIFF
--- a/controllers/snapshot/snapshot_controller_test.go
+++ b/controllers/snapshot/snapshot_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package snapshot
 
 import (
+	"github.com/redhat-appstudio/operator-toolkit/metadata"
 	"reflect"
 	"time"
 
@@ -235,6 +236,14 @@ var _ = Describe("SnapshotController", func() {
 		BeforeEach(func() {
 			hasSnapshot.Labels["velero.io/restore-name"] = "something"
 			Expect(k8sClient.Update(ctx, hasSnapshot)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: hasSnapshot.Namespace,
+					Name:      hasSnapshot.Name,
+				}, hasSnapshot)
+				return err == nil && metadata.HasLabel(hasSnapshot, "velero.io/restore-name")
+			}, time.Second*20).Should(BeTrue())
 		})
 
 		It("stops reconciliation without error", func() {


### PR DESCRIPTION
* Add eventually blocks for controller unit tests that check ignoring restored Snapshots

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
