### PR TITLE
fix(STONEINTG-706): don't record PLR starttime for reruns

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -112,7 +112,11 @@ func (a *Adapter) EnsureIntegrationTestPipelineForScenarioExists() (controller.O
 				a.logger.Error(err, "Failed to create pipelineRun for snapshot, environment and scenario")
 				return controller.RequeueWithError(err)
 			}
-			metrics.RegisterPipelineRunWithEphemeralEnvStarted(a.snapshot.CreationTimestamp, metav1.Now())
+
+			// measure only non-reruns
+			if _, ok := gitops.GetIntegrationTestRunLabelValue(a.snapshotEnvironmentBinding); !ok {
+				metrics.RegisterPipelineRunWithEphemeralEnvStarted(a.snapshot.CreationTimestamp, metav1.Now())
+			}
 			a.logger.LogAuditEvent("PipelineRun for snapshot created", pipelineRun, h.LogActionAdd,
 				"snapshot.Name", a.snapshot.Name)
 		}

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -1807,6 +1807,33 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 	})
 
+	Describe("createEnvironmentBindingForScenario", func() {
+
+		var (
+			testSEB *applicationapiv1alpha1.SnapshotEnvironmentBinding
+		)
+
+		When("SEB for rerun is created", func() {
+
+			BeforeEach(func() {
+				var err error
+				testSEB, err = adapter.createEnvironmentBindingForScenario(integrationTestScenario, env, ScenarioOptions{IsReRun: true})
+				Expect(err).To(Succeed())
+			})
+
+			AfterEach(func() {
+				err := k8sClient.Delete(ctx, testSEB)
+				Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("SEB contains rerun label", func() {
+				Expect(testSEB.GetLabels()).To(HaveKey(gitops.SnapshotIntegrationTestRun))
+			})
+
+		})
+
+	})
+
 	Describe("shouldScenarioRunInEphemeralEnv", func() {
 		It("returns true when env is defined in scenario", func() {
 			Expect(shouldScenarioRunInEphemeralEnv(integrationTestScenario)).To(BeTrue())

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -693,8 +693,8 @@ func GetComponentSourceFromComponent(component *applicationapiv1alpha1.Component
 }
 
 // GetIntegrationTestRunLabelValue returns value of the label responsible for re-running tests
-func GetIntegrationTestRunLabelValue(snapshot applicationapiv1alpha1.Snapshot) (string, bool) {
-	labels := snapshot.GetLabels()
+func GetIntegrationTestRunLabelValue(obj metav1.Object) (string, bool) {
+	labels := obj.GetLabels()
 	labelVal, ok := labels[SnapshotIntegrationTestRun]
 	return labelVal, ok
 }

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -498,14 +498,14 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	Context("GetIntegrationTestRunLabelValue tests", func() {
 
 		It("snapshot has no label defined", func() {
-			_, ok := gitops.GetIntegrationTestRunLabelValue(*hasSnapshot)
+			_, ok := gitops.GetIntegrationTestRunLabelValue(hasSnapshot)
 			Expect(ok).To(BeFalse())
 		})
 
 		It("snaphost has label defined", func() {
 			testScenario := "test-scenario"
 			hasSnapshot.Labels[gitops.SnapshotIntegrationTestRun] = testScenario
-			val, ok := gitops.GetIntegrationTestRunLabelValue(*hasSnapshot)
+			val, ok := gitops.GetIntegrationTestRunLabelValue(hasSnapshot)
 			Expect(ok).To(BeTrue())
 			Expect(val).To(Equal(testScenario))
 		})
@@ -517,7 +517,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 			testScenario := "test-scenario"
 			err := gitops.AddIntegrationTestRerunLabel(k8sClient, ctx, hasSnapshot, testScenario)
 			Expect(err).To(BeNil())
-			val, ok := gitops.GetIntegrationTestRunLabelValue(*hasSnapshot)
+			val, ok := gitops.GetIntegrationTestRunLabelValue(hasSnapshot)
 			Expect(ok).To(BeTrue())
 			Expect(val).To(Equal(testScenario))
 		})


### PR DESCRIPTION
Reruns are causing wrong data in this metric, this metric is suitable only for automatic runs.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
