### PR TITLE
chore(worklfows): remove docker build

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -132,18 +132,6 @@ jobs:
           make test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
-
-  docker:
-    name: Check docker build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check if dockerimage build is working
-        run: docker build -f ./Dockerfile .
-
   gitlint:
     name: Run gitlint checks
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This is a duplicated workflow, we are testing builds using konflux, we don't need this workflow

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
