### PR TITLE
feat: add additional buckets to sli 2b histogram

### DIFF
--- a/metrics/integration.go
+++ b/metrics/integration.go
@@ -45,7 +45,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "integration_svc_snapshot_created_to_pipelinerun_with_ephemeral_env_started_seconds",
 			Help:    "The duration measures the time elapsed between the creation of a snapshot resource and the initiation of an integration PipelineRun for pipelines operating within an ephemeral environment.",
-			Buckets: []float64{0.05, 0.1, 0.5, 1, 2, 3, 4, 5, 10, 15, 30},
+			Buckets: []float64{1, 5, 10, 15, 20, 25, 30, 35, 45, 60, 120, 240, 300},
 		},
 	)
 


### PR DESCRIPTION
I currently maintain a spreadsheet tracking the latency between snapshot creation time and PLR start time for scenarios that use ephemeral environments.  So far, five snapshots have taken 15-30 seconds and one has taken 30+ seconds.  This commit adds two new buckets: 30-45 and 45-60.  This will allow us to get a better idea of just how long ephemeral environments are taking to be created so that we can more accurately create an SLO for this SLI.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
