### PR TITLE
fix(rhtapbugs-975): use source_url instead of repo_url

### DIFF
--- a/.tekton/integration-service-pull-request.yaml
+++ b/.tekton/integration-service-pull-request.yaml
@@ -21,7 +21,7 @@ spec:
   - name: dockerfile
     value: Dockerfile
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{ source_url }}'
   - name: image-expires-after
     value: 5d
   - name: output-image


### PR DESCRIPTION
Update the tekton PR job to use source_url rather than repo_url for the git-url parameter.  This will ensure that the repo will clone from the source rather than the target when testing PR jobs

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
