### PR TITLE
fix(RHTAPWATCH-847): some gitlab MR snapshots missed

### DIFF
--- a/cmd/snapshotgc/snapshotgc.go
+++ b/cmd/snapshotgc/snapshotgc.go
@@ -231,30 +231,7 @@ func getSnapshotsForRemoval(
 
 	for _, snap := range snapshots {
 		label, found := snap.GetLabels()["pac.test.appstudio.openshift.io/event-type"]
-		if found && (label == "pull_request" ||
-			label == "Merge Request" ||
-			label == "Merge_Request" ||
-			label == "Note") {
-			if keptPrSnaps < prSnapshotsToKeep {
-				logger.V(1).Info(
-					"Skipping PR candidate snapshot",
-					"namespace", snap.Namespace,
-					"snapshot.name", snap.Name,
-					"pr-snapshot-kept", keptPrSnaps+1,
-					"pr-snapshots-to-keep", prSnapshotsToKeep,
-				)
-				keptPrSnaps++
-			} else {
-				logger.V(1).Info(
-					"Adding PR candidate snapshot",
-					"namespace", snap.Namespace,
-					"snapshot.name", snap.Name,
-					"pr-snapshot-kept", keptPrSnaps,
-					"pr-snapshots-to-keep", prSnapshotsToKeep,
-				)
-				shortList = append(shortList, snap)
-			}
-		} else if !found || label != "pull_request" {
+		if !found || label == "push" || label == "Push" {
 			if keptNonPrSnaps < nonPrSnapshotsToKeep {
 				logger.V(1).Info(
 					"Skipping non-PR candidate snapshot",
@@ -275,11 +252,25 @@ func getSnapshotsForRemoval(
 				shortList = append(shortList, snap)
 			}
 		} else {
-			logger.Info(
-				"Failed classifying snapshot",
-				"namespace", snap.Namespace,
-				"snapshot.name", snap.Name,
-			)
+			if keptPrSnaps < prSnapshotsToKeep {
+				logger.V(1).Info(
+					"Skipping PR candidate snapshot",
+					"namespace", snap.Namespace,
+					"snapshot.name", snap.Name,
+					"pr-snapshot-kept", keptPrSnaps+1,
+					"pr-snapshots-to-keep", prSnapshotsToKeep,
+				)
+				keptPrSnaps++
+			} else {
+				logger.V(1).Info(
+					"Adding PR candidate snapshot",
+					"namespace", snap.Namespace,
+					"snapshot.name", snap.Name,
+					"pr-snapshot-kept", keptPrSnaps,
+					"pr-snapshots-to-keep", prSnapshotsToKeep,
+				)
+				shortList = append(shortList, snap)
+			}
 		}
 	}
 	return shortList

--- a/cmd/snapshotgc/snapshotgc_test.go
+++ b/cmd/snapshotgc/snapshotgc_test.go
@@ -371,7 +371,7 @@ var _ = Describe("Test garbage collection for snapshots", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "newer-snapshot",
 					Labels: map[string]string{
-						"pac.test.appstudio.openshift.io/event-type": "some-event",
+						"pac.test.appstudio.openshift.io/event-type": "push",
 					},
 					CreationTimestamp: metav1.NewTime(currentTime.Add(time.Hour * 1)),
 				},
@@ -392,7 +392,7 @@ var _ = Describe("Test garbage collection for snapshots", func() {
 						},
 					}).Build()
 			candidates := []applicationapiv1alpha1.Snapshot{*newerSnap, *olderSnap}
-			output := getSnapshotsForRemoval(cl, candidates, 2, 2, logger)
+			output := getSnapshotsForRemoval(cl, candidates, 0, 2, logger)
 
 			Expect(output).To(BeEmpty())
 		})
@@ -427,7 +427,7 @@ var _ = Describe("Test garbage collection for snapshots", func() {
 						},
 					}).Build()
 			candidates := []applicationapiv1alpha1.Snapshot{*newerSnap, *olderSnap}
-			output := getSnapshotsForRemoval(cl, candidates, 1, 2, logger)
+			output := getSnapshotsForRemoval(cl, candidates, 1, 0, logger)
 
 			Expect(output).To(HaveLen(1))
 			Expect(output[0].Name).To(Equal("older-snapshot"))
@@ -464,7 +464,10 @@ var _ = Describe("Test garbage collection for snapshots", func() {
 			}
 			newerNonPRSnap := &applicationapiv1alpha1.Snapshot{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "newer-non-pr-snapshot",
+					Name: "newer-non-pr-snapshot",
+					Labels: map[string]string{
+						"pac.test.appstudio.openshift.io/event-type": "Push",
+					},
 					CreationTimestamp: metav1.NewTime(currentTime.Add(time.Hour * 11)),
 				},
 			}


### PR DESCRIPTION
There are multiple event-types that can be associated with GitLab MRs. Instead of trying to enumerate them all, we change the logic to spot push events (either missing the event-type label or it has value of push/Push) and consider the rest PR snapshots.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
