### PR TITLE
fix(STONEINTG-751): don't auth when there is nothing to report

### DIFF
--- a/status/reporters.go
+++ b/status/reporters.go
@@ -674,6 +674,13 @@ func (r *GitHubReporter) ReportStatusForSnapshot(k8sClient client.Client, ctx co
 		return err
 	}
 
+	if len(statuses.GetStatuses()) == 0 {
+		// no tests to report, skip
+		logger.Info("No test result to report to GitHub, skipping",
+			"snapshot.Namespace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return nil
+	}
+
 	labels := snapshot.GetLabels()
 
 	owner, found := labels[gitops.PipelineAsCodeURLOrgLabel]

--- a/status/reporters_test.go
+++ b/status/reporters_test.go
@@ -529,6 +529,7 @@ var _ = Describe("GitHubReporter", func() {
 
 		It("doesn't report status when the credentials are invalid/missing", func() {
 			// Invalid installation ID value
+			hasSnapshot.Annotations["test.appstudio.openshift.io/status"] = "[{\"scenario\":\"scenario1\",\"status\":\"Pending\",\"lastUpdateTime\":\"2023-07-26T16:57:49+02:00\",\"details\":\"pending\"}]"
 			hasSnapshot.Annotations["pac.test.appstudio.openshift.io/installation-id"] = "bad-installation-id"
 			err := reporter.ReportStatusForSnapshot(mockK8sClient, context.TODO(), &logger, hasSnapshot)
 			Expect(err).ToNot(BeNil())
@@ -550,6 +551,12 @@ var _ = Describe("GitHubReporter", func() {
 			delete(secretData, "github-private-key")
 			err = reporter.ReportStatusForSnapshot(mockK8sClient, context.TODO(), &logger, hasSnapshot)
 			Expect(err).ToNot(BeNil())
+		})
+
+		It("doesn't report status when there are no tests", func() {
+			err := reporter.ReportStatusForSnapshot(mockK8sClient, context.TODO(), &logger, hasSnapshot)
+			Expect(err).To(Succeed())
+			Expect(mockGitHubClient.UpdateCheckRunResult.cra).To(BeNil())
 		})
 
 		It("reports snapshot tests status via CheckRuns", func() {


### PR DESCRIPTION
When we have nothing to report, we should avoid to waste resources, mainly authentication to github API.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
