### PR TITLE
fix(buildpipeline): log details about unsuccessful PLR

### DIFF
--- a/controllers/buildpipeline/buildpipeline_adapter.go
+++ b/controllers/buildpipeline/buildpipeline_adapter.go
@@ -88,6 +88,10 @@ func (a *Adapter) EnsureSnapshotExists() (result controller.OperationResult, err
 		if h.HasPipelineRunFinished(a.pipelineRun) || a.pipelineRun.GetDeletionTimestamp() != nil {
 			// The pipeline run has failed
 			// OR pipeline has been deleted but it's still in running state (tekton bug/feature?)
+			a.logger.Info("Finished processing of unsuccessful build PLR",
+				"statusCondition", a.pipelineRun.GetStatusCondition(),
+				"deletionTimestamp", a.pipelineRun.GetDeletionTimestamp(),
+			)
 			canRemoveFinalizer = true
 			return controller.ContinueProcessing()
 		}


### PR DESCRIPTION
We are missing details why PLR has been stopped processing.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
