### PR TITLE
feat(STONEINTG-844): link tasks logs to task details in git reports

### DIFF
--- a/status/status_test.go
+++ b/status/status_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Status Adapter", func() {
 	BeforeEach(func() {
 		now := time.Now()
 		os.Setenv("CONSOLE_URL", "https://definetly.not.prod/preview/application-pipeline/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}")
+		os.Setenv("CONSOLE_URL_TASKLOG", "https://definetly.not.prod/preview/application-pipeline/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}/logs/{{ .TaskName }}")
 
 		successfulTaskRun = &tektonv1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
@@ -415,8 +416,8 @@ var _ = Describe("Status Adapter", func() {
 
 | Task | Duration | Test Suite | Status | Details |
 | --- | --- | --- | --- | --- |
-| pipeline1-task1 | 5m0s |  | :heavy_check_mark: SUCCESS | :heavy_check_mark: 10 success(es) |
-| pipeline1-task2 | 5m0s |  | :white_check_mark: SKIPPED |  |
+| <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/test-pipelinerun/logs/pipeline1-task1">pipeline1-task1</a> | 5m0s |  | :heavy_check_mark: SUCCESS | :heavy_check_mark: 10 success(es) |
+| <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/test-pipelinerun/logs/pipeline1-task2">pipeline1-task2</a> | 5m0s |  | :white_check_mark: SKIPPED |  |
 
 `
 		expectedTestReport := status.TestReport{


### PR DESCRIPTION
* Fetch the console task log URL from CONSOLE_URL_TASKLOG environment variable
* Add the link to the task name on the detailed report so it redirects to task details in Konflux UI console

Example updated detailed report with task links:
![image](https://github.com/redhat-appstudio/integration-service/assets/34320458/cefd1100-0774-423c-9fd7-d4afa102a6e0)

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
