### PR TITLE
fix(statusreport): include TestInvalid in evaluation

### DIFF
--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -80,7 +80,6 @@ func (a *Adapter) EnsureSnapshotTestStatusReportedToGitHub() (controller.Operati
 	}
 
 	if gitops.IsSnapshotMarkedAsPassed(a.snapshot) || gitops.IsSnapshotMarkedAsFailed(a.snapshot) || gitops.IsSnapshotMarkedAsInvalid(a.snapshot) {
-		a.logger.Info("Status has been reported successfully, now in the process of removing the finalizer")
 		// Remove the finalizer from all the Integration PLRs related to the Snapshot
 		err = helpers.RemoveFinalizerFromAllIntegrationPipelineRunsOfSnapshot(a.client, a.logger, a.context, *a.snapshot, helpers.IntegrationPipelineRunFinalizer)
 		if err != nil {

--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -209,7 +209,10 @@ func (a *Adapter) determineIfAllIntegrationTestsFinishedAndPassed(integrationTes
 	for _, integrationTestScenario := range *integrationTestScenarios {
 		integrationTestScenario := integrationTestScenario // G601
 		testDetails, ok := testStatuses.GetScenarioStatus(integrationTestScenario.Name)
-		if !ok || (testDetails.Status != intgteststat.IntegrationTestStatusTestPassed && testDetails.Status != intgteststat.IntegrationTestStatusTestFail && testDetails.Status != intgteststat.IntegrationTestStatusDeleted) {
+		if !ok || (testDetails.Status != intgteststat.IntegrationTestStatusTestPassed &&
+			testDetails.Status != intgteststat.IntegrationTestStatusTestFail &&
+			testDetails.Status != intgteststat.IntegrationTestStatusDeleted &&
+			testDetails.Status != intgteststat.IntegrationTestStatusTestInvalid) {
 			allIntegrationTestsFinished = false
 		}
 		if ok && testDetails.Status != intgteststat.IntegrationTestStatusTestPassed {

--- a/gitops/snapshot_predicate.go
+++ b/gitops/snapshot_predicate.go
@@ -64,7 +64,7 @@ func SnapshotIntegrationTestRerunTriggerPredicate() predicate.Predicate {
 func SnapshotTestAnnotationChangePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
-			return false
+			return true
 		},
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 			return false


### PR DESCRIPTION
determineIfAllIntegrationTestsFinishedAndPassed must take `TestInvalid` into account and eval it as finished test

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
