### PR TITLE
fix(STONEINTG-687): stop reconciliation when app is not found

### DIFF
--- a/controllers/component/component_controller.go
+++ b/controllers/component/component_controller.go
@@ -76,9 +76,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				return ctrl.Result{}, err
 			}
 		}
-		logger.Error(err, "Failed to get Application from the component",
-			"Component.Name", component.Name)
-		return ctrl.Result{}, err
+		return helpers.HandleLoaderError(logger, err, "Application", "Component")
 	}
 
 	if application == nil {

--- a/controllers/component/component_controller_test.go
+++ b/controllers/component/component_controller_test.go
@@ -121,12 +121,12 @@ var _ = Describe("ComponentController", func() {
 		}).Should(BeNil())
 	})
 
-	It("can fail when Reconcile fails to prepare the adapter when Application is not found", func() {
+	It("Should stop Reconciliation when Application is not found", func() {
 		Expect(k8sClient.Delete(ctx, hasApp)).Should(Succeed())
 		Eventually(func() error {
 			_, err := componentReconciler.Reconcile(ctx, req)
 			return err
-		}).ShouldNot(BeNil())
+		}).Should(BeNil())
 	})
 
 	It("can Reconcile function prepare the adapter and return the result of the reconcile handling operation", func() {


### PR DESCRIPTION
When application was removed, we cannot do much and should stop reconciliation instead of retrying indefinitely.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
