### PR TITLE
chore(RHTAPWATCH-729): get namespace Bindings snapshots

### DIFF
--- a/cmd/snapshotgc/snapshotgc_test.go
+++ b/cmd/snapshotgc/snapshotgc_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/zapr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -117,6 +118,105 @@ var _ = Describe("Test garbage collection for snapshots", func() {
 			Expect(err).Should(HaveOccurred())
 			Expect(err).To(MatchError(ContainSubstring(
 				"no kind is registered for the type v1alpha1.ReleaseList in scheme",
+			)))
+		})
+	})
+
+	Describe("Test getSnapshotsForNSBindings", func() {
+		It("Finds no snapshot when there are no bindings", func() {
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithLists(
+					&applicationapiv1alpha1.SnapshotEnvironmentBindingList{
+						Items: []applicationapiv1alpha1.SnapshotEnvironmentBinding{},
+					}).Build()
+			snapToData := make(map[string]snapshotData)
+			output, err := getSnapshotsForNSBindings(cl, snapToData, "ns1", logger)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(output).To(BeEmpty())
+		})
+
+		It("Finds a snapshot for a single binding", func() {
+			bind1 := &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-binding",
+					Namespace: "ns1",
+				},
+				Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+					Snapshot: "my-snapshot",
+				},
+			}
+			bind2 := &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "another-ns-binding",
+					Namespace: "another-ns",
+				},
+				Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+					Snapshot: "another-snapshot",
+				},
+			}
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithLists(
+					&applicationapiv1alpha1.SnapshotEnvironmentBindingList{
+						Items: []applicationapiv1alpha1.SnapshotEnvironmentBinding{*bind1, *bind2},
+					}).Build()
+			snapToData := make(map[string]snapshotData)
+			output, err := getSnapshotsForNSBindings(cl, snapToData, "ns1", logger)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(output).To(HaveLen(1))
+			Expect(output["my-snapshot"].environmentBinding.Name).To(Equal("my-binding"))
+		})
+
+		It("Finds multiple snapshots for multiple bindings", func() {
+			bind1 := &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind1",
+					Namespace: "ns1",
+				},
+				Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+					Snapshot: "snap1",
+				},
+			}
+			bind2 := &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind2",
+					Namespace: "ns1",
+				},
+				Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+					Snapshot: "snap2",
+				},
+			}
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithLists(
+					&applicationapiv1alpha1.SnapshotEnvironmentBindingList{
+						Items: []applicationapiv1alpha1.SnapshotEnvironmentBinding{*bind1, *bind2},
+					}).Build()
+			snapToData := make(map[string]snapshotData)
+			output, err := getSnapshotsForNSBindings(cl, snapToData, "ns1", logger)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(output).To(HaveLen(2))
+			Expect(output["snap1"].environmentBinding.Name).To(Equal("bind1"))
+			Expect(output["snap2"].environmentBinding.Name).To(Equal("bind2"))
+		})
+
+		It("Returns error when fails API call", func() {
+
+			cl := fake.NewClientBuilder().Build()
+			snapToData := make(map[string]snapshotData)
+			_, err := getSnapshotsForNSBindings(cl, snapToData, "ns1", logger)
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(
+				"no kind is registered for the type " +
+					"v1alpha1.SnapshotEnvironmentBindingList in scheme",
 			)))
 		})
 	})


### PR DESCRIPTION
Find all snapshots that are part of a SnapshotEnvironmentBinding

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
