### PR TITLE
feat(STONEINTG-786): disallow invalid containerImage to be added to component

### DIFF
--- a/controllers/buildpipeline/buildpipeline_adapter.go
+++ b/controllers/buildpipeline/buildpipeline_adapter.go
@@ -145,7 +145,7 @@ func (a *Adapter) EnsureSnapshotExists() (result controller.OperationResult, err
 	expectedSnapshot, err := a.prepareSnapshotForPipelineRun(a.pipelineRun, a.component, a.application)
 	if err != nil {
 		// If PipelineRun result returns cusomized error update PLR annotation and exit
-		if h.IsMissingInfoInPipelineRunError(err) {
+		if h.IsMissingInfoInPipelineRunError(err) || h.IsInvalidImageDigestError(err) || h.IsMissingValidComponentError(err) {
 			// update the build PLR annotation with the error cusomized Reason and Value
 			if annotateErr := tekton.AnnotateBuildPipelineRunWithCreateSnapshotAnnotation(a.context, a.pipelineRun, a.client, err); annotateErr != nil {
 				a.logger.Error(annotateErr, "Could not add create snapshot annotation to build pipelineRun", h.CreateSnapshotAnnotationName, a.pipelineRun)

--- a/helpers/errorhandlers.go
+++ b/helpers/errorhandlers.go
@@ -24,6 +24,8 @@ import (
 const (
 	ReasonEnvironmentNotInNamespace     = "EnvironmentNotInNamespace"
 	ReasonMissingInfoInPipelineRunError = "MissingInfoInPipelineRunError"
+	ReasonInvalidImageDigestError       = "InvalidImageDigest"
+	ReasonMissingValidComponentError    = "MissingValidComponentError"
 	ReasonUnknownError                  = "UnknownError"
 )
 
@@ -64,6 +66,28 @@ func MissingInfoInPipelineRunError(pipelineRunName, paramName string) error {
 
 func IsMissingInfoInPipelineRunError(err error) bool {
 	return getReason(err) == ReasonMissingInfoInPipelineRunError
+}
+
+func NewInvalidImageDigestError(componentName, image_digest string) error {
+	return &IntegrationError{
+		Reason:  ReasonInvalidImageDigestError,
+		Message: fmt.Sprintf("%s is invalid container image digest from component %s", image_digest, componentName),
+	}
+}
+
+func IsInvalidImageDigestError(err error) bool {
+	return getReason(err) == ReasonInvalidImageDigestError
+}
+
+func NewMissingValidComponentError(componentName string) error {
+	return &IntegrationError{
+		Reason:  ReasonMissingValidComponentError,
+		Message: fmt.Sprintf("The only one component %s is invalid, valid .Spec.ContainerImage is missing", componentName),
+	}
+}
+
+func IsMissingValidComponentError(err error) bool {
+	return getReason(err) == ReasonMissingValidComponentError
 }
 
 func HandleLoaderError(logger IntegrationLogger, err error, resource, from string) (ctrl.Result, error) {

--- a/helpers/errorhandlers_test.go
+++ b/helpers/errorhandlers_test.go
@@ -89,6 +89,18 @@ var _ = Describe("Helpers for error handlers", Ordered, func() {
 			Expect(err.Error()).To(Equal("Missing info revision from pipelinerun pipelineRunName"))
 		})
 
+		It("Can define InvalidImageDigestError", func() {
+			err := helpers.NewInvalidImageDigestError("componentName", "badDigest")
+			Expect(helpers.IsInvalidImageDigestError(err)).To(BeTrue())
+			Expect(err.Error()).To(Equal("badDigest is invalid container image digest from component componentName"))
+		})
+
+		It("Can define MissingValidComponentError", func() {
+			err := helpers.NewMissingValidComponentError("componentName")
+			Expect(helpers.IsMissingValidComponentError(err)).To(BeTrue())
+			Expect(err.Error()).To(Equal("The only one component componentName is invalid, valid .Spec.ContainerImage is missing"))
+		})
+
 		It("Can handle non integration error", func() {
 			err := fmt.Errorf("failed")
 			Expect(helpers.IsMissingInfoInPipelineRunError(err)).To(BeFalse())


### PR DESCRIPTION
Don't add containerImage with invalid digest to component

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
