### PR TITLE
chore(RHTAPWATCH-729): get namespace release snapshots

### DIFF
--- a/cmd/snapshotgc/snapshotgc.go
+++ b/cmd/snapshotgc/snapshotgc.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	utilruntime.Must(applicationapiv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(releasev1alpha1.AddToScheme(scheme))
+}
+
+// Stores pointers to resources to which the snapshot is associated
+type snapshotData struct {
+	// environmentBinding applicationapiv1alpha1.SnapshotEnvironmentBinding
+	release releasev1alpha1.Release
+}
+
+// Gets a map to allow to tell with direct lookup if a snapshot is associated with
+// a release resource
+func getSnapshotsForNSReleases(
+	cl client.Client,
+	snapToData map[string]snapshotData,
+	namespace string,
+	logger logr.Logger,
+) (map[string]snapshotData, error) {
+	releases := &releasev1alpha1.ReleaseList{}
+	err := cl.List(
+		context.Background(),
+		releases,
+		&client.ListOptions{Namespace: namespace},
+	)
+	if err != nil {
+		logger.Error(err, "Failed to list releases")
+		return nil, err
+	}
+
+	for _, release := range releases.Items {
+		data, ok := snapToData[release.Spec.Snapshot]
+		if !ok {
+			data = snapshotData{}
+		}
+		data.release = release
+		snapToData[release.Spec.Snapshot] = data
+	}
+	return snapToData, nil
+}

--- a/cmd/snapshotgc/snapshotgc_suite_test.go
+++ b/cmd/snapshotgc/snapshotgc_suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSnapshotgc(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Snapshotgc Test Suite")
+}

--- a/cmd/snapshotgc/snapshotgc_test.go
+++ b/cmd/snapshotgc/snapshotgc_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Test garbage collection for snapshots", func() {
+	var logger logr.Logger
+
+	BeforeEach(func() {
+		zapLog, err := zap.NewDevelopment()
+		if err != nil {
+			panic(fmt.Sprintf("who watches the watchmen (%v)?", err))
+		}
+		logger = zapr.NewLogger(zapLog)
+	})
+
+	Describe("Test getSnapshotsForNSReleases", func() {
+		It("Finds no snapshot when there are no releases", func() {
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithLists(
+					&releasev1alpha1.ReleaseList{
+						Items: []releasev1alpha1.Release{},
+					}).Build()
+			snapToData := make(map[string]snapshotData)
+			output, err := getSnapshotsForNSReleases(cl, snapToData, "ns1", logger)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(output).To(BeEmpty())
+		})
+
+		It("Finds a snapshot for a single release", func() {
+			rel1 := &releasev1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-release",
+					Namespace: "ns1",
+				},
+				Spec: releasev1alpha1.ReleaseSpec{
+					Snapshot: "my-snapshot",
+				},
+			}
+			rel2 := &releasev1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "another-ns-release",
+					Namespace: "another-ns",
+				},
+				Spec: releasev1alpha1.ReleaseSpec{
+					Snapshot: "another-snapshot",
+				},
+			}
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithLists(
+					&releasev1alpha1.ReleaseList{
+						Items: []releasev1alpha1.Release{*rel1, *rel2},
+					}).Build()
+			snapToData := make(map[string]snapshotData)
+			output, err := getSnapshotsForNSReleases(cl, snapToData, "ns1", logger)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(output).To(HaveLen(1))
+			Expect(output["my-snapshot"].release.Name).To(Equal("my-release"))
+		})
+
+		It("Finds multiple snapshots for multiple releases", func() {
+			rel1 := &releasev1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rel1",
+					Namespace: "ns1",
+				},
+				Spec: releasev1alpha1.ReleaseSpec{
+					Snapshot: "snap1",
+				},
+			}
+			rel2 := &releasev1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rel2",
+					Namespace: "ns1",
+				},
+				Spec: releasev1alpha1.ReleaseSpec{
+					Snapshot: "snap2",
+				},
+			}
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithLists(
+					&releasev1alpha1.ReleaseList{
+						Items: []releasev1alpha1.Release{*rel1, *rel2},
+					}).Build()
+			snapToData := make(map[string]snapshotData)
+			output, err := getSnapshotsForNSReleases(cl, snapToData, "ns1", logger)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(output).To(HaveLen(2))
+			Expect(output["snap1"].release.Name).To(Equal("rel1"))
+			Expect(output["snap2"].release.Name).To(Equal("rel2"))
+		})
+
+		It("Returns error when fails API call", func() {
+			cl := fake.NewClientBuilder().Build()
+			snapToData := make(map[string]snapshotData)
+			_, err := getSnapshotsForNSReleases(cl, snapToData, "ns1", logger)
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(
+				"no kind is registered for the type v1alpha1.ReleaseList in scheme",
+			)))
+		})
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.9.0
 	github.com/go-logr/logr v1.4.1
+	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-containerregistry v0.18.0
 	github.com/google/go-github/v45 v45.2.0
 	github.com/onsi/ginkgo/v2 v2.15.0
@@ -38,11 +39,11 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.8.0 h1:lRj6N9Nci7MvzrXuX6HFzU8XjmhPiXPlsKEy1u0KQro=
 github.com/evanphx/json-patch/v5 v5.8.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=


### PR DESCRIPTION
Find all snapshots that are part of a release

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
