### PR TITLE
chore(RHTAPWATCH-766): cronjob to release allocated namespace

### DIFF
--- a/config/environment_provisioning/environment_provisioning.yaml
+++ b/config/environment_provisioning/environment_provisioning.yaml
@@ -1,0 +1,44 @@
+---
+kind: CronJob
+apiVersion: batch/v1
+metadata:
+  name: spacerequest-garbage-collector
+spec:
+  schedule: "0 5 * * *" # every day at 5AM UTC
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: appstudio-pipeline
+          containers:
+            - name: cleanup-container
+              image: quay.io/redhat-user-workloads/rhtap-o11y-tenant/tools/tools:3e4c9a30e734aa34f57a084633ccfbb73d466fbd
+              command:
+                - /bin/bash
+                - -c
+                - |
+                #!/bin/bash
+
+                ALL_PIPELINERUNS=$(oc get pipelineruns -o=jsonpath='{.items[*].metadata.name}')
+                FINISHED_PIPELINERUNS=$(oc get pipelineruns -o=jsonpath='{.items[?(@.status.conditions[*].type=="Succeeded")].metadata.name}')
+                IFS=' ' read -ra PIPELINERUNS <<< "$FINISHED_PIPELINERUNS"
+
+                for SPACEREQUEST_NAME in $(oc get spacerequests -o=jsonpath='{.items[*].metadata.name}'); do
+                  if [ -n "$PIPELINERUN_NAME" ]; then
+                      if { echo "$FINISHED_PIPELINERUNS" | grep -q "$PIPELINERUN_NAME" || ! echo "$ALL_PIPELINERUNS" | grep -q "$PIPELINERUN_NAME"; }; then
+                          oc delete spacerequest $SPACEREQUEST_NAME
+                      fi
+                  fi
+                done
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 125Mi
+                limits:
+                  cpu: 250m
+                  memory: 125Mi
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true

--- a/config/environment_provisioning/kustomization.yaml
+++ b/config/environment_provisioning/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- environment_provisioning.yaml
+


### PR DESCRIPTION
A saftey-mechanism in case the namespace allocated by the `allocate-namespace` task wasn't removed when the pipeline finished running. Instead, a cronjob will run periodicly to make sure all allocated namespaces which are owned by a finished pipelineRun are removed.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
