### PR TITLE
fix(STONEINTG-769): do not block reconciliation when report fail

### DIFF
--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -83,8 +83,6 @@ func (a *Adapter) EnsureSnapshotTestStatusReportedToGitProvider() (controller.Op
 			"snapshot.Namespace", a.snapshot.Namespace, "snapshot.Name", a.snapshot.Name)
 		if helpers.IsObjectYoungerThanThreshold(a.snapshot, SnapshotRetryTimeout) {
 			return controller.RequeueWithError(err)
-		} else {
-			return controller.ContinueProcessing()
 		}
 	}
 


### PR DESCRIPTION
This is regression from https://github.com/MartinBasti/integration-service/commit/bc758969f9ec196d57002c3abe2ea130e108bcd3

Before this status has been ignored at lower level, hotfixing issue.

if PLR doesn't exist anymore, at least provide users some results withou
details, not just failing silently.

ContinueProcessing had to be removed, it would prevent unlocking
finalizers.

This is just workaround, to prevent catastrophic issues on deployments.
Future fix should be about preventing to even get to state where we are
missing PLR data.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
