### PR TITLE
chore(RHTAPWATCH-732): delete garbage collected snapshots

### DIFF
--- a/cmd/snapshotgc/snapshotgc.go
+++ b/cmd/snapshotgc/snapshotgc.go
@@ -167,3 +167,18 @@ func getSnapshotsForRemoval(
 	}
 	return shortList
 }
+
+// Delete snapshots determined to be garbage-collected
+func deleteSnapshots(
+	cl client.Client,
+	snapshots []applicationapiv1alpha1.Snapshot,
+	logger logr.Logger,
+) {
+
+	for _, snap := range snapshots {
+		err := cl.Delete(context.Background(), &snap)
+		if err != nil {
+			logger.Error(err, "Failed to delete snapshot")
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.9.0
 	github.com/go-logr/logr v1.4.1
-	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-containerregistry v0.19.0
 	github.com/google/go-github/v45 v45.2.0
 	github.com/onsi/ginkgo/v2 v2.15.0
@@ -44,6 +43,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect


### PR DESCRIPTION
Delete the snapshots that are on the list of snapshots to be garbage-collected.

Also changed the logging implementation in tests to use a buffer to
allow verifying a couple of things using the logs.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
