### PR TITLE
fix(STONEINTG-848): drop logic for detecting latest PLR

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -53,7 +53,6 @@ type ObjectLoader interface {
 	GetDeploymentTargetForDeploymentTargetClaim(c client.Client, ctx context.Context, dtc *applicationapiv1alpha1.DeploymentTargetClaim) (*applicationapiv1alpha1.DeploymentTarget, error)
 	FindExistingSnapshotEnvironmentBinding(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error)
 	GetAllPipelineRunsForSnapshotAndScenario(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, integrationTestScenario *v1beta1.IntegrationTestScenario) (*[]tektonv1.PipelineRun, error)
-	GetAllBuildPipelineRunsForComponent(c client.Client, ctx context.Context, component *applicationapiv1alpha1.Component) (*[]tektonv1.PipelineRun, error)
 	GetAllSnapshots(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Snapshot, error)
 	GetAutoReleasePlansForApplication(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]releasev1alpha1.ReleasePlan, error)
 	GetScenario(c client.Client, ctx context.Context, name, namespace string) (*v1beta1.IntegrationTestScenario, error)
@@ -384,26 +383,6 @@ func (l *loader) GetAllPipelineRunsForSnapshotAndScenario(adapterClient client.C
 		return nil, err
 	}
 	return &integrationPipelineRuns.Items, nil
-}
-
-// GetAllBuildPipelineRunsForComponent returns all PipelineRun for the
-// associated component. In the case the List operation fails,
-// an error will be returned.
-func (l *loader) GetAllBuildPipelineRunsForComponent(c client.Client, ctx context.Context, component *applicationapiv1alpha1.Component) (*[]tektonv1.PipelineRun, error) {
-	buildPipelineRuns := &tektonv1.PipelineRunList{}
-	opts := []client.ListOption{
-		client.InNamespace(component.Namespace),
-		client.MatchingLabels{
-			"pipelines.appstudio.openshift.io/type": "build",
-			"appstudio.openshift.io/component":      component.Name,
-		},
-	}
-
-	err := c.List(ctx, buildPipelineRuns, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return &buildPipelineRuns.Items, nil
 }
 
 // GetAllSnapshots returns all Snapshots in the Application's namespace nil if it's not found.

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -204,15 +204,6 @@ func (l *mockLoader) GetAllPipelineRunsForSnapshotAndScenario(c client.Client, c
 	return &pipelineRuns, err
 }
 
-// GetAllBuildPipelineRunsForComponent returns the resource and error passed as values of the context.
-func (l *mockLoader) GetAllBuildPipelineRunsForComponent(c client.Client, ctx context.Context, component *applicationapiv1alpha1.Component) (*[]tektonv1.PipelineRun, error) {
-	if ctx.Value(PipelineRunsContextKey) == nil {
-		return l.loader.GetAllBuildPipelineRunsForComponent(c, ctx, component)
-	}
-	pipelineRuns, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, PipelineRunsContextKey, []tektonv1.PipelineRun{})
-	return &pipelineRuns, err
-}
-
 // GetAllSnapshots returns the resource and error passed as values of the context.
 func (l *mockLoader) GetAllSnapshots(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Snapshot, error) {
 	if ctx.Value(AllSnapshotsContextKey) == nil {

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -336,21 +336,6 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		})
 	})
 
-	Context("When calling GetAllBuildPipelineRunsForComponent", func() {
-		It("returns snapshots and error from the context", func() {
-			pipelineRuns := []tektonv1.PipelineRun{}
-			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
-				{
-					ContextKey: PipelineRunsContextKey,
-					Resource:   pipelineRuns,
-				},
-			})
-			resource, err := loader.GetAllBuildPipelineRunsForComponent(nil, mockContext, nil)
-			Expect(resource).To(Equal(&pipelineRuns))
-			Expect(err).To(BeNil())
-		})
-	})
-
 	Context("When calling GetAllSnapshotEnvironmentBindingsForScenario", func() {
 		It("returns snapshotEnvironmentBindings and error from the context", func() {
 			environments := []applicationapiv1alpha1.Environment{}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -573,14 +573,6 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(env.ObjectMeta).To(Equal(hasEnv.ObjectMeta))
 	})
 
-	It("can fetch all build pipelineRuns", func() {
-		pipelineRuns, err := loader.GetAllBuildPipelineRunsForComponent(k8sClient, ctx, hasComp)
-		Expect(err).To(BeNil())
-		Expect(pipelineRuns).NotTo(BeNil())
-		Expect(*pipelineRuns).To(HaveLen(1))
-		Expect((*pipelineRuns)[0].Name).To(Equal(buildPipelineRun.Name))
-	})
-
 	It("can fetch all pipelineRuns for snapshot and scenario", func() {
 		pipelineRuns, err := loader.GetAllPipelineRunsForSnapshotAndScenario(k8sClient, ctx, hasSnapshot, integrationTestScenario)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
This logic were supposed to prevent accidentally create snapshot for older build, however there is a bug that not only push build PLR are considered but it also compares pull-request build PLR and false positively prevents creation of push snapshots.

Given the radical prunning of tekton PLR, this feature has small benefit but great potential for future to break things again. Thus the best is to remove it altogether.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
