### PR TITLE
fix(STONEINTG-709): add support missing info of build PLR error

### DIFF
--- a/controllers/buildpipeline/buildpipeline_adapter.go
+++ b/controllers/buildpipeline/buildpipeline_adapter.go
@@ -96,6 +96,16 @@ func (a *Adapter) EnsureSnapshotExists() (controller.OperationResult, error) {
 
 	expectedSnapshot, err := a.prepareSnapshotForPipelineRun(a.pipelineRun, a.component, a.application)
 	if err != nil {
+		// If PipelineRun result returns cusomized error update PLR annotation and exit
+		if h.IsMissingInfoInPipelineRunError(err) {
+			// update the build PLR annotation with the error cusomized Reason and Value
+			if annotateErr := a.annotateBuildPipelineRunWithCreateSnapshotAnnotation(err); annotateErr != nil {
+				a.logger.Error(annotateErr, "Could not add create snapshot annotation to build pipelineRun", h.CreateSnapshotAnnotationName, a.pipelineRun)
+			}
+			a.logger.Error(err, "Build PipelineRun %s failed with error, should be fixed and re-run manually", a.pipelineRun)
+			return a.removeFinalizerAndContinueProcessing()
+		}
+
 		return controller.RequeueWithError(err)
 	}
 

--- a/helpers/errorhandlers.go
+++ b/helpers/errorhandlers.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	ReasonEnvironmentNotInNamespace = "EnvironmentNotInNamespace"
-	ReasonUnknownError              = "UnknownError"
+	ReasonEnvironmentNotInNamespace     = "EnvironmentNotInNamespace"
+	ReasonMissingInfoInPipelineRunError = "MissingInfoInPipelineRunError"
+	ReasonUnknownError                  = "UnknownError"
 )
 
 type IntegrationError struct {
@@ -51,6 +52,17 @@ func NewEnvironmentNotInNamespaceError(environment, namespace string) error {
 
 func IsEnvironmentNotInNamespaceError(err error) bool {
 	return getReason(err) == ReasonEnvironmentNotInNamespace
+}
+
+func MissingInfoInPipelineRunError(pipelineRunName, paramName string) error {
+	return &IntegrationError{
+		Reason:  ReasonMissingInfoInPipelineRunError,
+		Message: fmt.Sprintf("Missing info %s from pipelinerun %s", paramName, pipelineRunName),
+	}
+}
+
+func IsMissingInfoInPipelineRunError(err error) bool {
+	return getReason(err) == ReasonMissingInfoInPipelineRunError
 }
 
 func HandleLoaderError(logger IntegrationLogger, err error, resource, from string) (ctrl.Result, error) {

--- a/helpers/errorhandlers_test.go
+++ b/helpers/errorhandlers_test.go
@@ -82,5 +82,17 @@ var _ = Describe("Helpers for error handlers", Ordered, func() {
 			err := fmt.Errorf("failed")
 			Expect(helpers.IsEnvironmentNotInNamespaceError(err)).To(BeFalse())
 		})
+
+		It("Can define MissingInfoInPipelineRunError", func() {
+			err := helpers.MissingInfoInPipelineRunError("pipelineRunName", "revision")
+			Expect(helpers.IsMissingInfoInPipelineRunError(err)).To(BeTrue())
+			Expect(err.Error()).To(Equal("Missing info revision from pipelinerun pipelineRunName"))
+		})
+
+		It("Can handle non integration error", func() {
+			err := fmt.Errorf("failed")
+			Expect(helpers.IsMissingInfoInPipelineRunError(err)).To(BeFalse())
+		})
+
 	})
 })

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -19,6 +19,7 @@ package tekton
 import (
 	"fmt"
 
+	h "github.com/redhat-appstudio/integration-service/helpers"
 	"github.com/redhat-appstudio/operator-toolkit/metadata"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"knative.dev/pkg/apis"
@@ -43,6 +44,18 @@ const (
 
 	// PipelineRunChainsSignedAnnotation is the label added by Tekton Chains to signed PipelineRuns
 	PipelineRunChainsSignedAnnotation = "chains.tekton.dev/signed"
+
+	// PipelineRunImageUrlParamName name of image url output param
+	PipelineRunImageUrlParamName = "IMAGE_URL"
+
+	// PipelineRunImageDigestParamName name of image digest in PipelineRun result param
+	PipelineRunImageDigestParamName = "IMAGE_DIGEST"
+
+	// PipelineRunChainsGitUrlParamName name of param chains repo url
+	PipelineRunChainsGitUrlParamName = "CHAINS-GIT_URL"
+
+	// PipelineRunChainsGitCommitParamName name of param repo chains commit
+	PipelineRunChainsGitCommitParamName = "CHAINS-GIT_COMMIT"
 )
 
 // IsBuildPipelineRun returns a boolean indicating whether the object passed is a PipelineRun from
@@ -136,48 +149,53 @@ func GetTypeFromPipelineRun(object client.Object) (string, error) {
 
 // GetOutputImage returns a string containing the output-image parameter value from a given PipelineRun.
 func GetOutputImage(object client.Object) (string, error) {
-	if pipelineRun, ok := object.(*tektonv1.PipelineRun); ok {
+	pipelineRun, ok := object.(*tektonv1.PipelineRun)
+	if ok {
 		for _, pipelineResult := range pipelineRun.Status.Results {
-			if pipelineResult.Name == "IMAGE_URL" {
+			if pipelineResult.Name == PipelineRunImageUrlParamName {
 				return pipelineResult.Value.StringVal, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("couldn't find the output-image PipelineRun param")
+
+	return "", h.MissingInfoInPipelineRunError(pipelineRun.Name, PipelineRunImageUrlParamName)
 }
 
 // GetOutputImageDigest returns a string containing the IMAGE_DIGEST result value from a given PipelineRun.
 func GetOutputImageDigest(object client.Object) (string, error) {
-	if pipelineRun, ok := object.(*tektonv1.PipelineRun); ok {
+	pipelineRun, ok := object.(*tektonv1.PipelineRun)
+	if ok {
 		for _, pipelineResult := range pipelineRun.Status.Results {
-			if pipelineResult.Name == "IMAGE_DIGEST" {
+			if pipelineResult.Name == PipelineRunImageDigestParamName {
 				return pipelineResult.Value.StringVal, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("couldn't find the IMAGE_DIGEST TaskRun result")
+	return "", h.MissingInfoInPipelineRunError(pipelineRun.Name, PipelineRunImageDigestParamName)
 }
 
 // GetComponentSourceGitUrl returns a string containing the CHAINS-GIT_URL result value from a given PipelineRun.
 func GetComponentSourceGitUrl(object client.Object) (string, error) {
-	if pipelineRun, ok := object.(*tektonv1.PipelineRun); ok {
+	pipelineRun, ok := object.(*tektonv1.PipelineRun)
+	if ok {
 		for _, pipelineResult := range pipelineRun.Status.Results {
-			if pipelineResult.Name == "CHAINS-GIT_URL" {
+			if pipelineResult.Name == PipelineRunChainsGitUrlParamName {
 				return pipelineResult.Value.StringVal, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("couldn't find the CHAINS-GIT_URL PipelineRun result")
+	return "", h.MissingInfoInPipelineRunError(pipelineRun.Name, PipelineRunChainsGitUrlParamName)
 }
 
 // GetComponentSourceGitCommit returns a string containing the CHAINS-GIT_COMMIT result value from a given PipelineRun.
 func GetComponentSourceGitCommit(object client.Object) (string, error) {
-	if pipelineRun, ok := object.(*tektonv1.PipelineRun); ok {
+	pipelineRun, ok := object.(*tektonv1.PipelineRun)
+	if ok {
 		for _, pipelineResult := range pipelineRun.Status.Results {
-			if pipelineResult.Name == "CHAINS-GIT_COMMIT" {
+			if pipelineResult.Name == PipelineRunChainsGitCommitParamName {
 				return pipelineResult.Value.StringVal, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("couldn't find the CHAINS-GIT_COMMIT PipelineRun result")
+	return "", h.MissingInfoInPipelineRunError(pipelineRun.Name, PipelineRunChainsGitCommitParamName)
 }


### PR DESCRIPTION
## Fix [STONEINTG-709](https://issues.redhat.com/browse/STONEINTG-709)  , adding new error handler for the missing params error returned by build PipelineRun and stop the PLR  to be returned to the reconcile queue .

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
