### PR TITLE
fix(STONEINTG-819): teach statusreport ctrl to deal with missing label

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -139,7 +139,7 @@ func (l *loader) GetComponentFromSnapshot(c client.Client, ctx context.Context, 
 
 		return component, nil
 	} else {
-		return nil, nil
+		return nil, fmt.Errorf("%s label missing from the Snapshot", gitops.SnapshotComponentLabel)
 	}
 }
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -512,6 +512,18 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(comp.ObjectMeta).To(Equal(hasComp.ObjectMeta))
 	})
 
+	It("ensures a non-nil error is returned when we cannot get a Component from a Snapshot if the label is missing", func() {
+		// Temporarily remove the component label from Snapshot
+		delete(hasSnapshot.Labels, gitops.SnapshotComponentLabel)
+
+		comp, err := loader.GetComponentFromSnapshot(k8sClient, ctx, hasSnapshot)
+		Expect(err).To(HaveOccurred())
+		Expect(comp).To(BeNil())
+
+		// Restore the component label
+		hasSnapshot.Labels[gitops.SnapshotComponentLabel] = "component-sample"
+	})
+
 	It("ensures we can get a Component from a Pipeline Run ", func() {
 		comp, err := loader.GetComponentFromPipelineRun(k8sClient, ctx, buildPipelineRun)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
* Currently, if a Snapshot doesn't contain a component label on it, the statusreport controller doesn't handle this case and causes nil pointer error.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
