### PR TITLE
fix(STONEINTG-776): [unit-test] point the Snapshot to a non-existent Application

### DIFF
--- a/controllers/snapshot/snapshot_controller_test.go
+++ b/controllers/snapshot/snapshot_controller_test.go
@@ -194,15 +194,8 @@ var _ = Describe("SnapshotController", func() {
 	})
 
 	It("Does not return an error if the application cannot be found", func() {
-		err := k8sClient.Delete(ctx, hasApp)
-		Eventually(func() bool {
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Namespace: hasApp.ObjectMeta.Namespace,
-				Name:      hasApp.ObjectMeta.Name,
-			}, hasApp)
-			return err != nil
-		}).Should(BeTrue())
-		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		hasSnapshot.Spec.Application = string("im-a-ghost")
+		Expect(k8sClient.Update(ctx, hasSnapshot)).Should(Succeed())
 
 		result, err := snapshotReconciler.Reconcile(ctx, req)
 		Expect(result).To(Equal(ctrl.Result{}))


### PR DESCRIPTION
Before this commit:

* Currently, this unit test fails intermittently because it first deletes the Application and then reconciles the related Snapshot, in the hope that the controller will stop the reconciliation because of the missing App and mark the Snapshot as Invalid.
* But since, when the App gets deleted, Snapshot also gets queued for deletion. So, this introduces a race condition where we're trying to reconcile a Snapshot, that's marked for deletion, hoping it gets successfully reconciled before the deletion.

After this commit:

* Instead of deleting the App and reconciling the Snapshot, we are pointing the Snapshot to a non-existent App to replicate the same behaviour.
* This eliminates the race condition.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
