### PR TITLE
fix(STONEINTG-710): race condition in status update time

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -57,8 +57,11 @@ const (
 	// SnapshotTestScenarioLabel contains json data with test results of the particular snapshot
 	SnapshotTestsStatusAnnotation = "test.appstudio.openshift.io/status"
 
-	// SnapshotPRLastUpdate contains timestamp of last time PR was updated
+	// (Deprecated) SnapshotPRLastUpdate contains timestamp of last time PR was updated
 	SnapshotPRLastUpdate = "test.appstudio.openshift.io/pr-last-update"
+
+	// SnapshotStatusReportAnnotation contains metadata of tests related to status reporting to git provider
+	SnapshotStatusReportAnnotation = "test.appstudio.openshift.io/git-reporter-status"
 
 	// BuildPipelineRunPrefix contains the build pipeline run related labels and annotations
 	BuildPipelineRunPrefix = "build.appstudio"
@@ -769,6 +772,7 @@ func AddIntegrationTestRerunLabel(adapterClient client.Client, ctx context.Conte
 	return nil
 }
 
+// Deprecated
 func GetLatestUpdateTime(snapshot *applicationapiv1alpha1.Snapshot) (time.Time, error) {
 	latestUpdateTime := snapshot.GetAnnotations()[SnapshotPRLastUpdate]
 	if latestUpdateTime == "" {
@@ -780,15 +784,6 @@ func GetLatestUpdateTime(snapshot *applicationapiv1alpha1.Snapshot) (time.Time, 
 		return t, fmt.Errorf("failed to unmarshal time annotation: %w", err)
 	}
 	return t, nil
-}
-
-func SetLatestUpdateTime(snapshot *applicationapiv1alpha1.Snapshot, t time.Time) error {
-	byteVal, _ := t.MarshalText()
-	err := metadata.SetAnnotation(snapshot, SnapshotPRLastUpdate, string(byteVal))
-	if err != nil {
-		return fmt.Errorf("failed to set annotation for snapshot %w", err)
-	}
-	return nil
 }
 
 func ResetSnapshotStatusConditions(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -135,20 +135,6 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 	})
 
-	It("ensures that latest update annotation can be set and get from snapshot", func() {
-		t := time.Time{}
-		Expect(t.UnmarshalText([]byte("2023-08-26T17:57:50+02:00"))).To(Succeed())
-		Expect(gitops.GetLatestUpdateTime(hasSnapshot)).To(Equal(t))
-		//set different time
-		Expect(t.UnmarshalText([]byte("2023-08-26T18:57:50+02:00"))).To(Succeed())
-		Expect(gitops.SetLatestUpdateTime(hasSnapshot, t)).To(Succeed())
-		Expect(hasSnapshot.GetAnnotations()[gitops.SnapshotPRLastUpdate]).To(Equal("2023-08-26T18:57:50+02:00"))
-		//set latest update time to zero
-		Expect(gitops.SetLatestUpdateTime(hasSnapshot, time.Time{})).To(Succeed())
-		Expect(hasSnapshot.GetAnnotations()[gitops.SnapshotPRLastUpdate]).To(Equal("0001-01-01T00:00:00Z"))
-
-	})
-
 	It("ensures the a decision can be made to NOT promote when the snaphot has not been marked as passed/failed", func() {
 		canBePromoted, reasons := gitops.CanSnapshotBePromoted(hasSnapshot)
 		Expect(canBePromoted).To(BeFalse())


### PR DESCRIPTION
Having single record of updated time may lead into race condition, where some scenario updates are being skipped.

Due this, we have to keep status of updates per scenario.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
