### PR TITLE
fix(STONEINTG-810): rename to Konflux

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -35,7 +35,7 @@ import (
 )
 
 // NamePrefix is a common name prefix for this service.
-const NamePrefix = "Red Hat Trusted App Test"
+const NamePrefix = "Red Hat Konflux"
 
 type StatusInterface interface {
 	GetReporter(*applicationapiv1alpha1.Snapshot) ReporterInterface

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -355,7 +355,7 @@ var _ = Describe("Status Adapter", func() {
 		t, err := time.Parse(time.RFC3339, "2023-07-26T16:57:49+02:00")
 		Expect(err).NotTo(HaveOccurred())
 		expectedTestReport := status.TestReport{
-			FullName:     "Red Hat Trusted App Test / snapshot-sample / scenario1",
+			FullName:     "Red Hat Konflux / snapshot-sample / scenario1",
 			ScenarioName: "scenario1",
 			Text:         "Test in progress",
 			Summary:      "Integration test for snapshot snapshot-sample and scenario scenario1 is in progress",
@@ -383,7 +383,7 @@ var _ = Describe("Status Adapter", func() {
 
 `
 		expectedTestReport := status.TestReport{
-			FullName:       "Red Hat Trusted App Test / snapshot-sample / scenario1",
+			FullName:       "Red Hat Konflux / snapshot-sample / scenario1",
 			ScenarioName:   "scenario1",
 			Text:           text,
 			Summary:        "Integration test for snapshot snapshot-sample and scenario scenario1 has passed",


### PR DESCRIPTION
Trusted App name has been deprecated, new name is konflux

(Name should be configurable, but this is for another story.)

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
