### PR TITLE
feat(STONEINTG-843): add consoleURL plr to github checkrun 

### DIFF
--- a/git/github/github_test.go
+++ b/git/github/github_test.go
@@ -144,7 +144,8 @@ func (MockRepositoriesService) ListStatuses(
 	var state = "success"
 	var description = "example-description"
 	var context = "example-context"
-	repoStatus := &ghapi.RepoStatus{ID: &id, State: &state, Description: &description, Context: &context}
+	var target_url = "https://example.com"
+	repoStatus := &ghapi.RepoStatus{ID: &id, State: &state, Description: &description, Context: &context, TargetURL: &target_url}
 	return []*ghapi.RepoStatus{repoStatus}, nil, nil
 }
 
@@ -177,6 +178,7 @@ var _ = Describe("Client", func() {
 		Repository:     "example-repo",
 		SHA:            "abcdef1",
 		ExternalID:     "example-external-id",
+		DetailsURL:     "https://example.com",
 		Conclusion:     "Passed",
 		Title:          "example-title",
 		Summary:        "example-summary",
@@ -192,6 +194,7 @@ var _ = Describe("Client", func() {
 		State:       "success",
 		Description: "example-description",
 		Context:     "example-context",
+		TargetURL:   "https://example.com",
 	}
 
 	BeforeEach(func() {
@@ -236,9 +239,16 @@ var _ = Describe("Client", func() {
 	})
 
 	It("can create commit statuses", func() {
-		id, err := client.CreateCommitStatus(context.TODO(), "", "", "", "", "", "")
+		id, err := client.CreateCommitStatus(context.TODO(), "", "", "", "", "", "", "")
 		Expect(err).To(BeNil())
 		Expect(id).To(Equal(int64(50)))
+	})
+
+	It("can set and get details URL", func() {
+		detilsURL := "https://example.com/details"
+
+		checkRunAdapter.DetailsURL = detilsURL
+		Expect(checkRunAdapter.DetailsURL).To(Equal(detilsURL))
 	})
 
 	It("can create check runs", func() {
@@ -304,6 +314,7 @@ var _ = Describe("Client", func() {
 			State:       "failure",
 			Description: "example-description",
 			Context:     "example-context",
+			TargetURL:   "https://example.com",
 		}
 		commitStatusExist, err = client.CommitStatusExists(commitStatuses, commitStatusAdapter)
 		Expect(commitStatusExist).To(BeFalse())

--- a/status/reporter.go
+++ b/status/reporter.go
@@ -52,6 +52,8 @@ type TestReport struct {
 	StartTime *time.Time
 	// time when test completed
 	CompletionTime *time.Time
+	// pipelineRun Name
+	TestPipelineRunName string
 }
 
 type ReporterInterface interface {

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -82,6 +82,7 @@ type CreateCommitStatusResult struct {
 	state         string
 	description   string
 	statusContext string
+	targetURL     string
 }
 
 type MockGitHubClient struct {
@@ -152,12 +153,13 @@ func (c *MockGitHubClient) GetExistingCommentID(comments []*ghapi.IssueComment, 
 	return nil
 }
 
-func (c *MockGitHubClient) CreateCommitStatus(ctx context.Context, owner string, repo string, SHA string, state string, description string, statusContext string) (int64, error) {
+func (c *MockGitHubClient) CreateCommitStatus(ctx context.Context, owner string, repo string, SHA string, state string, description string, statusContext string, targetURL string) (int64, error) {
 	var id int64 = 60
 	c.CreateCommitStatusResult.ID = id
 	c.CreateCommitStatusResult.state = state
 	c.CreateCommitStatusResult.description = description
 	c.CreateCommitStatusResult.statusContext = statusContext
+	c.CreateCommitStatusResult.targetURL = targetURL
 	return c.CreateCommitStatusResult.ID, c.CreateCommitStatusResult.Error
 }
 

--- a/status/status.go
+++ b/status/status.go
@@ -292,15 +292,16 @@ func (s *Status) generateTestReport(ctx context.Context, detail intgteststat.Int
 	}
 
 	report := TestReport{
-		Text:           text,
-		FullName:       fullName,
-		ScenarioName:   detail.ScenarioName,
-		SnapshotName:   snapshot.Name,
-		ComponentName:  snapshot.Labels[gitops.SnapshotComponentLabel],
-		Status:         detail.Status,
-		Summary:        summary,
-		StartTime:      detail.StartTime,
-		CompletionTime: detail.CompletionTime,
+		Text:                text,
+		FullName:            fullName,
+		ScenarioName:        detail.ScenarioName,
+		SnapshotName:        snapshot.Name,
+		ComponentName:       snapshot.Labels[gitops.SnapshotComponentLabel],
+		Status:              detail.Status,
+		Summary:             summary,
+		StartTime:           detail.StartTime,
+		CompletionTime:      detail.CompletionTime,
+		TestPipelineRunName: detail.TestPipelineRunName,
 	}
 	return &report, nil
 }

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -381,18 +381,19 @@ var _ = Describe("Status Adapter", func() {
 	})
 
 	It("report expected textual data for InProgress test scenario", func() {
-		hasSnapshot.Annotations["test.appstudio.openshift.io/status"] = "[{\"scenario\":\"scenario1\",\"status\":\"InProgress\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"lastUpdateTime\":\"2023-08-26T17:57:50+02:00\",\"details\":\"Test in progress\"}]"
+		hasSnapshot.Annotations["test.appstudio.openshift.io/status"] = "[{\"scenario\":\"scenario1\",\"status\":\"InProgress\",\"testPipelineRunName\":\"test-pipelinerun\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"lastUpdateTime\":\"2023-08-26T17:57:50+02:00\",\"details\":\"Test in progress\"}]"
 		t, err := time.Parse(time.RFC3339, "2023-07-26T16:57:49+02:00")
 		Expect(err).NotTo(HaveOccurred())
 		expectedTestReport := status.TestReport{
-			FullName:      "Red Hat Konflux / scenario1 / component-sample",
-			ScenarioName:  "scenario1",
-			SnapshotName:  "snapshot-sample",
-			ComponentName: "component-sample",
-			Text:          "Test in progress",
-			Summary:       "Integration test for snapshot snapshot-sample and scenario scenario1 is in progress",
-			Status:        integrationteststatus.IntegrationTestStatusInProgress,
-			StartTime:     &t,
+			FullName:            "Red Hat Konflux / scenario1 / component-sample",
+			ScenarioName:        "scenario1",
+			SnapshotName:        "snapshot-sample",
+			ComponentName:       "component-sample",
+			Text:                "Test in progress",
+			Summary:             "Integration test for snapshot snapshot-sample and scenario scenario1 is in progress",
+			Status:              integrationteststatus.IntegrationTestStatusInProgress,
+			StartTime:           &t,
+			TestPipelineRunName: "test-pipelinerun",
 		}
 		mockReporter.EXPECT().Initialize(gomock.Any(), gomock.Any()).Times(1)
 		mockReporter.EXPECT().ReportStatus(gomock.Any(), gomock.Eq(expectedTestReport)).Times(1)
@@ -421,15 +422,16 @@ var _ = Describe("Status Adapter", func() {
 
 `
 		expectedTestReport := status.TestReport{
-			FullName:       "Red Hat Konflux / scenario1",
-			ScenarioName:   "scenario1",
-			SnapshotName:   "snapshot-sample",
-			ComponentName:  "",
-			Text:           text,
-			Summary:        "Integration test for snapshot snapshot-sample and scenario scenario1 has passed",
-			Status:         integrationteststatus.IntegrationTestStatusTestPassed,
-			StartTime:      &ts,
-			CompletionTime: &tc,
+			FullName:            "Red Hat Konflux / scenario1",
+			ScenarioName:        "scenario1",
+			SnapshotName:        "snapshot-sample",
+			ComponentName:       "",
+			Text:                text,
+			Summary:             "Integration test for snapshot snapshot-sample and scenario scenario1 has passed",
+			Status:              integrationteststatus.IntegrationTestStatusTestPassed,
+			StartTime:           &ts,
+			CompletionTime:      &tc,
+			TestPipelineRunName: "test-pipelinerun",
 		}
 		mockReporter.EXPECT().Initialize(gomock.Any(), gomock.Any()).Times(1)
 		mockReporter.EXPECT().ReportStatus(gomock.Any(), gomock.Eq(expectedTestReport)).Times(1)


### PR DESCRIPTION
We added new field to github  endpoint CheckRun and CommitStatus on the creation : 

-  CheckRun           ->        DetailsURL
-  CommitStatus   ->        TargetURL

For more details see  [STONEINTEG-843](https://issues.redhat.com/browse/STONEINTG-843) 

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
