### PR TITLE
fix(STONEINTG-742): don't trigger duplicated integration PLRs

### DIFF
--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -149,6 +149,10 @@ func (a *Adapter) EnsureRerunPipelineRunsExist() (controller.OperationResult, er
 		testStatuses.UpdateTestStatusIfChanged(
 			integrationTestScenario.Name, intgteststat.IntegrationTestStatusInProgress,
 			fmt.Sprintf("IntegrationTestScenario pipeline '%s' has been created", pipelineRun.Name))
+		if err = testStatuses.UpdateTestPipelineRunName(integrationTestScenario.Name, pipelineRun.Name); err != nil {
+			// it doesn't make sense to restart reconciliation here, it will be eventually updated by integrationpipeline adapter
+			a.logger.Error(err, "Failed to update pipelinerun name in test status")
+		}
 
 	}
 
@@ -230,6 +234,10 @@ func (a *Adapter) EnsureStaticIntegrationPipelineRunsExist() (controller.Operati
 				testStatuses.UpdateTestStatusIfChanged(
 					integrationTestScenario.Name, intgteststat.IntegrationTestStatusInProgress,
 					fmt.Sprintf("IntegrationTestScenario pipeline '%s' has been created", pipelineRun.Name))
+				if err = testStatuses.UpdateTestPipelineRunName(integrationTestScenario.Name, pipelineRun.Name); err != nil {
+					// it doesn't make sense to restart reconciliation here, it will be eventually updated by integrationpipeline adapter
+					a.logger.Error(err, "Failed to update pipelinerun name in test status")
+				}
 			}
 		}
 

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -1618,8 +1618,10 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 				statuses, err = gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(hasSnapshot)
 				Expect(err).To(Succeed())
-				_, ok = statuses.GetScenarioStatus(integrationTestScenarioWithoutEnv.Name)
+				detail, ok := statuses.GetScenarioStatus(integrationTestScenarioWithoutEnv.Name)
 				Expect(ok).To(BeTrue()) // test restarted has a status now
+				Expect(detail).ToNot(BeNil())
+				Expect(detail.TestPipelineRunName).ToNot(BeEmpty()) // must set PLR name to prevent creation of duplicated PLR
 
 				m := MatchKeys(IgnoreExtras, Keys{
 					gitops.SnapshotIntegrationTestRun: Equal(integrationTestScenarioWithoutEnv.Name),


### PR DESCRIPTION
Re-running test sceanrio was causing creation of duplicated PLR for integration test. Record PLR name into test status annotation immediatelly to prevent controller to create additional PLR.

Only scenarios in static environment were affected by this bug.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
