### PR TITLE
fix(STONEINTG-779): fixes for annotating build PLR

### DIFF
--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -451,6 +451,10 @@ func RemoveFinalizerFromAllIntegrationPipelineRunsOfSnapshot(adapterClient clien
 // RemoveFinalizerFromPipelineRun removes the finalizer from the PipelineRun.
 // If finalizer was not removed successfully, a non-nil error is returned.
 func RemoveFinalizerFromPipelineRun(adapterClient client.Client, logger IntegrationLogger, ctx context.Context, pipelineRun *tektonv1.PipelineRun, finalizer string) error {
+	if !controllerutil.ContainsFinalizer(pipelineRun, finalizer) {
+		return nil
+	}
+
 	patch := client.MergeFrom(pipelineRun.DeepCopy())
 	if ok := controllerutil.RemoveFinalizer(pipelineRun, finalizer); ok {
 		err := adapterClient.Patch(ctx, pipelineRun, patch)

--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -46,6 +46,10 @@ func AnnotateBuildPipelineRunWithCreateSnapshotAnnotation(ctx context.Context, p
 	message := ""
 	status := ""
 	if ensureSnapshotExistsErr == nil {
+		if !metadata.HasAnnotation(pipelineRun, SnapshotNameLabel) {
+			// do nothing for in progress build PLR
+			return nil
+		}
 		message = fmt.Sprintf("Sucessfully created snapshot. See annotation %s for name", SnapshotNameLabel)
 		status = "success"
 	} else {


### PR DESCRIPTION
* remove finalizer after annotating build PLR
* annotate build PLR with successful only when the real snapshot is created
* requeue when failing to annotate build PLR or remove finalizer
* a few other small fixes

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
