### PR TITLE
fix(STONEINTG-807): report invalid test run into GH

### DIFF
--- a/status/reporters.go
+++ b/status/reporters.go
@@ -555,6 +555,8 @@ func generateSummary(state intgteststat.IntegrationTestStatus, snapshotName, sce
 		statusDesc = "has passed"
 	case intgteststat.IntegrationTestStatusTestFail:
 		statusDesc = "has failed"
+	case intgteststat.IntegrationTestStatusTestInvalid:
+		statusDesc = "is invalid"
 	default:
 		return summary, fmt.Errorf("unknown status")
 	}
@@ -573,9 +575,9 @@ func generateCheckRunTitle(state intgteststat.IntegrationTestStatus) (string, er
 		title = "Pending"
 	case intgteststat.IntegrationTestStatusInProgress:
 		title = "In Progress"
-	case intgteststat.IntegrationTestStatusEnvironmentProvisionError:
-		title = "Errored"
-	case intgteststat.IntegrationTestStatusDeploymentError:
+	case intgteststat.IntegrationTestStatusEnvironmentProvisionError,
+		intgteststat.IntegrationTestStatusDeploymentError,
+		intgteststat.IntegrationTestStatusTestInvalid:
 		title = "Errored"
 	case intgteststat.IntegrationTestStatusDeleted:
 		title = "Deleted"
@@ -626,7 +628,8 @@ func generateCheckRunConclusion(state intgteststat.IntegrationTestStatus) (strin
 
 	switch state {
 	case intgteststat.IntegrationTestStatusTestFail, intgteststat.IntegrationTestStatusEnvironmentProvisionError,
-		intgteststat.IntegrationTestStatusDeploymentError, intgteststat.IntegrationTestStatusDeleted:
+		intgteststat.IntegrationTestStatusDeploymentError, intgteststat.IntegrationTestStatusDeleted,
+		intgteststat.IntegrationTestStatusTestInvalid:
 		conclusion = gitops.IntegrationTestStatusFailureGithub
 	case intgteststat.IntegrationTestStatusTestPassed:
 		conclusion = gitops.IntegrationTestStatusSuccessGithub
@@ -649,7 +652,7 @@ func generateCommitState(state intgteststat.IntegrationTestStatus) (string, erro
 	case intgteststat.IntegrationTestStatusTestFail:
 		commitState = gitops.IntegrationTestStatusFailureGithub
 	case intgteststat.IntegrationTestStatusEnvironmentProvisionError, intgteststat.IntegrationTestStatusDeploymentError,
-		intgteststat.IntegrationTestStatusDeleted:
+		intgteststat.IntegrationTestStatusDeleted, intgteststat.IntegrationTestStatusTestInvalid:
 		commitState = gitops.IntegrationTestStatusErrorGithub
 	case intgteststat.IntegrationTestStatusTestPassed:
 		commitState = gitops.IntegrationTestStatusSuccessGithub

--- a/status/reporters_test.go
+++ b/status/reporters_test.go
@@ -610,8 +610,14 @@ var _ = Describe("GitHubReporter", func() {
 			Expect(mockGitHubClient.UpdateCheckRunResult.cra.Conclusion).To(Equal(gitops.IntegrationTestStatusFailureGithub))
 			Expect(mockGitHubClient.UpdateCheckRunResult.cra.CompletionTime.IsZero()).To(BeFalse())
 
+			hasSnapshot.Annotations["test.appstudio.openshift.io/status"] = "[{\"scenario\":\"scenario1\",\"status\":\"TestInvalid\",\"testPipelineRunName\":\"test-pipelinerun\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"completionTime\":\"2023-07-26T17:57:49+02:00\",\"lastUpdateTime\":\"2023-08-26T17:57:55+02:00\",\"details\":\"invalid\"}]"
+			Expect(reporter.ReportStatusForSnapshot(mockK8sClient, context.TODO(), &logger, hasSnapshot)).To(Succeed())
+			Expect(mockGitHubClient.UpdateCheckRunResult.cra.Summary).To(Equal("Integration test for snapshot snapshot-sample and scenario scenario1 is invalid"))
+			Expect(mockGitHubClient.UpdateCheckRunResult.cra.Conclusion).To(Equal(gitops.IntegrationTestStatusFailureGithub))
+			Expect(mockGitHubClient.UpdateCheckRunResult.cra.CompletionTime.IsZero()).To(BeFalse())
+
 			// Update existing CheckRun w/success
-			hasSnapshot.Annotations["test.appstudio.openshift.io/status"] = "[{\"scenario\":\"scenario1\",\"status\":\"TestPassed\",\"testPipelineRunName\":\"test-pipelinerun\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"completionTime\":\"2023-07-26T17:57:49+02:00\",\"lastUpdateTime\":\"2023-08-26T17:57:55+02:00\",\"details\":\"failed\"}]"
+			hasSnapshot.Annotations["test.appstudio.openshift.io/status"] = "[{\"scenario\":\"scenario1\",\"status\":\"TestPassed\",\"testPipelineRunName\":\"test-pipelinerun\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"completionTime\":\"2023-07-26T17:57:49+02:00\",\"lastUpdateTime\":\"2023-08-26T17:57:56+02:00\",\"details\":\"failed\"}]"
 			Expect(reporter.ReportStatusForSnapshot(mockK8sClient, context.TODO(), &logger, hasSnapshot)).To(BeNil())
 			Expect(mockGitHubClient.UpdateCheckRunResult.cra.Summary).To(Equal("Integration test for snapshot snapshot-sample and scenario scenario1 has passed"))
 			Expect(mockGitHubClient.UpdateCheckRunResult.cra.Conclusion).To(Equal(gitops.IntegrationTestStatusSuccessGithub))


### PR DESCRIPTION
Github reporter must process also invalid status of integration test. This status has been added recently, this is missing coutner part.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
