### PR TITLE
refactor(MarkSnapshot*): don't return the same pointer

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -174,7 +174,7 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 		"message", snapshotErrorMessage)
 
 	if !gitops.IsSnapshotMarkedAsFailed(a.snapshot) {
-		_, err = gitops.MarkSnapshotAsFailed(a.client, a.context, a.snapshot, snapshotErrorMessage)
+		err = gitops.MarkSnapshotAsFailed(a.client, a.context, a.snapshot, snapshotErrorMessage)
 		if err != nil {
 			a.logger.Error(err, "Failed to Update Snapshot status")
 			return controller.RequeueWithError(err)
@@ -237,7 +237,7 @@ func (a *Adapter) createIntegrationPipelineRunWithEnvironment(application *appli
 	go metrics.RegisterNewIntegrationPipelineRun()
 
 	if gitops.IsSnapshotNotStarted(a.snapshot) {
-		_, err := gitops.MarkSnapshotIntegrationStatusAsInProgress(a.client, a.context, a.snapshot, "Snapshot starts being tested by the integrationPipelineRun")
+		err := gitops.MarkSnapshotIntegrationStatusAsInProgress(a.client, a.context, a.snapshot, "Snapshot starts being tested by the integrationPipelineRun")
 		if err != nil {
 			a.logger.Error(err, "Failed to update integration status condition to in progress for snapshot")
 		} else {

--- a/controllers/binding/snapshotenvironmentbinding_adapter_test.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Binding Adapter", Ordered, func() {
 			return err
 		}, time.Second*10).ShouldNot(HaveOccurred())
 
-		finishedSnapshot, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, finishedSnapshot, "Snapshot passed")
+		err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, finishedSnapshot, "Snapshot passed")
 		Expect(err == nil).To(BeTrue())
 		Expect(gitops.HaveAppStudioTestsFinished(finishedSnapshot)).To(BeTrue())
 	})

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -507,7 +507,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("ensures global Component Image will not be updated in the PR context", func() {
-			_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshotPR, "test passed")
+			err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshotPR, "test passed")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshotPR)).To(BeTrue())
 			adapter.snapshot = hasSnapshotPR
@@ -522,7 +522,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("no error from ensuring global Component Image updated when AppStudio Tests failed", func() {
-			_, err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+			err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 			adapter.snapshot = hasSnapshot
@@ -535,7 +535,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("ensures global Component Image updated when AppStudio Tests succeeded", func() {
-			_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 			adapter.snapshot = hasSnapshot
@@ -568,7 +568,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 
 			gitops.SetSnapshotIntegrationStatusAsFinished(hasSnapshot, "Snapshot integration status condition is finished since all testing pipelines completed")
-			_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsFinished(hasSnapshot)).To(BeTrue())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
@@ -654,9 +654,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 			// Set the snapshot up for failure by setting its status as failed and invalid
 			// as well as marking it as PaC pull request event type
-			updatedSnapshot, err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+			err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
 			Expect(err).ShouldNot(HaveOccurred())
-			gitops.SetSnapshotIntegrationStatusAsInvalid(updatedSnapshot, "snapshot invalid")
+			gitops.SetSnapshotIntegrationStatusAsInvalid(hasSnapshot, "snapshot invalid")
 			hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePullRequestType
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 			Expect(gitops.IsSnapshotValid(hasSnapshot)).To(BeFalse())
@@ -682,9 +682,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 			// Set the snapshot up for failure by setting its status as failed and invalid
 			// as well as marking it as PaC pull request event type
-			updatedSnapshot, err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+			err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
 			Expect(err).ShouldNot(HaveOccurred())
-			gitops.SetSnapshotIntegrationStatusAsInvalid(updatedSnapshot, "snapshot invalid")
+			gitops.SetSnapshotIntegrationStatusAsInvalid(hasSnapshot, "snapshot invalid")
 			hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePullRequestType
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 			Expect(gitops.IsSnapshotValid(hasSnapshot)).To(BeFalse())
@@ -708,7 +708,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		It("ensures snapshot environmentBinding exists", func() {
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 
-			_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 			Expect(err).To(Succeed())
 			hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePushType
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
@@ -798,7 +798,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				}
 				Expect(k8sClient.Create(ctx, hasBinding)).Should(Succeed())
 
-				_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+				err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 				Expect(err).To(Succeed())
 				hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePushType
 				Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
@@ -941,8 +941,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("Skip integration test for passed Snapshot", func() {
-			updatedSnapshot, _ := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test pass")
-			Expect(gitops.HaveAppStudioTestsSucceeded(updatedSnapshot)).To(BeTrue())
+			err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test pass")
+			Expect(err).To(Succeed())
+			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
@@ -973,7 +974,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 
 		BeforeAll(func() {
-			_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 		})
@@ -1159,9 +1160,10 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		It("Skip ephemeral env creation for passed Snapshot", func() {
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			updatedSnapshot, _ := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test pass")
-			Expect(gitops.HaveAppStudioTestsSucceeded(updatedSnapshot)).To(BeTrue())
-			adapter = NewAdapter(updatedSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test pass")
+			Expect(err).To((Succeed()))
+			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
+			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -1169,7 +1171,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				},
 				{
 					ContextKey: loader.SnapshotContextKey,
-					Resource:   updatedSnapshot,
+					Resource:   hasSnapshot,
 				},
 			})
 			result, err := adapter.EnsureCreationOfEphemeralEnvironments()

--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -106,7 +106,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		if errors.IsNotFound(err) {
 			if !gitops.IsSnapshotMarkedAsInvalid(snapshot) {
-				_, err := gitops.MarkSnapshotAsInvalid(r.Client, ctx, snapshot,
+				err := gitops.MarkSnapshotAsInvalid(r.Client, ctx, snapshot,
 					fmt.Sprintf("The application %s owning this snapshot doesn't exist, try again after creating application", snapshot.Spec.Application))
 				if err != nil {
 					logger.Error(err, "Failed to update the status to Invalid for the snapshot",

--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -162,7 +162,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 			a.logger.Info("The global component list has changed in the meantime, marking snapshot as Invalid",
 				"snapshot.Name", a.snapshot.Name)
 			if !gitops.IsSnapshotMarkedAsInvalid(a.snapshot) {
-				_, err = gitops.MarkSnapshotAsInvalid(a.client, a.context, a.snapshot,
+				err = gitops.MarkSnapshotAsInvalid(a.client, a.context, a.snapshot,
 					"The global component list has changed in the meantime, superseding with a composite snapshot")
 				if err != nil {
 					a.logger.Error(err, "Failed to update the status to Invalid for the snapshot",
@@ -180,7 +180,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 	// This updates the Snapshot resource on the cluster
 	if allIntegrationTestsPassed {
 		if !gitops.IsSnapshotMarkedAsPassed(a.snapshot) {
-			a.snapshot, err = gitops.MarkSnapshotAsPassed(a.client, a.context, a.snapshot, "All Integration Pipeline tests passed")
+			err = gitops.MarkSnapshotAsPassed(a.client, a.context, a.snapshot, "All Integration Pipeline tests passed")
 			if err != nil {
 				a.logger.Error(err, "Failed to Update Snapshot AppStudioTestSucceeded status")
 				return controller.RequeueWithError(err)
@@ -190,7 +190,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 		}
 	} else {
 		if !gitops.IsSnapshotMarkedAsFailed(a.snapshot) {
-			a.snapshot, err = gitops.MarkSnapshotAsFailed(a.client, a.context, a.snapshot, "Some Integration pipeline tests failed")
+			err = gitops.MarkSnapshotAsFailed(a.client, a.context, a.snapshot, "Some Integration pipeline tests failed")
 			if err != nil {
 				a.logger.Error(err, "Failed to Update Snapshot AppStudioTestSucceeded status")
 				return controller.RequeueWithError(err)

--- a/gitops/binding_test.go
+++ b/gitops/binding_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures Binding Component is created", func() {
-		_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 		bindingComponents := gitops.NewBindingComponents(hasSnapshot)

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -189,7 +189,7 @@ func IsSnapshotMarkedAsPassed(snapshot *applicationapiv1alpha1.Snapshot) bool {
 
 // MarkSnapshotAsPassed updates the AppStudio Test succeeded condition for the Snapshot to passed.
 // If the patch command fails, an error will be returned.
-func MarkSnapshotAsPassed(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
+func MarkSnapshotAsPassed(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	condition := metav1.Condition{
 		Type:    AppStudioTestSucceededCondition,
@@ -201,12 +201,12 @@ func MarkSnapshotAsPassed(adapterClient client.Client, ctx context.Context, snap
 
 	err := adapterClient.Status().Patch(ctx, snapshot, patch)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	snapshotCompletionTime := &metav1.Time{Time: time.Now()}
 	go metrics.RegisterCompletedSnapshot(condition.Type, condition.Reason, snapshot.GetCreationTimestamp(), snapshotCompletionTime)
-	return snapshot, nil
+	return nil
 }
 
 // IsSnapshotMarkedAsFailed returns true if snapshot is marked as failed
@@ -216,7 +216,7 @@ func IsSnapshotMarkedAsFailed(snapshot *applicationapiv1alpha1.Snapshot) bool {
 
 // MarkSnapshotAsFailed updates the AppStudio Test succeeded condition for the Snapshot to failed.
 // If the patch command fails, an error will be returned.
-func MarkSnapshotAsFailed(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
+func MarkSnapshotAsFailed(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	condition := metav1.Condition{
 		Type:    AppStudioTestSucceededCondition,
@@ -228,25 +228,25 @@ func MarkSnapshotAsFailed(adapterClient client.Client, ctx context.Context, snap
 
 	err := adapterClient.Status().Patch(ctx, snapshot, patch)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	snapshotCompletionTime := &metav1.Time{Time: time.Now()}
 	go metrics.RegisterCompletedSnapshot(condition.Type, condition.Reason, snapshot.GetCreationTimestamp(), snapshotCompletionTime)
-	return snapshot, nil
+	return nil
 }
 
 // MarkSnapshotAsInvalid updates the AppStudio integration status condition for the Snapshot to invalid.
 // If the patch command fails, an error will be returned.
-func MarkSnapshotAsInvalid(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
+func MarkSnapshotAsInvalid(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	SetSnapshotIntegrationStatusAsInvalid(snapshot, message)
 	err := adapterClient.Status().Patch(ctx, snapshot, patch)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return snapshot, nil
+	return nil
 }
 
 // IsSnapshotMarkedAsInvalid returns true if snapshot is marked as failed
@@ -278,7 +278,7 @@ func SetSnapshotIntegrationStatusAsError(snapshot *applicationapiv1alpha1.Snapsh
 }
 
 // MarkSnapshotIntegrationStatusAsInProgress sets the AppStudio integration status condition for the Snapshot to In Progress.
-func MarkSnapshotIntegrationStatusAsInProgress(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
+func MarkSnapshotIntegrationStatusAsInProgress(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	meta.SetStatusCondition(&snapshot.Status.Conditions, metav1.Condition{
 		Type:    AppStudioIntegrationStatusCondition,
@@ -288,7 +288,7 @@ func MarkSnapshotIntegrationStatusAsInProgress(adapterClient client.Client, ctx 
 	})
 	err := adapterClient.Status().Patch(ctx, snapshot, patch)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	snapshotInProgressTime := &metav1.Time{Time: time.Now()}
@@ -300,7 +300,7 @@ func MarkSnapshotIntegrationStatusAsInProgress(adapterClient client.Client, ctx 
 
 		go metrics.RegisterIntegrationResponse(*buildPipelineRunFinishTimeMeta, snapshotInProgressTime)
 	}
-	return snapshot, nil
+	return nil
 }
 
 // PrepareToRegisterIntegrationPipelineRunStarted is to do preparation before calling RegisterPipelineRunStarted
@@ -382,7 +382,7 @@ func IsSnapshotMarkedAsDeployedToRootEnvironments(snapshot *applicationapiv1alph
 
 // MarkSnapshotAsDeployedToRootEnvironments updates the SnapshotDeployedToRootEnvironmentsCondition for the Snapshot to 'Deployed'.
 // If the patch command fails, an error will be returned.
-func MarkSnapshotAsDeployedToRootEnvironments(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
+func MarkSnapshotAsDeployedToRootEnvironments(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	condition := metav1.Condition{
 		Type:    SnapshotDeployedToRootEnvironmentsCondition,
@@ -394,9 +394,9 @@ func MarkSnapshotAsDeployedToRootEnvironments(adapterClient client.Client, ctx c
 
 	err := adapterClient.Status().Patch(ctx, snapshot, patch)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return snapshot, nil
+	return nil
 }
 
 // IsSnapshotMarkedAsAutoReleased returns true if snapshot is marked as deployed to root environments
@@ -406,7 +406,7 @@ func IsSnapshotMarkedAsAutoReleased(snapshot *applicationapiv1alpha1.Snapshot) b
 
 // MarkSnapshotAsAutoReleased updates the SnapshotAutoReleasedCondition for the Snapshot to 'AutoReleased'.
 // If the patch command fails, an error will be returned.
-func MarkSnapshotAsAutoReleased(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
+func MarkSnapshotAsAutoReleased(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	condition := metav1.Condition{
 		Type:    SnapshotAutoReleasedCondition,
@@ -418,10 +418,10 @@ func MarkSnapshotAsAutoReleased(adapterClient client.Client, ctx context.Context
 
 	err := adapterClient.Status().Patch(ctx, snapshot, patch)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return snapshot, nil
+	return nil
 }
 
 // IsSnapshotMarkedAsAddedToGlobalCandidateList returns true if snapshot's component is marked as added to global candidate list
@@ -431,7 +431,7 @@ func IsSnapshotMarkedAsAddedToGlobalCandidateList(snapshot *applicationapiv1alph
 
 // MarkSnapshotAsAddedToGlobalCandidateList updates the SnapshotAddedToGlobalCandidateListCondition for the Snapshot to true with reason 'Added'.
 // If the patch command fails, an error will be returned.
-func MarkSnapshotAsAddedToGlobalCandidateList(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) (*applicationapiv1alpha1.Snapshot, error) {
+func MarkSnapshotAsAddedToGlobalCandidateList(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	condition := metav1.Condition{
 		Type:    SnapshotAddedToGlobalCandidateListCondition,
@@ -443,10 +443,10 @@ func MarkSnapshotAsAddedToGlobalCandidateList(adapterClient client.Client, ctx c
 
 	err := adapterClient.Status().Patch(ctx, snapshot, patch)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return snapshot, nil
+	return nil
 }
 
 // ValidateImageDigest checks if image url contains valid digest, return error if check fails

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -155,12 +155,11 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures the Snapshots status can be marked as passed", func() {
-		updatedSnapshot, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
-		Expect(updatedSnapshot).NotTo(BeNil())
-		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
-		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.AppStudioTestSucceededCondition)).To(BeTrue())
-		Expect(gitops.IsSnapshotMarkedAsPassed(updatedSnapshot)).To(BeTrue())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
+		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.AppStudioTestSucceededCondition)).To(BeTrue())
+		Expect(gitops.IsSnapshotMarkedAsPassed(hasSnapshot)).To(BeTrue())
 	})
 
 	It("ensures the Snapshots LegacyTestSucceededCondition status can be marked as passed", func() {
@@ -202,17 +201,15 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures the Snapshots status can be marked as failed", func() {
-		updatedSnapshot, err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
-		Expect(updatedSnapshot).NotTo(BeNil())
-		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
-		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.AppStudioTestSucceededCondition)).To(BeFalse())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
+		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.AppStudioTestSucceededCondition)).To(BeFalse())
 		Expect(gitops.IsSnapshotMarkedAsFailed(hasSnapshot)).To(BeTrue())
 	})
 
 	It("ensures the Snapshots status can be marked as error", func() {
 		gitops.SetSnapshotIntegrationStatusAsError(hasSnapshot, "Test message")
-		Expect(hasSnapshot).NotTo(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.AppStudioIntegrationStatusCondition)).To(BeFalse())
 		Expect(gitops.IsSnapshotError(hasSnapshot)).To(BeTrue())
@@ -227,63 +224,58 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures the Snapshots status can be marked as in progress", func() {
-		updatedSnapshot, err := gitops.MarkSnapshotIntegrationStatusAsInProgress(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotIntegrationStatusAsInProgress(k8sClient, ctx, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
-		Expect(updatedSnapshot).NotTo(BeNil())
-		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
-		foundStatusCondition := meta.FindStatusCondition(updatedSnapshot.Status.Conditions, gitops.AppStudioIntegrationStatusCondition)
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
+		foundStatusCondition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.AppStudioIntegrationStatusCondition)
 		Expect(foundStatusCondition.Reason).To(Equal(gitops.AppStudioIntegrationStatusInProgress))
 	})
 
 	It("ensures the Snapshots status can be marked as invalid", func() {
-		updatedSnapshot, err := gitops.MarkSnapshotAsInvalid(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsInvalid(k8sClient, ctx, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
-		Expect(updatedSnapshot).NotTo(BeNil())
-		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
-		Expect(meta.IsStatusConditionTrue(updatedSnapshot.Status.Conditions, gitops.AppStudioIntegrationStatusCondition)).To(BeFalse())
-		Expect(gitops.IsSnapshotMarkedAsPassed(updatedSnapshot)).To(BeFalse())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
+		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.AppStudioIntegrationStatusCondition)).To(BeFalse())
+		Expect(gitops.IsSnapshotMarkedAsPassed(hasSnapshot)).To(BeFalse())
 	})
 
 	It("ensures the Snapshots status can be marked as auto released", func() {
 		Expect(gitops.IsSnapshotMarkedAsAutoReleased(hasSnapshot)).To(BeFalse())
 
-		updatedSnapshot, err := gitops.MarkSnapshotAsAutoReleased(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsAutoReleased(k8sClient, ctx, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
-		Expect(updatedSnapshot).NotTo(BeNil())
-		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
-		foundStatusCondition := meta.FindStatusCondition(updatedSnapshot.Status.Conditions, gitops.SnapshotAutoReleasedCondition)
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
+		foundStatusCondition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.SnapshotAutoReleasedCondition)
 		Expect(foundStatusCondition.Status).To(Equal(metav1.ConditionTrue))
 		Expect(foundStatusCondition.Message).To(Equal("Test message"))
 
-		Expect(gitops.IsSnapshotMarkedAsAutoReleased(updatedSnapshot)).To(BeTrue())
+		Expect(gitops.IsSnapshotMarkedAsAutoReleased(hasSnapshot)).To(BeTrue())
 	})
 
 	It("ensures the Snapshots status can be marked as deployed to root environments", func() {
 		Expect(gitops.IsSnapshotMarkedAsDeployedToRootEnvironments(hasSnapshot)).To(BeFalse())
 
-		updatedSnapshot, err := gitops.MarkSnapshotAsDeployedToRootEnvironments(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsDeployedToRootEnvironments(k8sClient, ctx, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
-		Expect(updatedSnapshot).NotTo(BeNil())
-		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
-		foundStatusCondition := meta.FindStatusCondition(updatedSnapshot.Status.Conditions, gitops.SnapshotDeployedToRootEnvironmentsCondition)
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
+		foundStatusCondition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.SnapshotDeployedToRootEnvironmentsCondition)
 		Expect(foundStatusCondition.Status).To(Equal(metav1.ConditionTrue))
 		Expect(foundStatusCondition.Message).To(Equal("Test message"))
 
-		Expect(gitops.IsSnapshotMarkedAsDeployedToRootEnvironments(updatedSnapshot)).To(BeTrue())
+		Expect(gitops.IsSnapshotMarkedAsDeployedToRootEnvironments(hasSnapshot)).To(BeTrue())
 	})
 
 	It("ensures the Snapshots status can be marked as component added to global candidate list", func() {
 		Expect(gitops.IsSnapshotMarkedAsAddedToGlobalCandidateList(hasSnapshot)).To(BeFalse())
 
-		updatedSnapshot, err := gitops.MarkSnapshotAsAddedToGlobalCandidateList(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsAddedToGlobalCandidateList(k8sClient, ctx, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
-		Expect(updatedSnapshot).NotTo(BeNil())
-		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
-		foundStatusCondition := meta.FindStatusCondition(updatedSnapshot.Status.Conditions, gitops.SnapshotAddedToGlobalCandidateListCondition)
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
+		foundStatusCondition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.SnapshotAddedToGlobalCandidateListCondition)
 		Expect(foundStatusCondition.Status).To(Equal(metav1.ConditionTrue))
 		Expect(foundStatusCondition.Message).To(Equal("Test message"))
 
-		Expect(gitops.IsSnapshotMarkedAsAddedToGlobalCandidateList(updatedSnapshot)).To(BeTrue())
+		Expect(gitops.IsSnapshotMarkedAsAddedToGlobalCandidateList(hasSnapshot)).To(BeTrue())
 	})
 
 	It("ensures the Snapshots can be checked for the AppStudioTestSucceededCondition", func() {
@@ -393,7 +385,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 	It("ensures the Snapshots status can be reset", func() {
 		gitops.SetSnapshotIntegrationStatusAsFinished(hasSnapshot, "Test message")
-		_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(gitops.HaveAppStudioTestsFinished(hasSnapshot)).To(BeTrue())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
@@ -408,12 +400,11 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(hasSnapshot).NotTo(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 
-		updatedSnapshot, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
-		Expect(updatedSnapshot).NotTo(BeNil())
-		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 
-		canBePromoted, reasons := gitops.CanSnapshotBePromoted(updatedSnapshot)
+		canBePromoted, reasons := gitops.CanSnapshotBePromoted(hasSnapshot)
 		Expect(canBePromoted).To(BeTrue())
 		Expect(reasons).To(BeEmpty())
 	})
@@ -423,22 +414,21 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(hasSnapshot).NotTo(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 
-		updatedSnapshot, err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
-		Expect(updatedSnapshot).NotTo(BeNil())
-		Expect(updatedSnapshot.Status.Conditions).NotTo(BeNil())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 
-		canBePromoted, reasons := gitops.CanSnapshotBePromoted(updatedSnapshot)
+		canBePromoted, reasons := gitops.CanSnapshotBePromoted(hasSnapshot)
 		Expect(canBePromoted).To(BeFalse())
 		Expect(reasons).To(HaveLen(1))
 
-		updatedSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePullRequestType
-		canBePromoted, reasons = gitops.CanSnapshotBePromoted(updatedSnapshot)
+		hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePullRequestType
+		canBePromoted, reasons = gitops.CanSnapshotBePromoted(hasSnapshot)
 		Expect(canBePromoted).To(BeFalse())
 		Expect(reasons).To(HaveLen(2))
 
-		gitops.SetSnapshotIntegrationStatusAsInvalid(updatedSnapshot, "Test message")
-		canBePromoted, reasons = gitops.CanSnapshotBePromoted(updatedSnapshot)
+		gitops.SetSnapshotIntegrationStatusAsInvalid(hasSnapshot, "Test message")
+		canBePromoted, reasons = gitops.CanSnapshotBePromoted(hasSnapshot)
 		Expect(canBePromoted).To(BeFalse())
 		Expect(reasons).To(HaveLen(3))
 	})

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -715,7 +715,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		_, err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 	})
@@ -752,7 +752,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		_, err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 	})
@@ -774,7 +774,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		_, err = gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+		err = gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 	})
@@ -811,7 +811,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		_, err = gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+		err = gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 	})
@@ -891,7 +891,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		_, err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 	})

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -463,7 +463,7 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(k8sClient).NotTo(BeNil())
 		Expect(ctx).NotTo(BeNil())
 		Expect(hasSnapshot).NotTo(BeNil())
-		_, err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 


### PR DESCRIPTION
MarkSnapshot* functiond were returning the same pointer as they received in snapshot paramter. There is no need to return pointer if we pass pointer as paramereter.

Given the pointer was returned it could puzzle devs to expect that it's a newly allocated memory instead. This old-new pointer was even used inconsistently in code, it's just safer to remove it and make clear that original pointer is being used for data updates.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
