### PR TITLE
fix(STONEINTG-798): use labels to find Snapshots for build pipelineRun

### DIFF
--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -52,6 +52,7 @@ const (
 	AutoReleasePlansContextKey
 	GetScenarioContextKey
 	AllEnvironmentsForScenarioContextKey
+	AllSnapshotsForBuildPipelineRunContextKey
 )
 
 func NewMockLoader() ObjectLoader {
@@ -243,4 +244,12 @@ func (l *mockLoader) GetAllEnvironmentsForScenario(c client.Client, ctx context.
 	}
 	environments, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllEnvironmentsForScenarioContextKey, []applicationapiv1alpha1.Environment{})
 	return &environments, err
+}
+
+func (l *mockLoader) GetAllSnapshotsForBuildPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*[]applicationapiv1alpha1.Snapshot, error) {
+	if ctx.Value(AllSnapshotsForBuildPipelineRunContextKey) == nil {
+		return l.loader.GetAllSnapshotsForBuildPipelineRun(c, ctx, pipelineRun)
+	}
+	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllSnapshotsForBuildPipelineRunContextKey, []applicationapiv1alpha1.Snapshot{})
+	return &snapshots, err
 }

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -186,6 +186,21 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		})
 	})
 
+	Context("When calling GetAllSnapshotsForBuildPipelineRun", func() {
+		It("returns resource and error from the context", func() {
+			snapshots := []applicationapiv1alpha1.Snapshot{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: AllSnapshotsForBuildPipelineRunContextKey,
+					Resource:   snapshots,
+				},
+			})
+			resource, err := loader.GetAllSnapshotsForBuildPipelineRun(nil, mockContext, nil)
+			Expect(resource).To(Equal(&snapshots))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("When calling FindAvailableDeploymentTargetClass", func() {
 		It("returns deploymentTargetClassre source and error from the context", func() {
 			dtcls := &applicationapiv1alpha1.DeploymentTargetClass{}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -103,8 +103,9 @@ var _ = Describe("Loader", Ordered, func() {
 				Name:      snapshotName,
 				Namespace: "default",
 				Labels: map[string]string{
-					gitops.SnapshotTypeLabel:      "component",
-					gitops.SnapshotComponentLabel: "component-sample",
+					gitops.SnapshotTypeLabel:         "component",
+					gitops.SnapshotComponentLabel:    "component-sample",
+					gitops.BuildPipelineRunNameLabel: "pipelinerun-sample",
 				},
 				Annotations: map[string]string{
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
@@ -532,6 +533,14 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(snapshot.ObjectMeta).To(Equal(hasSnapshot.ObjectMeta))
 	})
 
+	It("ensures we can get the Snapshot from a Pipeline Run", func() {
+		snapshots, err := loader.GetAllSnapshotsForBuildPipelineRun(k8sClient, ctx, buildPipelineRun)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(snapshots).NotTo(BeNil())
+		Expect(*snapshots).To(HaveLen(1))
+		Expect((*snapshots)[0].Name).To(Equal(hasSnapshot.Name))
+	})
+
 	It("ensures we can get the Environment from a Pipeline Run", func() {
 		env, err := loader.GetEnvironmentFromIntegrationPipelineRun(k8sClient, ctx, buildPipelineRun)
 		Expect(err).To(BeNil())
@@ -606,6 +615,13 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(err).To(BeNil())
 		Expect(gottenReleasePlanItems).NotTo(BeNil())
 
+	})
+
+	It("can get all environments for integrationTestScenario", func() {
+		environments, err := loader.GetAllEnvironmentsForScenario(k8sClient, ctx, integrationTestScenario)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*environments).To(HaveLen(1))
+		Expect((*environments)[0].Name).To(Equal(hasEnv.Name))
 	})
 
 	It("can get all environments for integrationTestScenario", func() {

--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -28,16 +28,16 @@ import (
 )
 
 // AnnotateBuildPipelineRun sets annotation for a build pipelineRun in defined context and returns that pipeline
-func AnnotateBuildPipelineRun(ctx context.Context, pipelineRun *tektonv1.PipelineRun, key, value string, cl client.Client) (*tektonv1.PipelineRun, error) {
+func AnnotateBuildPipelineRun(ctx context.Context, pipelineRun *tektonv1.PipelineRun, key, value string, cl client.Client) error {
 	patch := client.MergeFrom(pipelineRun.DeepCopy())
 
 	_ = metadata.SetAnnotation(&pipelineRun.ObjectMeta, key, value)
 
 	err := cl.Patch(ctx, pipelineRun, patch)
 	if err != nil {
-		return pipelineRun, err
+		return err
 	}
-	return pipelineRun, nil
+	return nil
 }
 
 // AnnotateBuildPipelineRunWithCreateSnapshotAnnotation sets annotation test.appstudio.openshift.io/create-snapshot-status to build pipelineRun with
@@ -64,6 +64,6 @@ func AnnotateBuildPipelineRunWithCreateSnapshotAnnotation(ctx context.Context, p
 	if err != nil {
 		return err
 	}
-	_, err = AnnotateBuildPipelineRun(ctx, pipelineRun, h.CreateSnapshotAnnotationName, string(jsonResult), cl)
+	err = AnnotateBuildPipelineRun(ctx, pipelineRun, h.CreateSnapshotAnnotationName, string(jsonResult), cl)
 	return err
 }


### PR DESCRIPTION
* Stop finding matching Snapshots by comparing the contents of existing ones when determining if a new Snapshot needs to be created for a given build pipelineRun
* Switch to using the Snapshot annotation on the build pipelineRun, and also attempt to find Snapshots that are labeled for that PLR as a backup
* Add GetAllSnapshotsForBuildPipelineRun loader function to facilitate the above

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
