### PR TITLE
fix: set build-source-image pipeline param to true

### DIFF
--- a/.tekton/integration-service-pull-request.yaml
+++ b/.tekton/integration-service-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/integration-service-push.yaml
+++ b/.tekton/integration-service-push.yaml
@@ -27,6 +27,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
This should resolve the `"msg":"Required task \"source-build\" is missing"` EC failure.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
