### PR TITLE
fix(STONEINTG-696): add mandatory label to pass EC verify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,14 @@ ENV ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS}
 # Refer to https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 for more details
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
 COPY --from=builder /opt/app-root/src/manager /
+
+# It is mandatory to set these labels
+LABEL description="RHTAP Integration Service"
+LABEL io.k8s.description="RHTAP Integration Service"
+LABEL io.k8s.display-name="Integration-service"
+LABEL summary="RHTAP Integration Service"
+LABEL io.openshift.tags="rhtap"
+
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
The five labels as below are missing in integration-service docker image.  Add these label by referencing to [release-service](https://github.com/redhat-appstudio/release-service/blob/main/Dockerfile#L35-L38) and [build-service](https://github.com/redhat-appstudio/build-service/blob/main/Dockerfile#L32)  Docker image to pass EC verify.

* description
* io.k8s.description
* io.k8s.display-name
* summary
* io.openshift.tags

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
