### PR TITLE
fix(STONEINTG-683): update message for status condition SnapshotDeplo…

### DIFF
--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -503,7 +503,7 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExist() (controller.OperationR
 
 	// Mark the Snapshot as already deployed to root environments to prevent re-deploying the Snapshot when it gets
 	// reconciled at a later time
-	a.snapshot, err = gitops.MarkSnapshotAsDeployedToRootEnvironments(a.client, a.context, a.snapshot, "The Snapshot was deployed to all root environments")
+	a.snapshot, err = gitops.MarkSnapshotAsDeployedToRootEnvironments(a.client, a.context, a.snapshot, "The Snapshot was deployed to all available root environments at the time of promotion")
 	if err != nil {
 		a.logger.Error(err, "Failed to update the Snapshot's status to DeployedToRootEnvironments")
 		return controller.RequeueWithError(err)


### PR DESCRIPTION
update message for status condition SnapshotDeployedToRootEnvironments

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
