### PR TITLE
fix(STONEINTG-751): add backoff threshold for GH authentication

### DIFF
--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -1145,7 +1145,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			// Set snapshot creation time to 3 hours ago
 			// time.Sub takes a time.Time and returns a time.Duration.  Time.Add takes a time.Duration
 			// and returns a time.Time.  Why?  Who knows.  We want the latter, so we add -3 hours here
-			hasSnapshot.CreationTimestamp = metav1.NewTime(time.Now().Add(-1 * RetryReleaseTimeout))
+			hasSnapshot.CreationTimestamp = metav1.NewTime(time.Now().Add(-1 * SnapshotRetryTimeout))
 
 			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
 			testErr := fmt.Errorf("something went wrong with the release")

--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/redhat-appstudio/integration-service/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"sort"
 	"time"
@@ -545,4 +546,11 @@ func AddFinalizerToScenario(adapterClient client.Client, logger IntegrationLogge
 	}
 
 	return nil
+}
+
+func IsObjectYoungerThanThreshold(obj metav1.Object, threshold time.Duration) bool {
+	objectCreationTime := obj.GetCreationTimestamp().Time
+	durationSinceObjectCreation := time.Since(objectCreationTime)
+
+	return durationSinceObjectCreation < threshold
 }

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -1072,4 +1072,15 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		logEntry = "Removed Finalizer from the Component"
 		Expect(buf.String()).Should(ContainSubstring(logEntry))
 	})
+
+	It("Returns RequeueWithError if the object is less than timeout threshold", func() {
+		hasCompTimeout := time.Duration(3 * time.Hour)
+
+		result := helpers.IsObjectYoungerThanThreshold(hasComp, hasCompTimeout)
+		Expect(result).To(BeTrue())
+		hasComp.CreationTimestamp = metav1.NewTime(time.Now().Add(-1 * hasCompTimeout))
+		result = helpers.IsObjectYoungerThanThreshold(hasComp, hasCompTimeout)
+		Expect(result).To(BeFalse())
+	})
+
 })


### PR DESCRIPTION

Adds a backoff timer to continue reconciliation when auth fails for github status reporting. Will allow reconciliation to continue without extraneous error logging after threshold reached.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
