### PR TITLE
fix(STONEINTG-819): don't retry if component label is missing

### DIFF
--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/redhat-appstudio/integration-service/cache"
+	"github.com/redhat-appstudio/integration-service/tekton"
 
 	"github.com/go-logr/logr"
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
@@ -128,7 +129,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return err
 	})
 	if err != nil {
-		return helpers.HandleLoaderError(logger, err, "Component", "Snapshot")
+		return helpers.HandleLoaderError(logger, err, fmt.Sprintf("Component or '%s' label", tekton.ComponentNameLabel), "Snapshot")
 	}
 
 	adapter := NewAdapter(snapshot, application, component, logger, loader, r.Client, ctx)

--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -33,6 +33,7 @@ import (
 	"github.com/redhat-appstudio/integration-service/metrics"
 	intgteststat "github.com/redhat-appstudio/integration-service/pkg/integrationteststatus"
 	"github.com/redhat-appstudio/integration-service/status"
+	"github.com/redhat-appstudio/integration-service/tekton"
 	"github.com/redhat-appstudio/operator-toolkit/metadata"
 )
 
@@ -157,7 +158,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 			return err
 		})
 		if err != nil {
-			if _, err = helpers.HandleLoaderError(a.logger, err, "Component", "Snapshot"); err != nil {
+			if _, err = helpers.HandleLoaderError(a.logger, err, fmt.Sprintf("Component or '%s' label", tekton.ComponentNameLabel), "Snapshot"); err != nil {
 				return controller.RequeueWithError(err)
 			}
 			return controller.ContinueProcessing()

--- a/helpers/errorhandlers.go
+++ b/helpers/errorhandlers.go
@@ -68,9 +68,10 @@ func IsMissingInfoInPipelineRunError(err error) bool {
 
 func HandleLoaderError(logger IntegrationLogger, err error, resource, from string) (ctrl.Result, error) {
 	if k8serrors.IsNotFound(err) {
-		logger.Info(fmt.Sprintf("Could not get %[1]s from %[2]s.  %[1]s may have been removed.  Declining to proceed with reconciliation", resource, from))
+		logger.Info(fmt.Sprintf("Could not get %[1]s from %[2]s.  %[1]s may have been removed.  Declining to proceed with reconciliation due to the error: %[3]v", resource, from, err))
 		return ctrl.Result{}, nil
 	}
+
 	logger.Error(err, fmt.Sprintf("Failed to get %s from the %s", resource, from))
 	return ctrl.Result{}, err
 }

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -28,8 +28,10 @@ import (
 	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -138,7 +140,8 @@ func (l *loader) GetComponentFromSnapshot(c client.Client, ctx context.Context, 
 
 		return component, nil
 	} else {
-		return nil, fmt.Errorf("%s label missing from the Snapshot", gitops.SnapshotComponentLabel)
+		groupResource := schema.GroupResource{Group: "", Resource: ""}
+		return nil, errors.NewNotFound(groupResource, fmt.Sprintf("Label '%s'", gitops.SnapshotComponentLabel))
 	}
 }
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -521,7 +521,7 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(comp).To(BeNil())
 
 		// Restore the component label
-		hasSnapshot.Labels[gitops.SnapshotComponentLabel] = "component-sample"
+		hasSnapshot.Labels[gitops.SnapshotComponentLabel] = hasComp.Name
 	})
 
 	It("ensures we can get a Component from a Pipeline Run ", func() {


### PR DESCRIPTION
* This commit treats the situation, where a Snapshot doesn't
   contain the Component label, as unrecoverable.
* And therefore, in that case, throws 'errors.NewNotFound()'
   so that `HandleLoaderError()` function doesn't requeue it,
   and instead, decline reconciliation.
* The `GetComponentFromSnapshot()` can throw errors of
  NotFound-type in 2 cases: When Component label is present
  but Component resource is missing from cluster. And when
  Component label is missing from the Snapshot.
* To make sure `HandleLoaderError()` can differentiate
  between these 2 errors, it will now log the error as well

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
