### PR TITLE
fix(STONEINTG-696): let gitlint ingore prs from red-hat-trusted-app-pipeline

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -14,4 +14,4 @@ line-length=72
 [contrib-title-conventional-commits]
 
 [ignore-by-author-name]
-regex=(.*)dependabot(.*),(.*)rhtap(.*)
+regex=((.*dependabot.*)|(.*rhtap.*)|(red-hat-trusted-app-pipeline))


### PR DESCRIPTION
let gitlint ignore pr from rhtap bot `red-hat-trusted-app-pipeline`, refer to this [pr](https://github.com/redhat-appstudio/integration-service/pull/466) from `red-hat-trusted-app-pipeline`

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
