### PR TITLE
feat(STONE-734): stop reconcilation for not found applicaiton

### DIFF
--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tekton
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	h "github.com/redhat-appstudio/integration-service/helpers"
+	"github.com/redhat-appstudio/operator-toolkit/metadata"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AnnotateBuildPipelineRun sets annotation for a build pipelineRun in defined context and returns that pipeline
+func AnnotateBuildPipelineRun(ctx context.Context, pipelineRun *tektonv1.PipelineRun, key, value string, cl client.Client) (*tektonv1.PipelineRun, error) {
+	patch := client.MergeFrom(pipelineRun.DeepCopy())
+
+	_ = metadata.SetAnnotation(&pipelineRun.ObjectMeta, key, value)
+
+	err := cl.Patch(ctx, pipelineRun, patch)
+	if err != nil {
+		return pipelineRun, err
+	}
+	return pipelineRun, nil
+}
+
+// AnnotateBuildPipelineRunWithCreateSnapshotAnnotation sets annotation test.appstudio.openshift.io/create-snapshot-status to build pipelineRun with
+// a message that reflects either success or failure for creating a snapshot
+func AnnotateBuildPipelineRunWithCreateSnapshotAnnotation(ctx context.Context, pipelineRun *tektonv1.PipelineRun, cl client.Client, ensureSnapshotExistsErr error) error {
+	message := ""
+	status := ""
+	if ensureSnapshotExistsErr == nil {
+		message = fmt.Sprintf("Sucessfully created snapshot. See annotation %s for name", SnapshotNameLabel)
+		status = "success"
+	} else {
+		message = fmt.Sprintf("Failed to create snapshot. Error: %s", ensureSnapshotExistsErr.Error())
+		status = "failed"
+	}
+
+	jsonResult, err := json.Marshal(map[string]string{
+		"status":  status,
+		"message": message,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = AnnotateBuildPipelineRun(ctx, pipelineRun, h.CreateSnapshotAnnotationName, string(jsonResult), cl)
+	return err
+}


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
