### PR TITLE
fix(STONEINTG-752): don't reconcile unnecessary Integration PLRs

### DIFF
--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -274,8 +274,8 @@ func (ipro *IntegrationPipelineRunOutcome) LogResults(logger logr.Logger) {
 	}
 }
 
-// GetIntegrationPipelineRunOutcome returns the IntegrationPipelineRunOutcome which can be used for further inspection of
-// the results and general outcome
+// GetIntegrationPipelineRunOutcome returns the IntegrationPipelineRunOutcome
+// which can be used for further inspection of the results and general outcome
 // This function must be called on the finished pipeline
 func GetIntegrationPipelineRunOutcome(adapterClient client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*IntegrationPipelineRunOutcome, error) {
 
@@ -353,6 +353,25 @@ func GetAllChildTaskRunsForPipelineRun(adapterClient client.Client, ctx context.
 		taskRuns = append(taskRuns, integrationTaskRun)
 	}
 	sort.Sort(SortTaskRunsByStartTime(taskRuns))
+	return taskRuns, nil
+}
+
+// GetAllTaskRunsWithMatchingPipelineLabel finds all Child TaskRuns
+// whose "tekton.dev/pipeline" label points to the given PipelineRun
+func GetAllTaskRunsWithMatchingPipelineLabel(adapterClient client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*tektonv1.TaskRunList, error) {
+	taskRuns := &tektonv1.TaskRunList{}
+	opts := []client.ListOption{
+		client.InNamespace(pipelineRun.Namespace),
+		client.MatchingLabels{
+			"tekton.dev/pipeline": pipelineRun.Name,
+		},
+	}
+
+	err := adapterClient.List(ctx, taskRuns, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	return taskRuns, nil
 }
 

--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -356,25 +356,6 @@ func GetAllChildTaskRunsForPipelineRun(adapterClient client.Client, ctx context.
 	return taskRuns, nil
 }
 
-// GetAllTaskRunsWithMatchingPipelineLabel finds all Child TaskRuns
-// whose "tekton.dev/pipeline" label points to the given PipelineRun
-func GetAllTaskRunsWithMatchingPipelineLabel(adapterClient client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*tektonv1.TaskRunList, error) {
-	taskRuns := &tektonv1.TaskRunList{}
-	opts := []client.ListOption{
-		client.InNamespace(pipelineRun.Namespace),
-		client.MatchingLabels{
-			"tekton.dev/pipeline": pipelineRun.Name,
-		},
-	}
-
-	err := adapterClient.List(ctx, taskRuns, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return taskRuns, nil
-}
-
 // HasPipelineRunSucceeded returns a boolean indicating whether the PipelineRun succeeded or not.
 // If the object passed to this function is not a PipelineRun, the function will return false.
 func HasPipelineRunSucceeded(object client.Object) bool {

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -53,6 +53,7 @@ const (
 	GetScenarioContextKey
 	AllEnvironmentsForScenarioContextKey
 	AllSnapshotsForBuildPipelineRunContextKey
+	AllTaskRunsWithMatchingPipelineLabelContextKey
 )
 
 func NewMockLoader() ObjectLoader {
@@ -252,4 +253,12 @@ func (l *mockLoader) GetAllSnapshotsForBuildPipelineRun(c client.Client, ctx con
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllSnapshotsForBuildPipelineRunContextKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
+}
+
+func (l *mockLoader) GetAllTaskRunsWithMatchingPipelineLabel(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*[]tektonv1.TaskRun, error) {
+	if ctx.Value(AllTaskRunsWithMatchingPipelineLabelContextKey) == nil {
+		return l.loader.GetAllTaskRunsWithMatchingPipelineLabel(c, ctx, pipelineRun)
+	}
+	taskRuns, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllTaskRunsWithMatchingPipelineLabelContextKey, []tektonv1.TaskRun{})
+	return &taskRuns, err
 }

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -365,4 +365,19 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Context("When calling GetAllTaskRunsWithMatchingPipelineLabel", func() {
+		It("returns TaskRuns and error from the context", func() {
+			taskRuns := []tektonv1.TaskRun{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: AllTaskRunsWithMatchingPipelineLabelContextKey,
+					Resource:   taskRuns,
+				},
+			})
+			resource, err := loader.GetAllTaskRunsWithMatchingPipelineLabel(nil, mockContext, nil)
+			Expect(resource).To(Equal(&taskRuns))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })


### PR DESCRIPTION
* Currently, we are processing Intg PLRs that are already finished, are marked for deletion, and don't contain a finalizer.
* This causes a problem when a user deletes the TaskRun(s) of this PLR, and then deletes it.
* Because our service tries to reconcile it as it just got marked for deletion. And then hits this bug when we aren't able to fetch all/some of its TaskRuns.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
