### PR TITLE
Add profiling to integration service

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,8 +19,9 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"github.com/redhat-appstudio/integration-service/controllers"
 	"os"
+
+	"github.com/redhat-appstudio/integration-service/controllers"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -102,6 +103,7 @@ func main() {
 				},
 			},
 		}),
+		PprofBindAddress: "127.0.0.1:9091",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Enabling profiling in our controller will allow us to start gathering data on how we can improve the performance of the integration service.

See [this blog](https://eng.d2iq.com/blog/profiling-kubernetes-controllers-with-pprof/) to understand how to gather logs from pprof once it is running in the cluster.  I've tested this on quickcluster and I can get the logs, but we'll get a better performance picture from real-world workloads.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
