### PR TITLE
feat(STONEINTG-725): retry for recoverable error when creating relase

### DIFF
--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -982,9 +982,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			})
 
 			result, err := adapter.EnsureAllReleasesExist()
-			Expect(result.CancelRequest).To(BeTrue())
-			Expect(result.RequeueRequest).To(BeFalse())
-			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeTrue())
+			Expect(err).To(HaveOccurred())
 			Expect(buf.String()).Should(ContainSubstring("Snapshot integration status marked as Invalid. Failed to get all ReleasePlans"))
 		})
 	})


### PR DESCRIPTION
when creating release for snapshot
* retry for recoverable error

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
