### PR TITLE
fix(RHTAPBUGS-1091): react to deleted running build PLR

### DIFF
--- a/controllers/buildpipeline/buildpipeline_adapter.go
+++ b/controllers/buildpipeline/buildpipeline_adapter.go
@@ -65,8 +65,9 @@ func NewAdapter(pipelineRun *tektonv1.PipelineRun, component *applicationapiv1al
 // to the build PipelineRun being processed exists. Otherwise, it will create a new pipeline Snapshot.
 func (a *Adapter) EnsureSnapshotExists() (controller.OperationResult, error) {
 	if !h.HasPipelineRunSucceeded(a.pipelineRun) {
-		if h.HasPipelineRunFinished(a.pipelineRun) {
+		if h.HasPipelineRunFinished(a.pipelineRun) || a.pipelineRun.GetDeletionTimestamp() != nil {
 			// The pipeline run  has failed
+			// OR pipeline has been deleted but it's still in running state (tekton bug/feature?)
 			return a.removeFinalizerAndContinueProcessing()
 		}
 		// The build pipeline run has not finished yet

--- a/controllers/buildpipeline/buildpipeline_controller.go
+++ b/controllers/buildpipeline/buildpipeline_controller.go
@@ -152,6 +152,8 @@ func setupControllerWithManager(manager ctrl.Manager, controller *Reconciler) er
 		WithEventFilter(predicate.Or(
 			tekton.BuildPipelineRunSignedAndSucceededPredicate(),
 			tekton.BuildPipelineRunFailedPredicate(),
-			tekton.BuildPipelineRunCreatedPredicate())).
+			tekton.BuildPipelineRunCreatedPredicate(),
+			tekton.BuildPipelineRunDeletingPredicate(),
+		)).
 		Complete(controller)
 }

--- a/tekton/predicates.go
+++ b/tekton/predicates.go
@@ -105,3 +105,23 @@ func BuildPipelineRunCreatedPredicate() predicate.Predicate {
 		},
 	}
 }
+
+// BuildPipelineRunDeletingPredicate returns a predicate which filters out all objects except
+// Build PipelineRuns which have been updated to deleting
+func BuildPipelineRunDeletingPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return IsBuildPipelineRun(e.ObjectNew) &&
+				hasPipelineRunStateChangedToDeleting(e.ObjectOld, e.ObjectNew)
+		},
+	}
+}

--- a/tekton/predicates_test.go
+++ b/tekton/predicates_test.go
@@ -368,4 +368,62 @@ var _ = Describe("Predicates", func() {
 			Expect(instance.Update(contextEvent)).To(BeFalse())
 		})
 	})
+
+	Context("when testing BuildPipelineRunDeletingPredicate", func() {
+		instance := tekton.BuildPipelineRunDeletingPredicate()
+
+		BeforeEach(func() {
+
+			pipelineRun = &tektonv1.PipelineRun{
+				ObjectMeta: v1.ObjectMeta{
+					GenerateName: prefix + "-",
+					Namespace:    namespace,
+					Labels: map[string]string{
+						"pipelines.appstudio.openshift.io/type": "build",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: tektonv1.PipelineRunSpec{},
+			}
+			newPipelineRun = pipelineRun.DeepCopy()
+		})
+
+		It("should ignore creation events", func() {
+			contextEvent := event.CreateEvent{
+				Object: pipelineRun,
+			}
+			Expect(instance.Create(contextEvent)).To(BeFalse())
+		})
+		It("should ignore deleting events", func() {
+			contextEvent := event.DeleteEvent{
+				Object: pipelineRun,
+			}
+			Expect(instance.Delete(contextEvent)).To(BeFalse())
+		})
+
+		It("should ignore generic events", func() {
+			contextEvent := event.GenericEvent{
+				Object: pipelineRun,
+			}
+			Expect(instance.Generic(contextEvent)).To(BeFalse())
+		})
+
+		It("should return false for an update event in which the build PLR has not been deleted", func() {
+			contextEvent := event.UpdateEvent{
+				ObjectOld: pipelineRun,
+				ObjectNew: newPipelineRun,
+			}
+			Expect(instance.Update(contextEvent)).To(BeFalse())
+		})
+
+		It("should return true for an update event marking build PLR for deletion", func() {
+			newPipelineRun.DeletionTimestamp = &v1.Time{Time: time.Now()}
+			contextEvent := event.UpdateEvent{
+				ObjectOld: pipelineRun,
+				ObjectNew: newPipelineRun,
+			}
+			Expect(instance.Update(contextEvent)).To(BeTrue())
+		})
+
+	})
 })


### PR DESCRIPTION
Tekton keeps deleting PLRs in running status. Integration-service must react to deletion event, even if PLR is still in running status to prevent blocking of deletion by removing finalizer.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
