### PR TITLE
fix(errors): support joined error

### DIFF
--- a/helpers/errorhandlers.go
+++ b/helpers/errorhandlers.go
@@ -14,9 +14,10 @@ limitations under the License.
 package helpers
 
 import (
+	"errors"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -36,8 +37,8 @@ func (ie *IntegrationError) Error() string {
 }
 
 func getReason(err error) string {
-	integrationErr, ok := err.(*IntegrationError)
-	if !ok {
+	var integrationErr *IntegrationError
+	if !errors.As(err, &integrationErr) {
 		return ReasonUnknownError
 	}
 	return integrationErr.Reason
@@ -66,7 +67,7 @@ func IsMissingInfoInPipelineRunError(err error) bool {
 }
 
 func HandleLoaderError(logger IntegrationLogger, err error, resource, from string) (ctrl.Result, error) {
-	if errors.IsNotFound(err) {
+	if k8serrors.IsNotFound(err) {
 		logger.Info(fmt.Sprintf("Could not get %[1]s from %[2]s.  %[1]s may have been removed.  Declining to proceed with reconciliation", resource, from))
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
Go support to join multiple errors into tree with error.Join() function. Improve detection of IntegrationService error by searching error tree. Without this patch, it would detect IntegrationService error only if it's first in list.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
