### PR TITLE
fix(RHTAPWATCH-847): support gitlab MR event type labels

### DIFF
--- a/cmd/snapshotgc/snapshotgc.go
+++ b/cmd/snapshotgc/snapshotgc.go
@@ -231,7 +231,10 @@ func getSnapshotsForRemoval(
 
 	for _, snap := range snapshots {
 		label, found := snap.GetLabels()["pac.test.appstudio.openshift.io/event-type"]
-		if found && label == "pull_request" {
+		if found && (label == "pull_request" ||
+			label == "Merge Request" ||
+			label == "Merge_Request" ||
+			label == "Note") {
 			if keptPrSnaps < prSnapshotsToKeep {
 				logger.V(1).Info(
 					"Skipping PR candidate snapshot",


### PR DESCRIPTION
The current implementation only took github PR event type into consideration when classifying snapshots to garbage collect. This change adds support to the equivalent labels set by gitlab.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
