### PR TITLE
feat(STONEINTG-703): reset snapshot status conditions when rerunning test

### DIFF
--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -156,6 +156,11 @@ func (a *Adapter) EnsureRerunPipelineRunsExist() (controller.OperationResult, er
 		return controller.RequeueWithError(err)
 	}
 
+	if err = gitops.ResetSnapshotStatusConditions(a.client, a.context, a.snapshot, "Integration test is being rerun for snapshot"); err != nil {
+		a.logger.Error(err, "Failed to reset snapshot status conditions")
+		return controller.RequeueWithError(err)
+	}
+
 	if err = gitops.RemoveIntegrationTestRerunLabel(a.client, a.context, a.snapshot); err != nil {
 		return controller.RequeueWithError(err)
 	}

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -392,6 +392,18 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(gitops.IsSnapshotValid(hasSnapshot)).To(BeTrue())
 	})
 
+	It("ensures the Snapshots status can be reset", func() {
+		gitops.SetSnapshotIntegrationStatusAsFinished(hasSnapshot, "Test message")
+		_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gitops.HaveAppStudioTestsFinished(hasSnapshot)).To(BeTrue())
+		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
+		Expect(gitops.ResetSnapshotStatusConditions(k8sClient, ctx, hasSnapshot, "in progress")).To(Succeed())
+		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
+		Expect(gitops.HaveAppStudioTestsFinished(hasSnapshot)).To(BeFalse())
+	})
+
 	It("ensures the a decision can be made to promote the Snapshot based on its status", func() {
 		gitops.SetSnapshotIntegrationStatusAsFinished(hasSnapshot, "Test message")
 		Expect(hasSnapshot).NotTo(BeNil())


### PR DESCRIPTION
Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
