### PR TITLE
chore: add red-hat-konflux to gitlint ignore list

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -14,4 +14,4 @@ line-length=72
 [contrib-title-conventional-commits]
 
 [ignore-by-author-name]
-regex=((.*dependabot.*)|(.*rhtap.*)|(red-hat-trusted-app-pipeline))
+regex=((.*dependabot.*)|(red-hat-konflux))


### PR DESCRIPTION
The user for Konflux reference updates has changed and is now failing gitlint checks. See #553 

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
