### PR TITLE
STONEINTG-769: Add GitLab commit status updates for integration tests

### DIFF
--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -19,21 +19,21 @@ package statusreport
 import (
 	"context"
 	"fmt"
-	"github.com/redhat-appstudio/integration-service/api/v1beta1"
-	"github.com/redhat-appstudio/integration-service/gitops"
-	"github.com/redhat-appstudio/integration-service/metrics"
-	"github.com/redhat-appstudio/operator-toolkit/metadata"
-	"k8s.io/client-go/util/retry"
 	"time"
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/operator-toolkit/controller"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redhat-appstudio/integration-service/api/v1beta1"
+	"github.com/redhat-appstudio/integration-service/gitops"
 	"github.com/redhat-appstudio/integration-service/helpers"
+	"github.com/redhat-appstudio/integration-service/loader"
+	"github.com/redhat-appstudio/integration-service/metrics"
 	intgteststat "github.com/redhat-appstudio/integration-service/pkg/integrationteststatus"
 	"github.com/redhat-appstudio/integration-service/status"
-
-	"github.com/redhat-appstudio/integration-service/loader"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/redhat-appstudio/operator-toolkit/metadata"
 )
 
 const SnapshotRetryTimeout = time.Duration(3 * time.Hour)
@@ -63,9 +63,9 @@ func NewAdapter(snapshot *applicationapiv1alpha1.Snapshot, application *applicat
 	}
 }
 
-// EnsureSnapshotTestStatusReportedToGitHub will ensure that integration test status including env provision and snapshotEnvironmentBinding error is reported to the git provider
+// EnsureSnapshotTestStatusReportedToGitProvider will ensure that integration test status including env provision and snapshotEnvironmentBinding error is reported to the git provider
 // which (indirectly) triggered its execution.
-func (a *Adapter) EnsureSnapshotTestStatusReportedToGitHub() (controller.OperationResult, error) {
+func (a *Adapter) EnsureSnapshotTestStatusReportedToGitProvider() (controller.OperationResult, error) {
 	if !gitops.IsSnapshotCreatedByPACPullRequestEvent(a.snapshot) {
 		return controller.ContinueProcessing()
 	}
@@ -79,7 +79,7 @@ func (a *Adapter) EnsureSnapshotTestStatusReportedToGitHub() (controller.Operati
 
 	err := a.status.ReportSnapshotStatus(a.context, reporter, a.snapshot)
 	if err != nil {
-		a.logger.Error(err, "failed to report test status to github for snapshot",
+		a.logger.Error(err, "failed to report test status to git provider for snapshot",
 			"snapshot.Namespace", a.snapshot.Namespace, "snapshot.Name", a.snapshot.Name)
 		if helpers.IsObjectYoungerThanThreshold(a.snapshot, SnapshotRetryTimeout) {
 			return controller.RequeueWithError(err)

--- a/controllers/statusreport/statusreport_adapter_test.go
+++ b/controllers/statusreport/statusreport_adapter_test.go
@@ -271,7 +271,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					Resource:   hasPRSnapshot,
 				},
 			})
-			result, err := adapter.EnsureSnapshotTestStatusReportedToGitHub()
+			result, err := adapter.EnsureSnapshotTestStatusReportedToGitProvider()
 			fmt.Fprintf(GinkgoWriter, "-------err: %v\n", err)
 			fmt.Fprintf(GinkgoWriter, "-------result: %v\n", result)
 			Expect(!result.CancelRequest && err == nil).To(BeTrue())

--- a/controllers/statusreport/statusreport_controller.go
+++ b/controllers/statusreport/statusreport_controller.go
@@ -89,7 +89,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	adapter := NewAdapter(snapshot, application, logger, loader, r.Client, ctx)
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureSnapshotFinishedAllTests,
-		adapter.EnsureSnapshotTestStatusReportedToGitHub,
+		adapter.EnsureSnapshotTestStatusReportedToGitProvider,
 	})
 }
 

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -102,6 +102,9 @@ const (
 	// PipelineAsCodePullRequestAnnotation is the git repository's pull request identifier
 	PipelineAsCodePullRequestAnnotation = PipelinesAsCodePrefix + "/pull-request"
 
+	// PipelineAsCodeSourceProjectIDAnnotation is the source project ID for gitlab
+	PipelineAsCodeSourceProjectIDAnnotation = PipelinesAsCodePrefix + "/source-project-id"
+
 	// PipelineAsCodePushType is the type of push event which triggered the pipelinerun in build service
 	PipelineAsCodePushType = "push"
 
@@ -110,6 +113,9 @@ const (
 
 	// PipelineAsCodeGitHubProviderType is the git provider type for a GitHub event which triggered the pipelinerun in build service.
 	PipelineAsCodeGitHubProviderType = "github"
+
+	// PipelineAsCodeGitHubProviderType is the git provider type for a GitHub event which triggered the pipelinerun in build service.
+	PipelineAsCodeGitLabProviderType = "gitlab"
 
 	//AppStudioTestSucceededCondition is the condition for marking if the AppStudio Tests succeeded for the Snapshot.
 	AppStudioTestSucceededCondition = "AppStudioTestSucceeded"

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/tektoncd/pipeline v0.57.0
 	github.com/tonglil/buflogr v1.1.1
+	github.com/xanzy/go-gitlab v0.97.0
 	go.uber.org/mock v0.4.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/oauth2 v0.17.0
@@ -63,6 +64,8 @@ require (
 	github.com/google/pprof v0.0.0-20230510103437-eeec1cb781c3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,7 +204,13 @@ github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4G
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
+github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
@@ -338,6 +344,8 @@ github.com/tektoncd/pipeline v0.57.0 h1:Fh+yGFLxOpUlLpDSH12CrJ9ePhvrZ4VL2XgZ4Oj7
 github.com/tektoncd/pipeline v0.57.0/go.mod h1:35+CiX43gZBEnGOtPNN1O2pCmCR2QTPZ0S3x/VEJmmE=
 github.com/tonglil/buflogr v1.1.1 h1:CKAjOHBSMmgbRFxpn/RhQHPj5oANc7ekhlsoUDvcZIg=
 github.com/tonglil/buflogr v1.1.1/go.mod h1:WLLtPRLqcFYWQLbA+ytXy5WrFTYnfA+beg1MpvJCxm4=
+github.com/xanzy/go-gitlab v0.97.0 h1:StMqJ1Kvt00X43pYIBBjj52dFlghwSeBhRDRfzaZ7xY=
+github.com/xanzy/go-gitlab v0.97.0/go.mod h1:ETg8tcj4OhrB84UEgeE8dSuV/0h4BBL1uOV/qK0vlyI=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/operator-toolkit/metadata"
+	gitlab "github.com/xanzy/go-gitlab"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redhat-appstudio/integration-service/gitops"
+	intgteststat "github.com/redhat-appstudio/integration-service/pkg/integrationteststatus"
+)
+
+type GitLabReporter struct {
+	logger    *logr.Logger
+	k8sClient client.Client
+	client    *gitlab.Client
+	sha       string
+	projectID int
+}
+
+func NewGitLabReporter(logger logr.Logger, k8sClient client.Client) *GitLabReporter {
+	return &GitLabReporter{
+		logger:    &logger,
+		k8sClient: k8sClient,
+	}
+}
+
+// check if interface has been correctly implemented
+var _ ReporterInterface = (*GitLabReporter)(nil)
+
+// Detect if snapshot has been created from gitlab provider
+func (r *GitLabReporter) Detect(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	return metadata.HasLabelWithValue(snapshot, gitops.PipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeGitLabProviderType)
+}
+
+// GetReporterName returns the reporter name
+func (r *GitLabReporter) GetReporterName() string {
+	return "GitlabReporter"
+}
+
+// Initialize initializes gitlab reporter
+func (r *GitLabReporter) Initialize(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) error {
+	token, err := GetPACGitProviderToken(ctx, r.k8sClient, snapshot)
+	if err != nil {
+		r.logger.Error(err, "failed to get token from snapshot",
+			"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return fmt.Errorf("failed to get PAC token for gitlab provider: %w", err)
+	}
+
+	annotations := snapshot.GetAnnotations()
+	repoUrl, ok := annotations[gitops.PipelineAsCodeRepoURLAnnotation]
+	if !ok {
+		return fmt.Errorf("failed to get value of %s annotation from the snapshot %s", gitops.PipelineAsCodeRepoURLAnnotation, snapshot.Name)
+	}
+
+	burl, err := url.Parse(repoUrl)
+	if err != nil {
+		return fmt.Errorf("failed to parse repo-url: %w", err)
+	}
+	apiURL := fmt.Sprintf("%s://%s", burl.Scheme, burl.Host)
+
+	r.client, err = gitlab.NewClient(token, gitlab.WithBaseURL(apiURL))
+	if err != nil {
+		return fmt.Errorf("failed to create gitlab client: %w", err)
+	}
+
+	labels := snapshot.GetLabels()
+	sha, found := labels[gitops.PipelineAsCodeSHALabel]
+	if !found {
+		return fmt.Errorf("sha label not found %q", gitops.PipelineAsCodeSHALabel)
+	}
+	r.sha = sha
+
+	projectIDstr, found := annotations[gitops.PipelineAsCodeSourceProjectIDAnnotation]
+	if !found {
+		return fmt.Errorf("project ID label not found %q", gitops.PipelineAsCodeSourceProjectIDAnnotation)
+	}
+
+	r.projectID, err = strconv.Atoi(projectIDstr)
+	if err != nil {
+		return fmt.Errorf("failed to convert project ID '%s' to integer: %w", projectIDstr, err)
+	}
+
+	return nil
+}
+
+// setCommitStatus sets commit status to be shown as pipeline run in gitlab view
+func (r *GitLabReporter) setCommitStatus(report TestReport) error {
+
+	glState, err := GenerateGitlabCommitState(report.Status)
+	if err != nil {
+		return fmt.Errorf("failed to generate gitlab state: %w", err)
+	}
+
+	opt := gitlab.SetCommitStatusOptions{
+		State:       gitlab.BuildStateValue(glState),
+		Name:        gitlab.Ptr(report.FullName),
+		Description: gitlab.Ptr(report.Summary),
+	}
+
+	r.logger.Info("creating commit status for scenario test status of snapshot",
+		"scenarioName", report.ScenarioName)
+
+	commitStatus, _, err := r.client.Commits.SetCommitStatus(r.projectID, r.sha, &opt)
+	if err != nil {
+		return fmt.Errorf("failed to set commit status: %w", err)
+	}
+
+	r.logger.Info("Created gitlab commit status", "scenario.name", report.ScenarioName, "commitStatus.ID", commitStatus.ID)
+	return nil
+}
+
+// ReportStatus reports test result to gitlab
+func (r *GitLabReporter) ReportStatus(ctx context.Context, report TestReport) error {
+	if r.client == nil {
+		return fmt.Errorf("gitlab reporter is not initialized")
+	}
+
+	if err := r.setCommitStatus(report); err != nil {
+		return fmt.Errorf("failed to set gitlab commit status: %w", err)
+	}
+
+	return nil
+}
+
+// GenerateGitlabCommitState transforms internal integration test state into Gitlab state
+func GenerateGitlabCommitState(state intgteststat.IntegrationTestStatus) (gitlab.BuildStateValue, error) {
+	glState := gitlab.Failed
+
+	switch state {
+	case intgteststat.IntegrationTestStatusPending:
+		glState = gitlab.Pending
+	case intgteststat.IntegrationTestStatusInProgress:
+		glState = gitlab.Running
+	case intgteststat.IntegrationTestStatusEnvironmentProvisionError,
+		intgteststat.IntegrationTestStatusDeploymentError,
+		intgteststat.IntegrationTestStatusTestInvalid:
+		glState = gitlab.Failed
+	case intgteststat.IntegrationTestStatusDeleted:
+		glState = gitlab.Canceled
+	case intgteststat.IntegrationTestStatusTestPassed:
+		glState = gitlab.Success
+	case intgteststat.IntegrationTestStatusTestFail:
+		glState = gitlab.Failed
+	default:
+		return glState, fmt.Errorf("unknown status %s", state)
+	}
+
+	return glState, nil
+}

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/tonglil/buflogr"
+	gitlab "github.com/xanzy/go-gitlab"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redhat-appstudio/integration-service/gitops"
+	"github.com/redhat-appstudio/integration-service/pkg/integrationteststatus"
+	"github.com/redhat-appstudio/integration-service/status"
+)
+
+var _ = Describe("GitLabReporter", func() {
+
+	const (
+		repoUrl   = "https://gitlab.com/example/example"
+		digest    = "12a4a35ccd08194595179815e4646c3a6c08bb77"
+		projectID = "123"
+	)
+
+	var (
+		hasSnapshot   *applicationapiv1alpha1.Snapshot
+		mockK8sClient *MockK8sClient
+		buf           bytes.Buffer
+		log           logr.Logger
+	)
+
+	BeforeEach(func() {
+		log = buflogr.NewWithBuffer(&buf)
+
+		hasSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/type":               "component",
+					"appstudio.openshift.io/component":               "component-sample",
+					"build.appstudio.redhat.com/pipeline":            "enterprise-contract",
+					"pac.test.appstudio.openshift.io/git-provider":   "gitlab",
+					"pac.test.appstudio.openshift.io/url-org":        "devfile-sample",
+					"pac.test.appstudio.openshift.io/url-repository": "devfile-sample-go-basic",
+					"pac.test.appstudio.openshift.io/sha":            "12a4a35ccd08194595179815e4646c3a6c08bb77",
+					"pac.test.appstudio.openshift.io/event-type":     "Merge Request",
+				},
+				Annotations: map[string]string{
+					"build.appstudio.redhat.com/commit_sha":             digest,
+					"appstudio.redhat.com/updateComponentOnSuccess":     "false",
+					"pac.test.appstudio.openshift.io/repo-url":          repoUrl,
+					"pac.test.appstudio.openshift.io/source-project-id": projectID,
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: "application-sample",
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "component-sample",
+						ContainerImage: "sample_image",
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{
+									Revision: "sample_revision",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+	})
+
+	It("Reporter can return name uninitialized", func() {
+		reporter := status.NewGitLabReporter(log, mockK8sClient)
+		Expect(reporter.GetReporterName()).To(Equal("GitlabReporter"))
+	})
+
+	It("can detect if gitlab reporter should be used", func() {
+		reporter := status.NewGitLabReporter(log, mockK8sClient)
+		hasSnapshot.Labels["pac.test.appstudio.openshift.io/git-provider"] = "gitlab"
+		Expect(reporter.Detect(hasSnapshot)).To(BeTrue())
+
+		hasSnapshot.Labels["pac.test.appstudio.openshift.io/git-provider"] = "not-gitlab"
+		Expect(reporter.Detect(hasSnapshot)).To(BeFalse())
+	})
+
+	Context("when provided Gitlab webhook integration credentials", func() {
+
+		var (
+			secretData    map[string][]byte
+			repo          pacv1alpha1.Repository
+			reporter      *status.GitLabReporter
+			defaultAPIURL = "/api/v4"
+			mux           *http.ServeMux
+			server        *httptest.Server
+		)
+
+		BeforeEach(func() {
+			mux = http.NewServeMux()
+			apiHandler := http.NewServeMux()
+			apiHandler.Handle(defaultAPIURL+"/", http.StripPrefix(defaultAPIURL, mux))
+
+			// server is a test HTTP server used to provide mock API responses
+			server = httptest.NewServer(apiHandler)
+
+			// mock URL with httptest server URL
+			hasSnapshot.Annotations[gitops.PipelineAsCodeRepoURLAnnotation] = server.URL
+
+			repo = pacv1alpha1.Repository{
+				Spec: pacv1alpha1.RepositorySpec{
+					URL: server.URL, // mocked URL
+					GitProvider: &pacv1alpha1.GitProvider{
+						Secret: &pacv1alpha1.Secret{
+							Name: "example-secret-name",
+							Key:  "example-token",
+						},
+					},
+				},
+			}
+
+			mockK8sClient = &MockK8sClient{
+				getInterceptor: func(key client.ObjectKey, obj client.Object) {
+					if secret, ok := obj.(*v1.Secret); ok {
+						secret.Data = secretData
+					}
+				},
+				listInterceptor: func(list client.ObjectList) {
+					if repoList, ok := list.(*pacv1alpha1.RepositoryList); ok {
+						repoList.Items = []pacv1alpha1.Repository{repo}
+					}
+				},
+			}
+
+			secretData = map[string][]byte{
+				"example-token": []byte("example-personal-access-token"),
+			}
+
+			reporter = status.NewGitLabReporter(log, mockK8sClient)
+
+			err := reporter.Initialize(context.TODO(), hasSnapshot)
+			Expect(err).To(Succeed())
+
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		DescribeTable("test handling of missing labels/annotations", func(missingKey string, isLabel bool) {
+			if isLabel {
+				delete(hasSnapshot.Labels, missingKey)
+			} else {
+				delete(hasSnapshot.Annotations, missingKey)
+			}
+			Expect(reporter.Initialize(context.TODO(), hasSnapshot)).ToNot(Succeed())
+		},
+			Entry("Missing repo_url", gitops.PipelineAsCodeRepoURLAnnotation, false),
+			Entry("Missing SHA", gitops.PipelineAsCodeSHALabel, true),
+			Entry("Missing project ID", gitops.PipelineAsCodeSourceProjectIDAnnotation, false),
+		)
+
+		It("creates a commit status for snapshot with correct textual data", func() {
+
+			summary := "Integration test for snapshot snapshot-sample and scenario scenario1 failed"
+
+			muxCommitStatusPost(mux, projectID, digest, summary)
+
+			Expect(reporter.ReportStatus(
+				context.TODO(),
+				status.TestReport{
+					FullName:     "fullname/scenario1",
+					ScenarioName: "scenario1",
+					Status:       integrationteststatus.IntegrationTestStatusEnvironmentProvisionError,
+					Summary:      summary,
+					Text:         "detailed text here",
+				})).To(Succeed())
+		})
+
+	})
+
+	Describe("Test helper functions", func() {
+
+		DescribeTable(
+			"reports correct gitlab statuses from test statuses",
+			func(teststatus integrationteststatus.IntegrationTestStatus, glState gitlab.BuildStateValue) {
+
+				state, err := status.GenerateGitlabCommitState(teststatus)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(state).To(Equal(glState))
+			},
+			Entry("Provision error", integrationteststatus.IntegrationTestStatusEnvironmentProvisionError, gitlab.Failed),
+			Entry("Deployment error", integrationteststatus.IntegrationTestStatusDeploymentError, gitlab.Failed),
+			Entry("Deleted", integrationteststatus.IntegrationTestStatusDeleted, gitlab.Canceled),
+			Entry("Success", integrationteststatus.IntegrationTestStatusTestPassed, gitlab.Success),
+			Entry("Test failure", integrationteststatus.IntegrationTestStatusTestFail, gitlab.Failed),
+			Entry("In progress", integrationteststatus.IntegrationTestStatusInProgress, gitlab.Running),
+			Entry("Pending", integrationteststatus.IntegrationTestStatusPending, gitlab.Pending),
+			Entry("Invalid", integrationteststatus.IntegrationTestStatusTestInvalid, gitlab.Failed),
+		)
+
+		It("check if all integration tests statuses are supported", func() {
+			for _, teststatus := range integrationteststatus.IntegrationTestStatusValues() {
+				_, err := status.GenerateGitlabCommitState(teststatus)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	})
+})
+
+// muxCommitStatusPost mocks commit status POST request, if catchStr is non-empty POST request must contain such substring
+func muxCommitStatusPost(mux *http.ServeMux, pid string, sha string, catchStr string) {
+	path := fmt.Sprintf("/projects/%s/statuses/%s", pid, sha)
+	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+		bit, _ := io.ReadAll(r.Body)
+		s := string(bit)
+		if catchStr != "" {
+			Expect(s).To(ContainSubstring(catchStr))
+		}
+		fmt.Fprintf(rw, "{}")
+	})
+}

--- a/status/status.go
+++ b/status/status.go
@@ -87,6 +87,11 @@ func (s *Status) GetReporter(snapshot *applicationapiv1alpha1.Snapshot) Reporter
 		return githubReporter
 	}
 
+	gitlabReporter := NewGitLabReporter(s.logger, s.client)
+	if gitlabReporter.Detect(snapshot) {
+		return gitlabReporter
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## TODO
- [x] logging
- [x] gitlab client mockking
- [x] test coverage

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
