### PR TITLE
fix(metrics): add more buckets into response metric

### DIFF
--- a/metrics/integration.go
+++ b/metrics/integration.go
@@ -29,7 +29,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "integration_svc_response_seconds",
 			Help:    "Integration service response time from the moment the buildPipelineRun is completed till the snapshot is marked as in progress status",
-			Buckets: []float64{0.5, 1, 2, 3, 4, 5, 6, 7, 10, 15, 30},
+			Buckets: []float64{0.5, 1, 2, 3, 4, 5, 6, 7, 10, 15, 30, 60, 120, 240},
 		},
 	)
 


### PR DESCRIPTION
We are often hit bucket 30 seconds, we need more datapoints to see, how much over 30 we are actually with reponse.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
