### PR TITLE
feat(STONEINTG-578): don't block other ITS test if one of them fails

### DIFF
--- a/controllers/scenario/scenario_adapter.go
+++ b/controllers/scenario/scenario_adapter.go
@@ -22,7 +22,6 @@ import (
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/api/v1beta1"
-	"github.com/redhat-appstudio/integration-service/gitops"
 	h "github.com/redhat-appstudio/integration-service/helpers"
 	"github.com/redhat-appstudio/integration-service/loader"
 	"github.com/redhat-appstudio/operator-toolkit/controller"
@@ -67,7 +66,7 @@ func (a *Adapter) EnsureCreatedScenarioIsValid() (controller.OperationResult, er
 		a.logger.Info("Application for scenario was not found.")
 
 		patch := client.MergeFrom(a.scenario.DeepCopy())
-		gitops.SetScenarioIntegrationStatusAsInvalid(a.scenario, "Failed to get application for scenario.")
+		h.SetScenarioIntegrationStatusAsInvalid(a.scenario, "Failed to get application for scenario.")
 		err := a.client.Status().Patch(a.context, a.scenario, patch)
 		if err != nil {
 			a.logger.Error(err, "Failed to update Scenario")
@@ -109,7 +108,7 @@ func (a *Adapter) EnsureCreatedScenarioIsValid() (controller.OperationResult, er
 			a.logger.Info("Environment doesn't exist in same namespace as IntegrationTestScenario.",
 				"environment.Name:", a.scenario.Spec.Environment.Name)
 			patch := client.MergeFrom(a.scenario.DeepCopy())
-			gitops.SetScenarioIntegrationStatusAsInvalid(a.scenario, "Environment "+a.scenario.Spec.Environment.Name+" is located in different namespace than scenario.")
+			h.SetScenarioIntegrationStatusAsInvalid(a.scenario, "Environment "+a.scenario.Spec.Environment.Name+" is located in different namespace than scenario.")
 			err = a.client.Status().Patch(a.context, a.scenario, patch)
 			if err != nil {
 				a.logger.Error(err, "Failed to update Scenario")
@@ -123,9 +122,9 @@ func (a *Adapter) EnsureCreatedScenarioIsValid() (controller.OperationResult, er
 	}
 
 	// If the scenario status IntegrationTestScenarioValid condition is not defined or false, we set it to Valid
-	if reflect.ValueOf(a.scenario.Status).IsZero() || !meta.IsStatusConditionTrue(a.scenario.Status.Conditions, gitops.IntegrationTestScenarioValid) {
+	if reflect.ValueOf(a.scenario.Status).IsZero() || !meta.IsStatusConditionTrue(a.scenario.Status.Conditions, h.IntegrationTestScenarioValid) {
 		patch := client.MergeFrom(a.scenario.DeepCopy())
-		gitops.SetScenarioIntegrationStatusAsValid(a.scenario, "Integration test scenario is Valid.")
+		h.SetScenarioIntegrationStatusAsValid(a.scenario, "Integration test scenario is Valid.")
 		err := a.client.Status().Patch(a.context, a.scenario, patch)
 		if err != nil {
 			a.logger.Error(err, "Failed to update Scenario")

--- a/controllers/scenario/scenario_adapter_test.go
+++ b/controllers/scenario/scenario_adapter_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 				result, err := adapter.EnsureCreatedScenarioIsValid()
 				return !result.CancelRequest && err == nil
 			}, time.Second*10).Should(BeTrue())
-			Expect(meta.IsStatusConditionFalse(integrationTestScenario.Status.Conditions, gitops.IntegrationTestScenarioValid)).To(BeTrue())
+			Expect(meta.IsStatusConditionFalse(integrationTestScenario.Status.Conditions, helpers.IntegrationTestScenarioValid)).To(BeTrue())
 		})
 
 	})

--- a/controllers/scenario/scenario_adapter_test.go
+++ b/controllers/scenario/scenario_adapter_test.go
@@ -257,20 +257,6 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 		}, time.Second*20).Should(BeTrue())
 	})
 
-	It("ensures the Scenario status can be marked as invalid", func() {
-		SetScenarioIntegrationStatusAsInvalid(invalidScenario, "Test message")
-		Expect(invalidScenario).NotTo(BeNil())
-		Expect(invalidScenario.Status.Conditions).NotTo(BeNil())
-		Expect(meta.IsStatusConditionFalse(invalidScenario.Status.Conditions, gitops.IntegrationTestScenarioValid)).To(BeTrue())
-	})
-
-	It("ensures the Scenario status can be marked as valid", func() {
-		SetScenarioIntegrationStatusAsValid(integrationTestScenario, "Test message")
-		Expect(integrationTestScenario).NotTo(BeNil())
-		Expect(integrationTestScenario.Status.Conditions).NotTo(BeNil())
-		Expect(meta.IsStatusConditionTrue(integrationTestScenario.Status.Conditions, gitops.IntegrationTestScenarioValid)).To(BeTrue())
-	})
-
 	When("IntegrationTestScenario is deleted while environment resources are still on the cluster", func() {
 		var (
 			ephemeralEnvironment  *applicationapiv1alpha1.Environment

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -221,10 +221,10 @@ func (a *Adapter) EnsureStaticIntegrationPipelineRunsExist() (controller.Operati
 		var errsForPLRCreation error
 		for _, integrationTestScenario := range *integrationTestScenarios {
 			integrationTestScenario := integrationTestScenario //G601
-			if !gitops.IsScenarioValid(&integrationTestScenario) {
+			if !h.IsScenarioValid(&integrationTestScenario) {
 				a.logger.Info("IntegrationTestScenario is invalid, will not create pipelineRun for it",
 					"integrationTestScenario.Name", integrationTestScenario.Name)
-				scenarioStatusCondition := meta.FindStatusCondition(integrationTestScenario.Status.Conditions, gitops.IntegrationTestScenarioValid)
+				scenarioStatusCondition := meta.FindStatusCondition(integrationTestScenario.Status.Conditions, h.IntegrationTestScenarioValid)
 				testStatuses.UpdateTestStatusIfChanged(
 					integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestInvalid,
 					fmt.Sprintf("IntegrationTestScenario '%s' is invalid: %s", integrationTestScenario.Name, scenarioStatusCondition.Message))

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	clienterrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
@@ -217,8 +218,18 @@ func (a *Adapter) EnsureStaticIntegrationPipelineRunsExist() (controller.Operati
 			}
 		}()
 
+		var errsForPLRCreation error
 		for _, integrationTestScenario := range *integrationTestScenarios {
 			integrationTestScenario := integrationTestScenario //G601
+			if !gitops.IsScenarioValid(&integrationTestScenario) {
+				a.logger.Info("IntegrationTestScenario is invalid, will not create pipelineRun for it",
+					"integrationTestScenario.Name", integrationTestScenario.Name)
+				scenarioStatusCondition := meta.FindStatusCondition(integrationTestScenario.Status.Conditions, gitops.IntegrationTestScenarioValid)
+				testStatuses.UpdateTestStatusIfChanged(
+					integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestInvalid,
+					fmt.Sprintf("IntegrationTestScenario '%s' is invalid: %s", integrationTestScenario.Name, scenarioStatusCondition.Message))
+				continue
+			}
 			if shouldScenarioRunInEphemeralEnv(&integrationTestScenario) {
 				// integration pipeline runs for scenarios which need an ephemeral environment are handled in EnsureCreationOfEphemeralEnvironments()
 				a.logger.Info("IntegrationTestScenario has environment defined, skipping creation of pipelinerun.", "IntegrationTestScenario", integrationTestScenario)
@@ -234,7 +245,18 @@ func (a *Adapter) EnsureStaticIntegrationPipelineRunsExist() (controller.Operati
 			} else {
 				pipelineRun, err := a.createIntegrationPipelineRun(a.application, &integrationTestScenario, a.snapshot)
 				if err != nil {
-					return a.HandlePipelineCreationError(err, &integrationTestScenario, testStatuses)
+					if clienterrors.IsInvalid(err) {
+						a.logger.Error(err, "pipelineRun failed during creation due to invalid resource",
+							"integrationScenario.Name", integrationTestScenario.Name)
+						testStatuses.UpdateTestStatusIfChanged(
+							integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestInvalid,
+							fmt.Sprintf("Creation of pipelineRun failed during creation due to invalid resource: %s.", err))
+					} else {
+						a.logger.Error(err, "Failed to create pipelineRun for snapshot and scenario",
+							"integrationScenario.Name", integrationTestScenario.Name)
+						errsForPLRCreation = errors.Join(errsForPLRCreation, err)
+					}
+					continue
 				}
 				gitops.PrepareToRegisterIntegrationPipelineRunStarted(a.snapshot) // don't count re-runs
 				testStatuses.UpdateTestStatusIfChanged(
@@ -249,7 +271,12 @@ func (a *Adapter) EnsureStaticIntegrationPipelineRunsExist() (controller.Operati
 
 		err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.snapshot, testStatuses, a.client, a.context)
 		if err != nil {
-			return controller.RequeueWithError(err)
+			a.logger.Error(err, "Failed to update test status in snapshot annotation")
+			errsForPLRCreation = errors.Join(errsForPLRCreation, err)
+		}
+
+		if errsForPLRCreation != nil {
+			return controller.RequeueWithError(errsForPLRCreation)
 		}
 	}
 

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, integrationTestScenario)).Should(Succeed())
-		gitops.SetScenarioIntegrationStatusAsValid(integrationTestScenario, "valid")
+		helpers.SetScenarioIntegrationStatusAsValid(integrationTestScenario, "valid")
 
 		integrationTestScenarioWithoutEnv = &v1beta1.IntegrationTestScenario{
 			ObjectMeta: metav1.ObjectMeta{
@@ -162,7 +162,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, integrationTestScenarioWithoutEnv)).Should(Succeed())
-		gitops.SetScenarioIntegrationStatusAsValid(integrationTestScenarioWithoutEnv, "valid")
+		helpers.SetScenarioIntegrationStatusAsValid(integrationTestScenarioWithoutEnv, "valid")
 
 		testReleasePlan = &releasev1alpha1.ReleasePlan{
 			ObjectMeta: metav1.ObjectMeta{
@@ -372,7 +372,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, integrationTestScenarioWithoutEnvCopy)).Should(Succeed())
-			gitops.SetScenarioIntegrationStatusAsValid(integrationTestScenarioWithoutEnvCopy, "valid")
+			helpers.SetScenarioIntegrationStatusAsValid(integrationTestScenarioWithoutEnvCopy, "valid")
 
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
@@ -1044,7 +1044,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, integrationTestScenarioForInvalidSnapshot)).Should(Succeed())
-			gitops.SetScenarioIntegrationStatusAsValid(integrationTestScenarioForInvalidSnapshot, "valid")
+			helpers.SetScenarioIntegrationStatusAsValid(integrationTestScenarioForInvalidSnapshot, "valid")
 
 			Eventually(func() error {
 				err := k8sClient.Get(ctx, types.NamespacedName{
@@ -1106,13 +1106,13 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 
-		It("will stop reconciliation and write status to snapshot annotation", func() {
+		It("Write status to snapshot annotation when meeting invalid resource error", func() {
 			var buf bytes.Buffer
 
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
 
-			gitops.SetScenarioIntegrationStatusAsInvalid(integrationTestScenarioForInvalidSnapshot, "invalid")
+			helpers.SetScenarioIntegrationStatusAsInvalid(integrationTestScenarioForInvalidSnapshot, "invalid")
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/api/v1beta1"
 	"github.com/redhat-appstudio/integration-service/helpers"
 	"github.com/redhat-appstudio/integration-service/metrics"
 	"github.com/redhat-appstudio/integration-service/tekton"
@@ -853,4 +854,30 @@ func CopySnapshotLabelsAndAnnotation(application *applicationapiv1alpha1.Applica
 	_ = metadata.CopyLabelsByPrefix(source, &snapshot.ObjectMeta, prefix)
 	_ = metadata.CopyAnnotationsByPrefix(source, &snapshot.ObjectMeta, prefix)
 
+}
+
+// SetScenarioIntegrationStatusAsInvalid sets the IntegrationTestScenarioValid status condition for the Scenario to invalid.
+func SetScenarioIntegrationStatusAsInvalid(scenario *v1beta1.IntegrationTestScenario, message string) {
+	meta.SetStatusCondition(&scenario.Status.Conditions, metav1.Condition{
+		Type:    IntegrationTestScenarioValid,
+		Status:  metav1.ConditionFalse,
+		Reason:  AppStudioIntegrationStatusInvalid,
+		Message: message,
+	})
+}
+
+// SetScenarioIntegrationStatusAsValid sets the IntegrationTestScenarioValid integration status condition for the Scenario to valid.
+func SetScenarioIntegrationStatusAsValid(scenario *v1beta1.IntegrationTestScenario, message string) {
+	meta.SetStatusCondition(&scenario.Status.Conditions, metav1.Condition{
+		Type:    IntegrationTestScenarioValid,
+		Status:  metav1.ConditionTrue,
+		Reason:  AppStudioIntegrationStatusValid,
+		Message: message,
+	})
+}
+
+// IsScenarioValid sets the IntegrationTestScenarioValid integration status condition for the Scenario to valid.
+func IsScenarioValid(scenario *v1beta1.IntegrationTestScenario) bool {
+	statusCondition := meta.FindStatusCondition(scenario.Status.Conditions, IntegrationTestScenarioValid)
+	return statusCondition.Status != metav1.ConditionFalse
 }

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	"github.com/redhat-appstudio/integration-service/api/v1beta1"
 	"github.com/redhat-appstudio/integration-service/helpers"
 	"github.com/redhat-appstudio/integration-service/metrics"
 	"github.com/redhat-appstudio/integration-service/tekton"
@@ -141,9 +140,6 @@ const (
 	// LegacyIntegrationStatusCondition is the condition for marking the AppStudio integration status of the Snapshot.
 	LegacyIntegrationStatusCondition = "HACBSIntegrationStatus"
 
-	// IntegrationTestScenarioValid is the condition for marking the AppStudio integration status of the Scenario.
-	IntegrationTestScenarioValid = "IntegrationTestScenarioValid"
-
 	// SnapshotDeployedToRootEnvironmentsCondition is the condition for marking if Snapshot was deployed to root environments
 	// within the user's workspace.
 	SnapshotDeployedToRootEnvironmentsCondition = "DeployedToRootEnvironments"
@@ -166,9 +162,6 @@ const (
 
 	// AppStudioIntegrationStatusErrorOccured is the reason that's set when the AppStudio integration gets into an error state.
 	AppStudioIntegrationStatusErrorOccured = "ErrorOccured"
-
-	// AppStudioIntegrationStatusValid is the reason that's set when the AppStudio integration gets into an valid state.
-	AppStudioIntegrationStatusValid = "Valid"
 
 	//AppStudioIntegrationStatusInProgress is the reason that's set when the AppStudio tests gets into an in progress state.
 	AppStudioIntegrationStatusInProgress = "InProgress"
@@ -854,30 +847,4 @@ func CopySnapshotLabelsAndAnnotation(application *applicationapiv1alpha1.Applica
 	_ = metadata.CopyLabelsByPrefix(source, &snapshot.ObjectMeta, prefix)
 	_ = metadata.CopyAnnotationsByPrefix(source, &snapshot.ObjectMeta, prefix)
 
-}
-
-// SetScenarioIntegrationStatusAsInvalid sets the IntegrationTestScenarioValid status condition for the Scenario to invalid.
-func SetScenarioIntegrationStatusAsInvalid(scenario *v1beta1.IntegrationTestScenario, message string) {
-	meta.SetStatusCondition(&scenario.Status.Conditions, metav1.Condition{
-		Type:    IntegrationTestScenarioValid,
-		Status:  metav1.ConditionFalse,
-		Reason:  AppStudioIntegrationStatusInvalid,
-		Message: message,
-	})
-}
-
-// SetScenarioIntegrationStatusAsValid sets the IntegrationTestScenarioValid integration status condition for the Scenario to valid.
-func SetScenarioIntegrationStatusAsValid(scenario *v1beta1.IntegrationTestScenario, message string) {
-	meta.SetStatusCondition(&scenario.Status.Conditions, metav1.Condition{
-		Type:    IntegrationTestScenarioValid,
-		Status:  metav1.ConditionTrue,
-		Reason:  AppStudioIntegrationStatusValid,
-		Message: message,
-	})
-}
-
-// IsScenarioValid sets the IntegrationTestScenarioValid integration status condition for the Scenario to valid.
-func IsScenarioValid(scenario *v1beta1.IntegrationTestScenario) bool {
-	statusCondition := meta.FindStatusCondition(scenario.Status.Conditions, IntegrationTestScenarioValid)
-	return statusCondition.Status != metav1.ConditionFalse
 }

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/api/v1beta1"
 	"github.com/redhat-appstudio/integration-service/gitops"
 	"github.com/redhat-appstudio/operator-toolkit/metadata"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -37,10 +38,11 @@ import (
 var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 	var (
-		hasApp      *applicationapiv1alpha1.Application
-		hasComp     *applicationapiv1alpha1.Component
-		hasSnapshot *applicationapiv1alpha1.Snapshot
-		sampleImage string
+		hasApp                  *applicationapiv1alpha1.Application
+		hasComp                 *applicationapiv1alpha1.Component
+		hasSnapshot             *applicationapiv1alpha1.Snapshot
+		integrationTestScenario *v1beta1.IntegrationTestScenario
+		sampleImage             string
 	)
 
 	const (
@@ -83,6 +85,45 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
+
+		integrationTestScenario = &v1beta1.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-pass",
+				Namespace: "default",
+
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/optional": "false",
+				},
+			},
+			Spec: v1beta1.IntegrationTestScenarioSpec{
+				Application: "application-sample",
+				ResolverRef: v1beta1.ResolverRef{
+					Resolver: "git",
+					Params: []v1beta1.ResolverParameter{
+						{
+							Name:  "url",
+							Value: "https://github.com/redhat-appstudio/integration-examples.git",
+						},
+						{
+							Name:  "revision",
+							Value: "main",
+						},
+						{
+							Name:  "pathInRepo",
+							Value: "pipelineruns/integration_pipelinerun_pass.yaml",
+						},
+					},
+				},
+				Environment: v1beta1.TestEnvironment{
+					Name: "envname",
+					Type: "POC",
+					Configuration: &applicationapiv1alpha1.EnvironmentConfiguration{
+						Env: []applicationapiv1alpha1.EnvVarPair{},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, integrationTestScenario)).Should(Succeed())
 	})
 
 	BeforeEach(func() {
@@ -127,6 +168,8 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		err := k8sClient.Delete(ctx, hasComp)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasSnapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, integrationTestScenario)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 	})
 
@@ -567,7 +610,21 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				Expect(snapshotRerun.GetLabels()).ShouldNot(m, "shouldn't have re-run label")
 			})
 		})
-
 	})
 
+	Context("IntegrationTestscenario can be marked as valid and invalid", func() {
+		It("ensures the Scenario status can be marked as invalid", func() {
+			gitops.SetScenarioIntegrationStatusAsInvalid(integrationTestScenario, "Test message")
+			Expect(integrationTestScenario).NotTo(BeNil())
+			Expect(gitops.IsScenarioValid(integrationTestScenario)).To(BeFalse())
+			Expect(meta.IsStatusConditionFalse(integrationTestScenario.Status.Conditions, gitops.IntegrationTestScenarioValid)).To(BeTrue())
+		})
+
+		It("ensures the Scenario status can be marked as valid", func() {
+			gitops.SetScenarioIntegrationStatusAsValid(integrationTestScenario, "Test message")
+			Expect(integrationTestScenario).NotTo(BeNil())
+			Expect(gitops.IsScenarioValid(integrationTestScenario)).To(BeTrue())
+			Expect(meta.IsStatusConditionTrue(integrationTestScenario.Status.Conditions, gitops.IntegrationTestScenarioValid)).To(BeTrue())
+		})
+	})
 })

--- a/helpers/scenario.go
+++ b/helpers/scenario.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/redhat-appstudio/integration-service/api/v1beta1"
+)
+
+const (
+
+	// IntegrationTestScenarioValid is the condition for marking the AppStudio integration status of the Scenario.
+	IntegrationTestScenarioValid = "IntegrationTestScenarioValid"
+
+	// AppStudioIntegrationStatusInvalid is the reason that's set when the AppStudio integration gets into an invalid state.
+	AppStudioIntegrationStatusInvalid = "Invalid"
+
+	// AppStudioIntegrationStatusValid is the reason that's set when the AppStudio integration gets into an valid state.
+	AppStudioIntegrationStatusValid = "Valid"
+)
+
+// SetScenarioIntegrationStatusAsInvalid sets the IntegrationTestScenarioValid status condition for the Scenario to invalid.
+func SetScenarioIntegrationStatusAsInvalid(scenario *v1beta1.IntegrationTestScenario, message string) {
+	meta.SetStatusCondition(&scenario.Status.Conditions, metav1.Condition{
+		Type:    IntegrationTestScenarioValid,
+		Status:  metav1.ConditionFalse,
+		Reason:  AppStudioIntegrationStatusInvalid,
+		Message: message,
+	})
+}
+
+// SetScenarioIntegrationStatusAsValid sets the IntegrationTestScenarioValid integration status condition for the Scenario to valid.
+func SetScenarioIntegrationStatusAsValid(scenario *v1beta1.IntegrationTestScenario, message string) {
+	meta.SetStatusCondition(&scenario.Status.Conditions, metav1.Condition{
+		Type:    IntegrationTestScenarioValid,
+		Status:  metav1.ConditionTrue,
+		Reason:  AppStudioIntegrationStatusValid,
+		Message: message,
+	})
+}
+
+// IsScenarioValid sets the IntegrationTestScenarioValid integration status condition for the Scenario to valid.
+func IsScenarioValid(scenario *v1beta1.IntegrationTestScenario) bool {
+	statusCondition := meta.FindStatusCondition(scenario.Status.Conditions, IntegrationTestScenarioValid)
+	return statusCondition.Status != metav1.ConditionFalse
+}

--- a/helpers/scenario_test.go
+++ b/helpers/scenario_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/integration-service/api/v1beta1"
+	"github.com/redhat-appstudio/integration-service/helpers"
+)
+
+var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
+
+	var (
+		integrationTestScenario *v1beta1.IntegrationTestScenario
+	)
+
+	BeforeAll(func() {
+		integrationTestScenario = &v1beta1.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-pass",
+				Namespace: "default",
+
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/optional": "false",
+				},
+			},
+			Spec: v1beta1.IntegrationTestScenarioSpec{
+				Application: "application-sample",
+				ResolverRef: v1beta1.ResolverRef{
+					Resolver: "git",
+					Params: []v1beta1.ResolverParameter{
+						{
+							Name:  "url",
+							Value: "https://github.com/redhat-appstudio/integration-examples.git",
+						},
+						{
+							Name:  "revision",
+							Value: "main",
+						},
+						{
+							Name:  "pathInRepo",
+							Value: "pipelineruns/integration_pipelinerun_pass.yaml",
+						},
+					},
+				},
+				Environment: v1beta1.TestEnvironment{
+					Name: "envname",
+					Type: "POC",
+					Configuration: &applicationapiv1alpha1.EnvironmentConfiguration{
+						Env: []applicationapiv1alpha1.EnvVarPair{},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, integrationTestScenario)).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		err := k8sClient.Delete(ctx, integrationTestScenario)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	Context("IntegrationTestscenario can be marked as valid and invalid", func() {
+		It("ensures the Scenario status can be marked as invalid", func() {
+			helpers.SetScenarioIntegrationStatusAsInvalid(integrationTestScenario, "Test message")
+			Expect(integrationTestScenario).NotTo(BeNil())
+			Expect(helpers.IsScenarioValid(integrationTestScenario)).To(BeFalse())
+			Expect(meta.IsStatusConditionFalse(integrationTestScenario.Status.Conditions, helpers.IntegrationTestScenarioValid)).To(BeTrue())
+		})
+
+		It("ensures the Scenario status can be marked as valid", func() {
+			helpers.SetScenarioIntegrationStatusAsValid(integrationTestScenario, "Test message")
+			Expect(integrationTestScenario).NotTo(BeNil())
+			Expect(helpers.IsScenarioValid(integrationTestScenario)).To(BeTrue())
+			Expect(meta.IsStatusConditionTrue(integrationTestScenario.Status.Conditions, helpers.IntegrationTestScenarioValid)).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
* Continue running other ITS PLR if one ITS is misconfigured or ITS PLR fails

Signed-off-by: Hongwei Liu <hongliu@gmail.com>

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
