### PR TITLE
fix(stoneintg-730): Add build PLR annotation for snapshot status

### DIFF
--- a/helpers/build.go
+++ b/helpers/build.go
@@ -1,0 +1,3 @@
+package helpers
+
+const CreateSnapshotAnnotationName = "test.appstudio.openshift.io/create-snapshot-status"


### PR DESCRIPTION
Add an annotation to the build pipelineRuns that shows the current status of the snapshot associated (or that will be associated) with that build pipeline.  This will allow users to more easily find out if build pipelines are not being finalized because the snapshot quota has been reached

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
