### PR TITLE
fix(STONEINTG-714): gitops predicates cover all types of events

### DIFF
--- a/gitops/predicates.go
+++ b/gitops/predicates.go
@@ -26,6 +26,15 @@ import (
 // SnapshotEnvironmentBinding whose component deployment status goes from unknown/false to true.
 func DeploymentSucceededForIntegrationBindingPredicate() predicate.Predicate {
 	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return hasDeploymentSucceeded(e.ObjectOld, e.ObjectNew)
 		},
@@ -36,6 +45,15 @@ func DeploymentSucceededForIntegrationBindingPredicate() predicate.Predicate {
 // SnapshotEnvironmentBinding that have resulted in a deployment failure.
 func DeploymentFailedForIntegrationBindingPredicate() predicate.Predicate {
 	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return hasDeploymentFailed(e.ObjectOld, e.ObjectNew)
 		},

--- a/gitops/predicates_test.go
+++ b/gitops/predicates_test.go
@@ -152,6 +152,27 @@ var _ = Describe("Predicates", Ordered, func() {
 			}
 			Expect(instance.Update(contextEvent)).To(BeTrue())
 		})
+
+		It("returns false when the SEB with succeeded deployment is created", func() {
+			contextEvent := event.CreateEvent{
+				Object: bindingTrueStatus,
+			}
+			Expect(instance.Create(contextEvent)).To(BeFalse())
+		})
+
+		It("returns false when the SEB with succeeded deployment is deleted", func() {
+			contextEvent := event.DeleteEvent{
+				Object: bindingTrueStatus,
+			}
+			Expect(instance.Delete(contextEvent)).To(BeFalse())
+		})
+
+		It("returns false when the SEB with succeeded deployment encounters a generic event", func() {
+			contextEvent := event.GenericEvent{
+				Object: bindingTrueStatus,
+			}
+			Expect(instance.Generic(contextEvent)).To(BeFalse())
+		})
 	})
 	Context("when testing DeploymentFailedPredicate predicate", func() {
 		instance := gitops.DeploymentFailedForIntegrationBindingPredicate()
@@ -169,6 +190,27 @@ var _ = Describe("Predicates", Ordered, func() {
 				ObjectNew: bindingDeploymentFailedStatus,
 			}
 			Expect(instance.Update(contextEvent)).To(BeTrue())
+		})
+
+		It("returns false when the SEB with failed deployment is created", func() {
+			contextEvent := event.CreateEvent{
+				Object: bindingDeploymentFailedStatus,
+			}
+			Expect(instance.Create(contextEvent)).To(BeFalse())
+		})
+
+		It("returns false when the SEB with failed deployment is deleted", func() {
+			contextEvent := event.DeleteEvent{
+				Object: bindingDeploymentFailedStatus,
+			}
+			Expect(instance.Delete(contextEvent)).To(BeFalse())
+		})
+
+		It("returns false when the SEB with failed deployment encounters a generic event", func() {
+			contextEvent := event.GenericEvent{
+				Object: bindingDeploymentFailedStatus,
+			}
+			Expect(instance.Generic(contextEvent)).To(BeFalse())
 		})
 	})
 	Context("when testing IntegrationSnapshotEnvironmentBindingPredicate predicate", func() {


### PR DESCRIPTION
* Update all gitops predicates to return false for creation, delete and generic events

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
