### PR TITLE
fix(statusreporting): Revert predicate creation event

### DIFF
--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -80,6 +80,7 @@ func (a *Adapter) EnsureSnapshotTestStatusReportedToGitHub() (controller.Operati
 	}
 
 	if gitops.IsSnapshotMarkedAsPassed(a.snapshot) || gitops.IsSnapshotMarkedAsFailed(a.snapshot) || gitops.IsSnapshotMarkedAsInvalid(a.snapshot) {
+		a.logger.Info("Status has been reported successfully, now in the process of removing the finalizer")
 		// Remove the finalizer from all the Integration PLRs related to the Snapshot
 		err = helpers.RemoveFinalizerFromAllIntegrationPipelineRunsOfSnapshot(a.client, a.logger, a.context, *a.snapshot, helpers.IntegrationPipelineRunFinalizer)
 		if err != nil {

--- a/gitops/snapshot_predicate.go
+++ b/gitops/snapshot_predicate.go
@@ -64,7 +64,7 @@ func SnapshotIntegrationTestRerunTriggerPredicate() predicate.Predicate {
 func SnapshotTestAnnotationChangePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
-			return true
+			return false
 		},
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 			return false


### PR DESCRIPTION
This reverts commit 06e25a01eaa84ad3bf0119844f2c27da6370cfaa.

controller is not ready for this, needs fixes to handle case when snapshot doesn't have component

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
