### PR TITLE
DO NOT MERGE: access the ephemeral CI cluster

### DIFF
--- a/controllers/binding/snapshotenvironmentbinding_adapter.go
+++ b/controllers/binding/snapshotenvironmentbinding_adapter.go
@@ -146,7 +146,7 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 	if conditionStatus := gitops.GetBindingConditionStatus(a.snapshotEnvironmentBinding); conditionStatus != nil {
 		reasonMsg = fmt.Sprintf("%s (%s)", conditionStatus.Reason, conditionStatus.Message)
 	}
-	// we don't want to scare users prematurely, report error only after SEB timeout for trying to deploy
+	// we do not want to scare users prematurely, report error only after SEB timeout for trying to deploy
 	a.logger.Info(
 		fmt.Sprintf("SEB has been in the error state for more than the threshold time of %f seconds", SnapshotEnvironmentBindingErrorTimeoutSeconds),
 		"reason", reasonMsg,


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
