### PR TITLE
fix(stoneinteg-761): create a new metric to replace static env

### DIFF
--- a/metrics/integration.go
+++ b/metrics/integration.go
@@ -33,10 +33,19 @@ var (
 		},
 	)
 
+	//This metric should be dropped once SnapshotCreatedToPipelineRunStartedSeconds is merged in prod
 	SnapshotCreatedToPipelineRunStartedStaticEnvSeconds = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds",
 			Help:    "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started in a static environment",
+			Buckets: []float64{0.05, 0.1, 0.5, 1, 2, 3, 4, 5, 10, 15, 30},
+		},
+	)
+
+	SnapshotCreatedToPipelineRunStartedSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "integration_svc_snapshot_created_to_pipelinerun_started_seconds",
+			Help:    "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started in the environment",
 			Buckets: []float64{0.05, 0.1, 0.5, 1, 2, 3, 4, 5, 10, 15, 30},
 		},
 	)
@@ -102,6 +111,7 @@ func RegisterInvalidSnapshot(conditiontype, reason string) {
 
 func RegisterPipelineRunStarted(snapshotCreatedTime metav1.Time, pipelineRunStartTime *metav1.Time) {
 	SnapshotCreatedToPipelineRunStartedStaticEnvSeconds.Observe(pipelineRunStartTime.Sub(snapshotCreatedTime.Time).Seconds())
+	SnapshotCreatedToPipelineRunStartedSeconds.Observe(pipelineRunStartTime.Sub(snapshotCreatedTime.Time).Seconds())
 }
 
 func RegisterIntegrationResponse(duration time.Duration) {
@@ -124,6 +134,7 @@ func RegisterReleaseLatency(startTime metav1.Time) {
 func init() {
 	metrics.Registry.MustRegister(
 		SnapshotCreatedToPipelineRunStartedStaticEnvSeconds,
+		SnapshotCreatedToPipelineRunStartedSeconds,
 		IntegrationSvcResponseSeconds,
 		IntegrationPipelineRunTotal,
 		SnapshotConcurrentTotal,

--- a/metrics/integration_test.go
+++ b/metrics/integration_test.go
@@ -32,6 +32,7 @@ import (
 var _ = Describe("Metrics Integration", Ordered, func() {
 	BeforeAll(func() {
 		metrics.Registry.Unregister(SnapshotCreatedToPipelineRunStartedStaticEnvSeconds)
+		metrics.Registry.Unregister(SnapshotCreatedToPipelineRunStartedSeconds)
 		metrics.Registry.Unregister(SnapshotConcurrentTotal)
 		metrics.Registry.Unregister(SnapshotDurationSeconds)
 	})
@@ -41,6 +42,12 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 			Name: "integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds",
 			Help: "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started in a static environment",
 		}
+
+		SnapshotCreatedToPipelineRunStartedSecondsHeader = inputHeader{
+			Name: "integration_svc_snapshot_created_to_pipelinerun_started_seconds",
+			Help: "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started in the environment",
+		}
+
 		SnapshotDurationSecondsHeader = inputHeader{
 			Name: "integration_svc_snapshot_attempt_duration_seconds",
 			Help: "Snapshot durations from the moment the Snapshot was created till the Snapshot is marked as finished",
@@ -64,6 +71,13 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 					Buckets: []float64{1, 5, 10, 30},
 				},
 			)
+			SnapshotCreatedToPipelineRunStartedSeconds = prometheus.NewHistogram(
+				prometheus.HistogramOpts{
+					Name:    "integration_svc_snapshot_created_to_pipelinerun_started_seconds",
+					Help:    "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started in the environment",
+					Buckets: []float64{1, 5, 10, 30},
+				},
+			)
 			SnapshotConcurrentTotal = prometheus.NewGauge(
 				prometheus.GaugeOpts{
 					Name: "integration_svc_snapshot_attempt_concurrent_requests",
@@ -74,6 +88,7 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 
 		AfterAll(func() {
 			metrics.Registry.Unregister(SnapshotCreatedToPipelineRunStartedStaticEnvSeconds)
+			metrics.Registry.Unregister(SnapshotCreatedToPipelineRunStartedSeconds)
 			metrics.Registry.Unregister(SnapshotConcurrentTotal)
 		})
 
@@ -96,8 +111,10 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 			// Defined buckets for SnapshotCreatedToPipelineRunStartedSeconds
 			timeBuckets := []string{"1", "5", "10", "30"}
 			data := []int{1, 2, 3, 4}
-			readerData := createHistogramReader(SnapshotPipelineRunStartedStaticEnvSecondsHeader, timeBuckets, data, "", elapsedSeconds, len(inputSeconds))
-			Expect(testutil.CollectAndCompare(SnapshotCreatedToPipelineRunStartedStaticEnvSeconds, strings.NewReader(readerData))).To(Succeed())
+			readerDataEnv := createHistogramReader(SnapshotPipelineRunStartedStaticEnvSecondsHeader, timeBuckets, data, "", elapsedSeconds, len(inputSeconds))
+			Expect(testutil.CollectAndCompare(SnapshotCreatedToPipelineRunStartedStaticEnvSeconds, strings.NewReader(readerDataEnv))).To(Succeed())
+			readerData := createHistogramReader(SnapshotCreatedToPipelineRunStartedSecondsHeader, timeBuckets, data, "", elapsedSeconds, len(inputSeconds))
+			Expect(testutil.CollectAndCompare(SnapshotCreatedToPipelineRunStartedSeconds, strings.NewReader(readerData))).To(Succeed())
 		})
 	})
 
@@ -107,6 +124,13 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 				prometheus.HistogramOpts{
 					Name:    "integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds",
 					Help:    "Snapshot durations from the moment the snapshot resource was created till a integration pipelineRun is started in static environment",
+					Buckets: []float64{1, 5, 10, 30},
+				},
+			)
+			SnapshotCreatedToPipelineRunStartedSeconds = prometheus.NewHistogram(
+				prometheus.HistogramOpts{
+					Name:    "integration_svc_snapshot_created_to_pipelinerun_started_seconds",
+					Help:    "Time duration from the moment the snapshot resource was created till a integration pipelineRun is started in the environment",
 					Buckets: []float64{1, 5, 10, 30},
 				},
 			)
@@ -138,6 +162,7 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 
 		AfterAll(func() {
 			metrics.Registry.Unregister(SnapshotCreatedToPipelineRunStartedStaticEnvSeconds)
+			metrics.Registry.Unregister(SnapshotCreatedToPipelineRunStartedSeconds)
 			metrics.Registry.Unregister(SnapshotDurationSeconds)
 			metrics.Registry.Unregister(SnapshotConcurrentTotal)
 			metrics.Registry.Unregister(SnapshotTotal)


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
