### PR TITLE
fix(gosec): implicit memory aliasing in for loop

### DIFF
--- a/controllers/scenario/scenario_adapter.go
+++ b/controllers/scenario/scenario_adapter.go
@@ -157,6 +157,7 @@ func (a *Adapter) EnsureDeletedScenarioResourcesAreCleanedUp() (controller.Opera
 		return controller.RequeueWithError(err)
 	}
 	for _, testEnvironment := range *environmentsForScenario {
+		testEnvironment := testEnvironment
 		if h.IsEnvironmentEphemeral(&testEnvironment) {
 			dtc, err := a.loader.GetDeploymentTargetClaimForEnvironment(a.client, a.context, &testEnvironment)
 			if err != nil || dtc == nil {


### PR DESCRIPTION
Fixing gosec: G601 (CWE-118): Implicit memory aliasing in for loop.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
