### PR TITLE
chore(RHTAPWATCH-778): add snapshotgc cronjob

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -25,3 +25,6 @@ resources:
 - prometheus_service_account.yaml
 - prometheus_viewer_role.yaml
 - prometheus_role_binding.yaml
+
+# Snapshot garbage collector
+- snapshotgc_rbac.yaml

--- a/config/rbac/snapshotgc_rbac.yaml
+++ b/config/rbac/snapshotgc_rbac.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-garbage-collector
+  namespace: system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-garbage-collector
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - releases
+  - snapshotenvironmentbindings
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - snapshots
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: snapshot-garbage-collector
+subjects:
+- kind: ServiceAccount
+  name: snapshot-garbage-collector
+  namespace: system
+roleRef:
+  kind: ClusterRole
+  name: snapshot-garbage-collector
+  apiGroup: rbac.authorization.k8s.io

--- a/config/snapshotgc/kustomization.yaml
+++ b/config/snapshotgc/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- snapshotgc.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+namePrefix: integration-service-

--- a/config/snapshotgc/snapshotgc.yaml
+++ b/config/snapshotgc/snapshotgc.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: snapshot-garbage-collector
+spec:
+  schedule: "0 5 * * *" # every day at 5AM UTC
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: test-gc
+              image: >-
+                quay.io/redhat-appstudio/integration-service:latest
+              command:
+                - /snapshotgc
+                - --zap-log-level=debug
+                - --pr-snapshots-to-keep=100
+                - --non-pr-snapshots-to-keep=700
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 1000m
+                  memory: 500Mi
+                limits:
+                  cpu: 1000m
+                  memory: 500Mi
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+          restartPolicy: Never
+          serviceAccountName: snapshot-garbage-collector


### PR DESCRIPTION
Adding a cronjob and associated rbac resources for running the snapshots garbage collector

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
