### PR TITLE
fix(STONEINTG-809): add merge request when judging PR event

### DIFF
--- a/controllers/buildpipeline/buildpipeline_adapter_test.go
+++ b/controllers/buildpipeline/buildpipeline_adapter_test.go
@@ -133,8 +133,9 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				Name:      "snapshot-sample",
 				Namespace: "default",
 				Labels: map[string]string{
-					gitops.SnapshotTypeLabel:      "component",
-					gitops.SnapshotComponentLabel: hasComp.Name,
+					gitops.SnapshotTypeLabel:            "component",
+					gitops.SnapshotComponentLabel:       hasComp.Name,
+					gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePullRequestType,
 				},
 				Annotations: map[string]string{
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
@@ -903,6 +904,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(err).To(BeNil())
 			Expect(allSnapshots).NotTo(BeNil())
 			existingSnapshot := gitops.FindMatchingSnapshot(hasApp, allSnapshots, hasSnapshot)
+			Expect(existingSnapshot).NotTo(BeNil())
 			Expect(existingSnapshot.Name).To(Equal(hasSnapshot.Name))
 		})
 	})

--- a/controllers/integrationpipeline/integrationpipeline_adapter.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter.go
@@ -100,9 +100,9 @@ func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, 
 		return controller.RequeueWithError(fmt.Errorf("failed to update test status in snapshot: %w", err))
 	}
 
-	// Remove the finalizer from Integration PLRs only if they aren't related to Snapshots created by Pull-Request event
+	// Remove the finalizer from Integration PLRs only if they are related to Snapshots created by Push event
 	// If they are related, then the statusreport controller removes the finalizers from these PLRs
-	if !gitops.IsSnapshotCreatedByPACPullRequestEvent(a.snapshot) && (h.HasPipelineRunFinished(a.pipelineRun) || pipelinerunStatus == intgteststat.IntegrationTestStatusDeleted) {
+	if gitops.IsSnapshotCreatedByPACPushEvent(a.snapshot) && (h.HasPipelineRunFinished(a.pipelineRun) || pipelinerunStatus == intgteststat.IntegrationTestStatusDeleted) {
 		err = h.RemoveFinalizerFromPipelineRun(a.client, a.logger, a.context, a.pipelineRun, h.IntegrationPipelineRunFinalizer)
 		if err != nil {
 			return controller.RequeueWithError(fmt.Errorf("failed to remove the finalizer: %w", err))

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -354,7 +354,7 @@ func (a *Adapter) EnsureCreationOfEphemeralEnvironments() (controller.OperationR
 // EnsureGlobalCandidateImageUpdated is an operation that ensure the ContainerImage in the Global Candidate List
 // being updated when the Snapshot passed all the integration tests
 func (a *Adapter) EnsureGlobalCandidateImageUpdated() (controller.OperationResult, error) {
-	if a.component == nil || gitops.IsSnapshotCreatedByPACPullRequestEvent(a.snapshot) {
+	if a.component == nil || !gitops.IsSnapshotCreatedByPACPushEvent(a.snapshot) {
 		a.logger.Info("The Snapshot wasn't created for a single component push event, not updating the global candidate list.")
 		return controller.ContinueProcessing()
 	}

--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -66,7 +66,7 @@ func NewAdapter(snapshot *applicationapiv1alpha1.Snapshot, application *applicat
 // EnsureSnapshotTestStatusReportedToGitProvider will ensure that integration test status including env provision and snapshotEnvironmentBinding error is reported to the git provider
 // which (indirectly) triggered its execution.
 func (a *Adapter) EnsureSnapshotTestStatusReportedToGitProvider() (controller.OperationResult, error) {
-	if !gitops.IsSnapshotCreatedByPACPullRequestEvent(a.snapshot) {
+	if gitops.IsSnapshotCreatedByPACPushEvent(a.snapshot) {
 		return controller.ContinueProcessing()
 	}
 
@@ -152,7 +152,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 
 	// If the Snapshot is a component type, check if the global component list changed in the meantime and
 	// create a composite snapshot if it did. Does not apply for PAC pull request events.
-	if metadata.HasLabelWithValue(a.snapshot, gitops.SnapshotTypeLabel, gitops.SnapshotComponentType) && !gitops.IsSnapshotCreatedByPACPullRequestEvent(a.snapshot) {
+	if metadata.HasLabelWithValue(a.snapshot, gitops.SnapshotTypeLabel, gitops.SnapshotComponentType) && gitops.IsSnapshotCreatedByPACPushEvent(a.snapshot) {
 		var component *applicationapiv1alpha1.Component
 		err = retry.OnError(retry.DefaultRetry, func(_ error) bool { return true }, func() error {
 			component, err = a.loader.GetComponentFromSnapshot(a.client, a.context, a.snapshot)

--- a/controllers/statusreport/statusreport_adapter_test.go
+++ b/controllers/statusreport/statusreport_adapter_test.go
@@ -176,8 +176,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				Name:      "snapshot-sample",
 				Namespace: "default",
 				Labels: map[string]string{
-					gitops.SnapshotTypeLabel:      "component",
-					gitops.SnapshotComponentLabel: hasComp.Name,
+					gitops.SnapshotTypeLabel:            "component",
+					gitops.SnapshotComponentLabel:       hasComp.Name,
+					gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePushType,
 				},
 				Annotations: map[string]string{
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",


### PR DESCRIPTION
Changes as blow are made to support gitlab merge request
    * remove func IsSnapshotCreatedByPACPullRequestEvent()
    * add func IsSnapshotCreatedByPACPushEvent()
    * add func IsSnapshotCreatedBySamePACEvent()
   
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
