### PR TITLE
fix(STONEINTG-709): when build PLR missing param, reconciliation will be stopped

### DIFF
--- a/.tekton/integration-service-pull-request.yaml
+++ b/.tekton/integration-service-pull-request.yaml
@@ -21,7 +21,7 @@ spec:
   - name: dockerfile
     value: Dockerfile
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{ source_url }}'
   - name: image-expires-after
     value: 5d
   - name: output-image

--- a/controllers/binding/snapshotenvironmentbinding_adapter_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter_test.go
@@ -399,9 +399,9 @@ var _ = Describe("Binding Adapter", Ordered, func() {
 
 		integrationPipelineRun := integrationPipelineRuns.Items[0]
 		fmt.Fprintf(GinkgoWriter, "*******integrationPipelineRun: %v\n", integrationPipelineRun)
-		Expect(integrationPipelineRun.Labels["appstudio.openshift.io/application"] == hasApp.Name).To(BeTrue())
-		Expect(integrationPipelineRun.Labels["appstudio.openshift.io/component"] == hasComp.Name).To(BeTrue())
-		Expect(integrationPipelineRun.Labels["appstudio.openshift.io/environment"] == hasEnv.Name).To(BeTrue())
+		Expect(integrationPipelineRun.Labels["appstudio.openshift.io/application"]).To(Equal(hasApp.Name))
+		Expect(integrationPipelineRun.Labels["appstudio.openshift.io/component"]).To(Equal(hasComp.Name))
+		Expect(integrationPipelineRun.Labels["appstudio.openshift.io/environment"]).To(Equal(hasEnv.Name))
 		Expect(integrationPipelineRun.Spec.Workspaces).NotTo(BeNil())
 		Expect(integrationPipelineRun.Spec.Workspaces).NotTo(BeEmpty())
 		Expect(integrationPipelineRun.Spec.Params).NotTo(BeEmpty())

--- a/controllers/binding/snapshotenvironmentbinding_adapter_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter_test.go
@@ -402,9 +402,9 @@ var _ = Describe("Binding Adapter", Ordered, func() {
 		Expect(integrationPipelineRun.Labels["appstudio.openshift.io/application"] == hasApp.Name).To(BeTrue())
 		Expect(integrationPipelineRun.Labels["appstudio.openshift.io/component"] == hasComp.Name).To(BeTrue())
 		Expect(integrationPipelineRun.Labels["appstudio.openshift.io/environment"] == hasEnv.Name).To(BeTrue())
-		Expect(integrationPipelineRun.Spec.Workspaces != nil).To(BeTrue())
-		Expect(len(integrationPipelineRun.Spec.Workspaces) > 0).To(BeTrue())
-		Expect(len(integrationPipelineRun.Spec.Params) > 0).To(BeTrue())
+		Expect(integrationPipelineRun.Spec.Workspaces).NotTo(BeNil())
+		Expect(integrationPipelineRun.Spec.Workspaces).NotTo(BeEmpty())
+		Expect(integrationPipelineRun.Spec.Params).NotTo(BeEmpty())
 
 		Expect(k8sClient.Delete(ctx, &integrationPipelineRuns.Items[0])).Should(Succeed())
 

--- a/controllers/binding/snapshotenvironmentbinding_controller.go
+++ b/controllers/binding/snapshotenvironmentbinding_controller.go
@@ -122,6 +122,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	integrationTestScenario, err := r.getIntegrationTestScenarioFromSnapshotEnvironmentBinding(ctx, snapshotEnvironmentBinding)
 	if err != nil {
 		logger.Error(err, "Failed to get IntegrationTestScenario from the SnapshotEnvironmentBinding")
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/binding/snapshotenvironmentbinding_controller_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_controller_test.go
@@ -319,8 +319,8 @@ var _ = Describe("BindingController", func() {
 		err := k8sClient.Delete(ctx, hasApp)
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, types.NamespacedName{
-				Namespace: hasComp.ObjectMeta.Namespace,
-				Name:      hasComp.ObjectMeta.Name,
+				Namespace: hasApp.ObjectMeta.Namespace,
+				Name:      hasApp.ObjectMeta.Name,
 			}, hasApp)
 			return err != nil && errors.IsNotFound(err)
 		}).Should(BeTrue())
@@ -335,8 +335,8 @@ var _ = Describe("BindingController", func() {
 		err := k8sClient.Delete(ctx, hasSnapshot)
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, types.NamespacedName{
-				Namespace: hasComp.ObjectMeta.Namespace,
-				Name:      hasComp.ObjectMeta.Name,
+				Namespace: hasSnapshot.ObjectMeta.Namespace,
+				Name:      hasSnapshot.ObjectMeta.Name,
 			}, hasSnapshot)
 			return err != nil && errors.IsNotFound(err)
 		}).Should(BeTrue())
@@ -353,6 +353,22 @@ var _ = Describe("BindingController", func() {
 			_, err := bindingReconciler.Reconcile(ctx, req)
 			return err
 		}).ShouldNot(BeNil())
+	})
+
+	It("can fail when Reconcile fails to prepare the adapter when IntegrationTestScenario is not found", func() {
+		err := k8sClient.Delete(ctx, integrationTestScenario)
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: integrationTestScenario.ObjectMeta.Namespace,
+				Name:      integrationTestScenario.ObjectMeta.Name,
+			}, integrationTestScenario)
+			return err != nil && errors.IsNotFound(err)
+		}).Should(BeTrue())
+
+		result, err := bindingReconciler.Reconcile(ctx, req)
+		Expect(result).To(Equal(ctrl.Result{}))
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("can Reconcile function prepare the adapter and return the result of the reconcile handling operation", func() {

--- a/controllers/buildpipeline/buildpipeline_adapter_test.go
+++ b/controllers/buildpipeline/buildpipeline_adapter_test.go
@@ -689,7 +689,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			pipelineRuns, err := adapter.getSucceededBuildPipelineRunsForComponent(hasComp)
 			Expect(err).To(BeNil())
 			Expect(pipelineRuns).NotTo(BeNil())
-			Expect(len(*pipelineRuns)).To(Equal(2))
+			Expect(*pipelineRuns).To(HaveLen(2))
 			Expect((*pipelineRuns)[0].Name == buildPipelineRun.Name || (*pipelineRuns)[1].Name == buildPipelineRun.Name).To(BeTrue())
 		})
 

--- a/controllers/buildpipeline/buildpipeline_adapter_test.go
+++ b/controllers/buildpipeline/buildpipeline_adapter_test.go
@@ -19,8 +19,9 @@ package buildpipeline
 import (
 	"bytes"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/redhat-appstudio/integration-service/gitops"
 	"github.com/redhat-appstudio/integration-service/helpers"

--- a/controllers/buildpipeline/buildpipeline_controller.go
+++ b/controllers/buildpipeline/buildpipeline_controller.go
@@ -100,8 +100,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	application := &applicationapiv1alpha1.Application{}
-	application, err = loader.GetApplicationFromComponent(r.Client, ctx, component)
+	application, err := loader.GetApplicationFromComponent(r.Client, ctx, component)
 	if err != nil {
 		logger.Error(err, "Failed to get Application from Component",
 			"Component.Name ", component.Name, "Component.Namespace ", component.Namespace)

--- a/controllers/component/component_adapter_test.go
+++ b/controllers/component/component_adapter_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Component Adapter", Ordered, func() {
 		})
 		snapshots := &applicationapiv1alpha1.SnapshotList{}
 		Eventually(func() bool {
-			k8sClient.List(ctx, snapshots, &client.ListOptions{Namespace: hasApp.Namespace})
+			Expect(k8sClient.List(ctx, snapshots, &client.ListOptions{Namespace: hasApp.Namespace})).To(Succeed())
 			return len(snapshots.Items) == 0
 		}, time.Second*20).Should(BeTrue())
 
@@ -138,7 +138,7 @@ var _ = Describe("Component Adapter", Ordered, func() {
 		result, err := adapter.EnsureComponentIsCleanedUp()
 
 		Eventually(func() bool {
-			k8sClient.List(ctx, snapshots, &client.ListOptions{Namespace: hasApp.Namespace})
+			Expect(k8sClient.List(ctx, snapshots, &client.ListOptions{Namespace: hasApp.Namespace})).To(Succeed())
 			return !result.CancelRequest && len(snapshots.Items) == 1 && err == nil
 		}, time.Second*20).Should(BeTrue())
 	})

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -507,7 +507,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("ensures global Component Image will not be updated in the PR context", func() {
-			gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshotPR, "test passed")
+			_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshotPR, "test passed")
+			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshotPR)).To(BeTrue())
 			adapter.snapshot = hasSnapshotPR
 
@@ -521,7 +522,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("no error from ensuring global Component Image updated when AppStudio Tests failed", func() {
-			gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+			_, err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 			adapter.snapshot = hasSnapshot
 			result, err := adapter.EnsureGlobalCandidateImageUpdated()
@@ -533,7 +535,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("ensures global Component Image updated when AppStudio Tests succeeded", func() {
-			gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 			adapter.snapshot = hasSnapshot
 
@@ -565,7 +568,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 
 			gitops.SetSnapshotIntegrationStatusAsFinished(hasSnapshot, "Snapshot integration status condition is finished since all testing pipelines completed")
-			gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsFinished(hasSnapshot)).To(BeTrue())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
@@ -704,7 +708,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		It("ensures snapshot environmentBinding exists", func() {
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 
-			gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			Expect(err).To(Succeed())
 			hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePushType
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
@@ -793,7 +798,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				}
 				Expect(k8sClient.Create(ctx, hasBinding)).Should(Succeed())
 
-				gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+				_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+				Expect(err).To(Succeed())
 				hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePushType
 				Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 			})
@@ -967,7 +973,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 
 		BeforeAll(func() {
-			gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 		})
 
@@ -1737,7 +1744,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				statuses, err := intgteststat.NewSnapshotIntegrationTestStatuses("")
 				Expect(err).To(Succeed())
 				statuses.UpdateTestStatusIfChanged(integrationTestScenarioWithoutEnv.Name, intgteststat.IntegrationTestStatusInProgress, fakeDetails)
-				statuses.UpdateTestPipelineRunName(integrationTestScenarioWithoutEnv.Name, fakePLRName)
+				Expect(statuses.UpdateTestPipelineRunName(integrationTestScenarioWithoutEnv.Name, fakePLRName)).To(Succeed())
 				Expect(gitops.WriteIntegrationTestStatusesIntoSnapshot(hasSnapshot, statuses, k8sClient, ctx)).Should(Succeed())
 
 				// add rerun label

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -762,7 +762,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(binding.Spec.Environment).To(Equal(env.Name))
 
 			owners := binding.GetOwnerReferences()
-			Expect(len(owners) == 1).To(BeTrue())
+			Expect(owners).To(HaveLen(1))
 			Expect(owners[0].Name).To(Equal(hasSnapshot.Name))
 
 			// Check if the adapter function detects that it already released the snapshot
@@ -1271,7 +1271,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(binding.Spec.Environment).To(Equal(ephemeralEnv.Name))
 
 			owners := binding.GetOwnerReferences()
-			Expect(len(owners) == 1).To(BeTrue())
+			Expect(owners).To(HaveLen(1))
 			Expect(owners[0].Name).To(Equal(ephemeralEnv.Name))
 		})
 

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -639,7 +639,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					return err
 				}
 				if len(releaseList.Items) > 0 {
-					Expect(releaseList.Items[0].ObjectMeta.Labels["appstudio.openshift.io/component"] == hasComp.Name)
+					Expect(releaseList.Items[0].ObjectMeta.Labels["appstudio.openshift.io/component"]).To(Equal(hasComp.Name))
 				}
 				return nil
 			}, time.Second*10).Should(BeNil())
@@ -1089,10 +1089,10 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					Namespace: snapshotEnvironmentBinding.Namespace,
 					Name:      snapshotEnvironmentBinding.Name,
 				}, updatedSEB)
-				return err == nil && len(updatedSEB.Spec.Components) == 1
+				return err == nil && len(updatedSEB.Spec.Components) == 1 && updatedSEB.Spec.Snapshot == otherSnapshot.Name
 			}, time.Second*10).Should(BeTrue())
-			Expect(updatedSEB.Spec.Snapshot == otherSnapshot.Name)
-			Expect(updatedSEB.Spec.Components[0].Name == secondComp.Name)
+			Expect(updatedSEB.Spec.Snapshot).To(Equal(otherSnapshot.Name))
+			Expect(updatedSEB.Spec.Components[0].Name).To(Equal(secondComp.Name))
 
 			err = k8sClient.Delete(ctx, snapshotEnvironmentBinding)
 			Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())

--- a/git/github/github_test.go
+++ b/git/github/github_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Client", func() {
 
 		allCheckRuns, err := client.GetAllCheckRunsForRef(context.TODO(), "", "", "", 1)
 		Expect(err).To(BeNil())
-		Expect(len(allCheckRuns) > 0).To(BeTrue())
+		Expect(allCheckRuns).NotTo(BeEmpty())
 
 		existingCheckRun := client.GetExistingCheckRun(allCheckRuns, checkRunAdapter)
 		Expect(existingCheckRun).NotTo(BeNil())
@@ -291,7 +291,7 @@ var _ = Describe("Client", func() {
 	It("can check if creating a new commit status is needed", func() {
 		commitStatuses, err := client.GetAllCommitStatusesForRef(context.TODO(), "", "", "")
 		Expect(err).To(BeNil())
-		Expect(len(commitStatuses) > 0).To(BeTrue())
+		Expect(commitStatuses).NotTo(BeEmpty())
 
 		commitStatusExist, err := client.CommitStatusExists(commitStatuses, commitStatusAdapter)
 		Expect(commitStatusExist).To(BeTrue())
@@ -313,7 +313,7 @@ var _ = Describe("Client", func() {
 	It("can get existing comment id", func() {
 		comments, err := client.GetAllCommentsForPR(context.TODO(), "", "", 1)
 		Expect(err).To(BeNil())
-		Expect(len(comments) > 0).To(BeTrue())
+		Expect(comments).NotTo(BeEmpty())
 
 		commentID := client.GetExistingCommentID(comments, "snapshotName", "scenarioName")
 		Expect(*commentID).To(Equal(int64(40)))

--- a/git/github/github_test.go
+++ b/git/github/github_test.go
@@ -286,19 +286,6 @@ var _ = Describe("Client", func() {
 		existingCheckRun := client.GetExistingCheckRun(allCheckRuns, checkRunAdapter)
 		Expect(existingCheckRun).NotTo(BeNil())
 
-		checkRunAdapter = &github.CheckRunAdapter{
-			Name:           "example-name",
-			Owner:          "example-owner",
-			Repository:     "example-repo",
-			SHA:            "abcdef1",
-			ExternalID:     "example-external-id",
-			Conclusion:     "failure",
-			Title:          "example-title",
-			Summary:        "example-summary",
-			Text:           "example-text-update",
-			StartTime:      time.Now(),
-			CompletionTime: time.Now(),
-		}
 	})
 
 	It("can check if creating a new commit status is needed", func() {

--- a/gitops/binding_test.go
+++ b/gitops/binding_test.go
@@ -175,7 +175,8 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures Binding Component is created", func() {
-		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 		bindingComponents := gitops.NewBindingComponents(hasSnapshot)
 		Expect(bindingComponents).NotTo(BeNil())

--- a/gitops/binding_test.go
+++ b/gitops/binding_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(newSnapshotEnvironmentBinding).NotTo(BeNil())
 		Expect(newSnapshotEnvironmentBinding.Spec.Snapshot).To(Equal(hasSnapshot.Name))
 		Expect(newSnapshotEnvironmentBinding.Spec.Environment).To(Equal(env.Name))
-		Expect(len(newSnapshotEnvironmentBinding.Spec.Components)).To(Equal(1))
+		Expect(newSnapshotEnvironmentBinding.Spec.Components).To(HaveLen(1))
 
 		Expect(gitops.IsBindingDeployed(newSnapshotEnvironmentBinding)).NotTo(BeTrue())
 		Expect(gitops.HaveBindingsFailed(newSnapshotEnvironmentBinding)).NotTo(BeTrue())

--- a/gitops/environment_test.go
+++ b/gitops/environment_test.go
@@ -384,7 +384,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 		It("Can return DeploymentTargetClaim object", func() {
 			dtc := gitops.NewDeploymentTargetClaim("default", deploymentTargetClass.Name)
-			Expect(dtc.Spec.DeploymentTargetClassName == applicationapiv1alpha1.DeploymentTargetClassName(deploymentTargetClass.Name)).To(BeTrue())
+			Expect(dtc.Spec.DeploymentTargetClassName).To(Equal(applicationapiv1alpha1.DeploymentTargetClassName(deploymentTargetClass.Name)))
 		})
 	})
 

--- a/gitops/snapshot_integration_tests_status_test.go
+++ b/gitops/snapshot_integration_tests_status_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Snapshot integration test statuses", func() {
 		It("Creates empty statuses when a snaphost doesn't have test status annotation", func() {
 			statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(snapshot)
 			Expect(err).To(BeNil())
-			Expect(len(statuses.GetStatuses())).To(Equal(0))
+			Expect(statuses.GetStatuses()).To(BeEmpty())
 		})
 
 		When("Snapshot contains empty test status annotation", func() {
@@ -94,7 +94,7 @@ var _ = Describe("Snapshot integration test statuses", func() {
 			It("Returns empty test statuses", func() {
 				statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(snapshot)
 				Expect(err).To(BeNil())
-				Expect(len(statuses.GetStatuses())).To(Equal(0))
+				Expect(statuses.GetStatuses()).To(BeEmpty())
 			})
 		})
 
@@ -111,7 +111,7 @@ var _ = Describe("Snapshot integration test statuses", func() {
 			It("Returns expected test statuses", func() {
 				statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(snapshot)
 				Expect(err).To(BeNil())
-				Expect(len(statuses.GetStatuses())).To(Equal(1))
+				Expect(statuses.GetStatuses()).To(HaveLen(1))
 
 				statusDetail := statuses.GetStatuses()[0]
 				Expect(statusDetail.Status).To(Equal(intgteststat.IntegrationTestStatusInProgress))
@@ -191,7 +191,7 @@ var _ = Describe("Snapshot integration test statuses", func() {
 
 				statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(snapshot)
 				Expect(err).To(BeNil())
-				Expect(len(statuses.GetStatuses())).To(Equal(1))
+				Expect(statuses.GetStatuses()).To(HaveLen(1))
 			})
 		})
 

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -135,15 +135,14 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 	It("ensures that latest update annotation can be set and get from snapshot", func() {
 		t := time.Time{}
-		t.UnmarshalText([]byte("2023-08-26T17:57:50+02:00"))
+		Expect(t.UnmarshalText([]byte("2023-08-26T17:57:50+02:00"))).To(Succeed())
 		Expect(gitops.GetLatestUpdateTime(hasSnapshot)).To(Equal(t))
 		//set different time
-		t.UnmarshalText([]byte("2023-08-26T18:57:50+02:00"))
-		gitops.SetLatestUpdateTime(hasSnapshot, t)
+		Expect(t.UnmarshalText([]byte("2023-08-26T18:57:50+02:00"))).To(Succeed())
+		Expect(gitops.SetLatestUpdateTime(hasSnapshot, t)).To(Succeed())
 		Expect(hasSnapshot.GetAnnotations()[gitops.SnapshotPRLastUpdate]).To(Equal("2023-08-26T18:57:50+02:00"))
-		//set latest update time to nil
-		t.UnmarshalText([]byte(""))
-		gitops.SetLatestUpdateTime(hasSnapshot, t)
+		//set latest update time to zero
+		Expect(gitops.SetLatestUpdateTime(hasSnapshot, time.Time{})).To(Succeed())
 		Expect(hasSnapshot.GetAnnotations()[gitops.SnapshotPRLastUpdate]).To(Equal("0001-01-01T00:00:00Z"))
 
 	})

--- a/helpers/errorhandlers.go
+++ b/helpers/errorhandlers.go
@@ -15,6 +15,7 @@ package helpers
 
 import (
 	"fmt"
+	"regexp"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -22,6 +23,7 @@ import (
 
 const (
 	ReasonEnvironmentNotInNamespace = "EnvironmentNotInNamespace"
+	MissingParamInPipelineRun       = "MissingParamInPipelineRun"
 	ReasonUnknownError              = "UnknownError"
 )
 
@@ -51,6 +53,19 @@ func NewEnvironmentNotInNamespaceError(environment, namespace string) error {
 
 func IsEnvironmentNotInNamespaceError(err error) bool {
 	return getReason(err) == ReasonEnvironmentNotInNamespace
+}
+
+func IsMissingParamInPipelineRunError(err error) bool {
+	pattern := `couldn't find the '.*' PipelineRun parameter`
+	re := regexp.MustCompile(pattern)
+	return re.MatchString(getReason(err))
+}
+
+func MissingParamInPipelineRunError(pipelinerunName, paramName string) error {
+	return &IntegrationError{
+		Reason:  ReasonEnvironmentNotInNamespace,
+		Message: fmt.Sprintf("Missing param %s in PipelineRun %s", pipelinerunName, paramName),
+	}
 }
 
 func HandleLoaderError(logger IntegrationLogger, err error, resource, from string) (ctrl.Result, error) {

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -995,7 +995,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 		taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(k8sClient, ctx, integrationPipelineRun)
 		Expect(err).To(BeNil())
-		Expect(len(taskRuns)).To(Equal(2))
+		Expect(taskRuns).To(HaveLen(2))
 
 		// We expect the tasks to be sorted by start time
 		tr1 := taskRuns[0]

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		now = time.Now()
+		now = time.Now().Truncate(time.Second) // saved resources doesn't have subsecond values in timestamps
 
 		hasApp = &applicationapiv1alpha1.Application{
 			ObjectMeta: metav1.ObjectMeta{
@@ -673,7 +673,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		integrationTaskRun := helpers.NewTaskRunFromTektonTaskRun("task-success", &successfulTaskRun.Status)
 		Expect(integrationTaskRun).NotTo(BeNil())
 		Expect(integrationTaskRun.GetPipelineTaskName()).To(Equal("task-success"))
-		Expect(integrationTaskRun.GetStartTime().Equal(now))
+		Expect(integrationTaskRun.GetStartTime()).To(Equal(now))
 		Expect(integrationTaskRun.GetDuration().Minutes()).To(Equal(5.0))
 
 		integrationTaskRun = helpers.NewTaskRunFromTektonTaskRun("task-instant", &emptyTaskRun.Status)
@@ -1000,7 +1000,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		// We expect the tasks to be sorted by start time
 		tr1 := taskRuns[0]
 		Expect(tr1.GetPipelineTaskName()).To(Equal("pipeline1-task1"))
-		Expect(tr1.GetStartTime().Equal(now))
+		Expect(tr1.GetStartTime()).To(Equal(now))
 		Expect(tr1.GetDuration().Minutes()).To(Equal(5.0))
 
 		result1, err := tr1.GetTestResult()
@@ -1014,7 +1014,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(result1).To(Equal(result2))
 
 		tr2 := taskRuns[1]
-		Expect(tr2.GetStartTime().Equal(now.Add(5 * time.Minute)))
+		Expect(tr2.GetStartTime()).To(Equal(now.Add(5 * time.Minute)))
 		Expect(tr2.GetDuration().Minutes()).To(Equal(5.0))
 
 		result3, err := tr2.GetTestResult()

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -715,7 +715,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		_, err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 	})
 
@@ -751,7 +752,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		_, err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 	})
 
@@ -772,7 +774,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+		_, err = gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 	})
 
@@ -808,7 +811,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+		_, err = gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 	})
 
@@ -887,7 +891,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		_, err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 	})
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -538,7 +538,7 @@ var _ = Describe("Loader", Ordered, func() {
 		pipelineRuns, err := loader.GetAllBuildPipelineRunsForComponent(k8sClient, ctx, hasComp)
 		Expect(err).To(BeNil())
 		Expect(pipelineRuns).NotTo(BeNil())
-		Expect(len(*pipelineRuns)).To(Equal(1))
+		Expect(*pipelineRuns).To(HaveLen(1))
 		Expect((*pipelineRuns)[0].Name == buildPipelineRun.Name)
 	})
 
@@ -546,7 +546,7 @@ var _ = Describe("Loader", Ordered, func() {
 		pipelineRuns, err := loader.GetAllPipelineRunsForSnapshotAndScenario(k8sClient, ctx, hasSnapshot, integrationTestScenario)
 		Expect(err).To(BeNil())
 		Expect(pipelineRuns).NotTo(BeNil())
-		Expect(len(*pipelineRuns)).To(Equal(1))
+		Expect(*pipelineRuns).To(HaveLen(1))
 		Expect((*pipelineRuns)[0].Name == buildPipelineRun.Name)
 	})
 
@@ -554,7 +554,7 @@ var _ = Describe("Loader", Ordered, func() {
 		integrationTestScenarios, err := loader.GetAllIntegrationTestScenariosForApplication(k8sClient, ctx, hasApp)
 		Expect(err).To(BeNil())
 		Expect(integrationTestScenarios).NotTo(BeNil())
-		Expect(len(*integrationTestScenarios)).To(Equal(1))
+		Expect(*integrationTestScenarios).To(HaveLen(1))
 		Expect((*integrationTestScenarios)[0].Name == integrationTestScenario.Name)
 	})
 
@@ -562,7 +562,7 @@ var _ = Describe("Loader", Ordered, func() {
 		integrationTestScenarios, err := loader.GetRequiredIntegrationTestScenariosForApplication(k8sClient, ctx, hasApp)
 		Expect(err).To(BeNil())
 		Expect(integrationTestScenarios).NotTo(BeNil())
-		Expect(len(*integrationTestScenarios)).To(Equal(1))
+		Expect(*integrationTestScenarios).To(HaveLen(1))
 		Expect((*integrationTestScenarios)[0].Name == integrationTestScenario.Name)
 	})
 
@@ -593,7 +593,7 @@ var _ = Describe("Loader", Ordered, func() {
 	It("ensures that all Snapshots for a given application can be found", func() {
 		snapshots, err := loader.GetAllSnapshots(k8sClient, ctx, hasApp)
 		Expect(err).To(BeNil())
-		Expect(len(*snapshots)).To(Equal(1))
+		Expect(*snapshots).To(HaveLen(1))
 	})
 
 	It("ensures the ReleasePlan can be gotten for Application", func() {
@@ -640,7 +640,7 @@ var _ = Describe("Loader", Ordered, func() {
 			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(k8sClient, ctx, hasApp)
 			Expect(err).To(BeNil())
 			Expect(autoReleasePlans).ToNot(BeNil())
-			Expect(len(*autoReleasePlans)).To(Equal(1))
+			Expect(*autoReleasePlans).To(HaveLen(1))
 			Expect((*autoReleasePlans)[0].Name).To(Equal(releasePlanWithLabel.Name))
 
 		})
@@ -680,7 +680,7 @@ var _ = Describe("Loader", Ordered, func() {
 			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(k8sClient, ctx, hasApp)
 			Expect(err).To(BeNil())
 			Expect(autoReleasePlans).ToNot(BeNil())
-			Expect(len(*autoReleasePlans)).To(Equal(1))
+			Expect(*autoReleasePlans).To(HaveLen(1))
 			Expect((*autoReleasePlans)[0].Name).To(Equal(releasePlanNoLabel.Name))
 
 		})
@@ -723,7 +723,7 @@ var _ = Describe("Loader", Ordered, func() {
 			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(k8sClient, ctx, hasApp)
 			Expect(err).To(BeNil())
 			Expect(autoReleasePlans).ToNot(BeNil())
-			Expect(len(*autoReleasePlans)).To(Equal(0))
+			Expect(*autoReleasePlans).To(BeEmpty())
 		})
 
 		It("Can fetch integration test scenario", func() {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -539,7 +539,7 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(err).To(BeNil())
 		Expect(pipelineRuns).NotTo(BeNil())
 		Expect(*pipelineRuns).To(HaveLen(1))
-		Expect((*pipelineRuns)[0].Name == buildPipelineRun.Name)
+		Expect((*pipelineRuns)[0].Name).To(Equal(buildPipelineRun.Name))
 	})
 
 	It("can fetch all pipelineRuns for snapshot and scenario", func() {
@@ -547,7 +547,7 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(err).To(BeNil())
 		Expect(pipelineRuns).NotTo(BeNil())
 		Expect(*pipelineRuns).To(HaveLen(1))
-		Expect((*pipelineRuns)[0].Name == buildPipelineRun.Name)
+		Expect((*pipelineRuns)[0].Name).To(Equal(integrationPipelineRun.Name))
 	})
 
 	It("can fetch all integrationTestScenario for application", func() {
@@ -555,7 +555,7 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(err).To(BeNil())
 		Expect(integrationTestScenarios).NotTo(BeNil())
 		Expect(*integrationTestScenarios).To(HaveLen(1))
-		Expect((*integrationTestScenarios)[0].Name == integrationTestScenario.Name)
+		Expect((*integrationTestScenarios)[0].Name).To(Equal(integrationTestScenario.Name))
 	})
 
 	It("can fetch required integrationTestScenario for application", func() {
@@ -563,31 +563,31 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(err).To(BeNil())
 		Expect(integrationTestScenarios).NotTo(BeNil())
 		Expect(*integrationTestScenarios).To(HaveLen(1))
-		Expect((*integrationTestScenarios)[0].Name == integrationTestScenario.Name)
+		Expect((*integrationTestScenarios)[0].Name).To(Equal(integrationTestScenario.Name))
 	})
 
 	It("can find available DeploymentTargetClass for application", func() {
 		dtcls, err := loader.FindAvailableDeploymentTargetClass(k8sClient, ctx)
 		Expect(err).To(BeNil())
-		Expect(dtcls.Name == deploymentTargetClass.Name)
+		Expect(dtcls.Name).To(Equal(deploymentTargetClass.Name))
 	})
 
 	It("can fetch DeploymentTargetClaim for environment", func() {
 		dtcls, err := loader.GetDeploymentTargetClaimForEnvironment(k8sClient, ctx, hasEnv)
 		Expect(err).To(BeNil())
-		Expect(dtcls.Name == deploymentTargetClass.Name)
+		Expect(dtcls.Name).To(Equal(deploymentTargetClaim.Name))
 	})
 
 	It("can fetch DeploymentTarget for DeploymentTargetClaim", func() {
 		dt, err := loader.GetDeploymentTargetForDeploymentTargetClaim(k8sClient, ctx, deploymentTargetClaim)
 		Expect(err).To(BeNil())
-		Expect(dt.Name == deploymentTarget.Name)
+		Expect(dt.Name).To(Equal(deploymentTarget.Name))
 	})
 
 	It("can snapshotEnvironmentBinding for application and environment", func() {
 		binding, err := loader.FindExistingSnapshotEnvironmentBinding(k8sClient, ctx, hasApp, hasEnv)
 		Expect(err).To(BeNil())
-		Expect(binding.Name == hasBinding.Name)
+		Expect(binding.Name).To(Equal(hasBinding.Name))
 	})
 
 	It("ensures that all Snapshots for a given application can be found", func() {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -459,7 +459,8 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(k8sClient).NotTo(BeNil())
 		Expect(ctx).NotTo(BeNil())
 		Expect(hasSnapshot).NotTo(BeNil())
-		gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 
 		// Normally we would Ensure that releases exist here, but that requires

--- a/pkg/integrationteststatus/integration_test_status_test.go
+++ b/pkg/integrationteststatus/integration_test_status_test.go
@@ -125,9 +125,9 @@ var _ = Describe("integrationteststatus library unittests", func() {
 		})
 
 		It("Can add new scenario test status", func() {
-			Expect(len(sits.GetStatuses())).To(Equal(0))
+			Expect(sits.GetStatuses()).To(BeEmpty())
 			sits.UpdateTestStatusIfChanged(testScenarioName, intgteststat.IntegrationTestStatusPending, testDetails)
-			Expect(len(sits.GetStatuses())).To(Equal(1))
+			Expect(sits.GetStatuses()).To(HaveLen(1))
 
 			detail, ok := sits.GetScenarioStatus(testScenarioName)
 			Expect(ok).To(BeTrue())
@@ -411,7 +411,7 @@ var _ = Describe("integrationteststatus library unittests", func() {
 				Expect(newSt.LastUpdateTime).NotTo(Equal(oldTimestamp))
 
 				// no changes to nuber of records
-				Expect(len(sits.GetStatuses())).To(Equal(1))
+				Expect(sits.GetStatuses()).To(HaveLen(1))
 			})
 
 			It("Updating details of scenario is reflected", func() {
@@ -433,20 +433,20 @@ var _ = Describe("integrationteststatus library unittests", func() {
 				Expect(newSt.LastUpdateTime).NotTo(Equal(oldTimestamp))
 
 				// no changes to nuber of records
-				Expect(len(sits.GetStatuses())).To(Equal(1))
+				Expect(sits.GetStatuses()).To(HaveLen(1))
 			})
 
 			It("Scenario can be deleted", func() {
 				sits.ResetDirty()
 				sits.DeleteStatus(testScenarioName)
-				Expect(len(sits.GetStatuses())).To(Equal(0))
+				Expect(sits.GetStatuses()).To(BeEmpty())
 				Expect(sits.IsDirty()).To(BeTrue())
 			})
 
 			It("Initialization with empty scneario list will remove data", func() {
 				sits.ResetDirty()
 				sits.InitStatuses(&[]string{})
-				Expect(len(sits.GetStatuses())).To(Equal(0))
+				Expect(sits.GetStatuses()).To(BeEmpty())
 				Expect(sits.IsDirty()).To(BeTrue())
 			})
 
@@ -457,7 +457,7 @@ var _ = Describe("integrationteststatus library unittests", func() {
 			sits.InitStatuses(&[]string{testScenarioName})
 
 			Expect(sits.IsDirty()).To(BeTrue())
-			Expect(len(sits.GetStatuses())).To(Equal(1))
+			Expect(sits.GetStatuses()).To(HaveLen(1))
 
 			statusDetail, ok := sits.GetScenarioStatus(testScenarioName)
 			Expect(ok).To(BeTrue())
@@ -469,7 +469,7 @@ var _ = Describe("integrationteststatus library unittests", func() {
 			It("Returns empty test statuses", func() {
 				statuses, err := intgteststat.NewSnapshotIntegrationTestStatuses("[]")
 				Expect(err).To(BeNil())
-				Expect(len(statuses.GetStatuses())).To(Equal(0))
+				Expect(statuses.GetStatuses()).To(BeEmpty())
 			})
 		})
 
@@ -487,7 +487,7 @@ var _ = Describe("integrationteststatus library unittests", func() {
 			It("Returns expected test statuses", func() {
 				statuses, err := intgteststat.NewSnapshotIntegrationTestStatuses(jsondata)
 				Expect(err).To(BeNil())
-				Expect(len(statuses.GetStatuses())).To(Equal(1))
+				Expect(statuses.GetStatuses()).To(HaveLen(1))
 
 				statusDetail := statuses.GetStatuses()[0]
 				Expect(statusDetail.Status).To(Equal(intgteststat.IntegrationTestStatusInProgress))

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -55,6 +55,6 @@ var _ = Describe("Status Adapter", func() {
 		adapter := status.NewAdapter(logr.Discard(), nil, status.WithGitHubReporter(&MockReporter{}))
 		reporters, err := adapter.GetReporters(pipelineRun)
 		Expect(err).To(BeNil())
-		Expect(len(reporters)).To(Equal(1))
+		Expect(reporters).To(HaveLen(1))
 	})
 })

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -458,7 +458,7 @@ var _ = Describe("Integration pipeline", func() {
 				To(Equal("false"))
 
 			Expect(string(newIntegrationBundlePipelineRun.Spec.PipelineRef.ResolverRef.Resolver)).To(Equal("bundles"))
-			Expect(len(newIntegrationBundlePipelineRun.Spec.PipelineRef.ResolverRef.Params)).To(Equal(3))
+			Expect(newIntegrationBundlePipelineRun.Spec.PipelineRef.ResolverRef.Params).To(HaveLen(3))
 		})
 	})
 
@@ -478,7 +478,7 @@ var _ = Describe("Integration pipeline", func() {
 
 		It("has set all parameters required for executing the EC pipeline", func() {
 			Expect(string(enterpriseContractPipelineRun.Spec.PipelineRef.ResolverRef.Resolver)).To(Equal("git"))
-			Expect(len(enterpriseContractPipelineRun.Spec.PipelineRef.ResolverRef.Params)).To(Equal(3))
+			Expect(enterpriseContractPipelineRun.Spec.PipelineRef.ResolverRef.Params).To(HaveLen(3))
 
 			Expect(enterpriseContractPipelineRun.Spec.Params[0].Name).To(Equal("SNAPSHOT"))
 			Expect(enterpriseContractPipelineRun.Spec.Params[1].Name).To(Equal("POLICY_CONFIGURATION"))

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -413,7 +413,7 @@ var _ = Describe("Integration pipeline", func() {
 			Expect(newIntegrationPipelineRun.Labels["appstudio.openshift.io/environment"]).
 				To(Equal(hasEnv.Name))
 
-			Expect(newIntegrationPipelineRun.Spec.Workspaces != nil).To(BeTrue())
+			Expect(newIntegrationPipelineRun.Spec.Workspaces).NotTo(BeNil())
 			Expect(newIntegrationPipelineRun.Spec.Workspaces).NotTo(BeEmpty())
 			Expect(newIntegrationPipelineRun.Spec.Workspaces[0].Name).To(Equal("cluster-credentials"))
 			Expect(newIntegrationPipelineRun.Spec.Workspaces[0].Secret.SecretName).

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -414,12 +414,12 @@ var _ = Describe("Integration pipeline", func() {
 				To(Equal(hasEnv.Name))
 
 			Expect(newIntegrationPipelineRun.Spec.Workspaces != nil).To(BeTrue())
-			Expect(len(newIntegrationPipelineRun.Spec.Workspaces) > 0).To(BeTrue())
+			Expect(newIntegrationPipelineRun.Spec.Workspaces).NotTo(BeEmpty())
 			Expect(newIntegrationPipelineRun.Spec.Workspaces[0].Name).To(Equal("cluster-credentials"))
 			Expect(newIntegrationPipelineRun.Spec.Workspaces[0].Secret.SecretName).
 				To(Equal(deploymentTarget.Spec.KubernetesClusterCredentials.ClusterCredentialsSecret))
 
-			Expect(len(newIntegrationPipelineRun.Spec.Params) > 0).To(BeTrue())
+			Expect(newIntegrationPipelineRun.Spec.Params).NotTo(BeEmpty())
 			Expect(newIntegrationPipelineRun.Spec.Params[0].Name).To(Equal("NAMESPACE"))
 			Expect(newIntegrationPipelineRun.Spec.Params[0].Value.StringVal).
 				To(Equal(deploymentTarget.Spec.KubernetesClusterCredentials.DefaultNamespace))


### PR DESCRIPTION
## [Fix error of missing param in build PLR ](https://issues.redhat.com/browse/STONEINTG-709)
 
- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
