### PR TITLE
fix(KFLUXBUGS-1202): use proper project id when talking with GL project

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -110,6 +110,9 @@ const (
 	// PipelineAsCodeSourceProjectIDAnnotation is the source project ID for gitlab
 	PipelineAsCodeSourceProjectIDAnnotation = PipelinesAsCodePrefix + "/source-project-id"
 
+	// PipelineAsCodeTargetProjectIDAnnotation is the target project ID for gitlab
+	PipelineAsCodeTargetProjectIDAnnotation = PipelinesAsCodePrefix + "/target-project-id"
+
 	// PipelineAsCodePushType is the type of push event which triggered the pipelinerun in build service
 	PipelineAsCodePushType = "push"
 

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -43,10 +43,11 @@ import (
 var _ = Describe("GitLabReporter", func() {
 
 	const (
-		repoUrl      = "https://gitlab.com/example/example"
-		digest       = "12a4a35ccd08194595179815e4646c3a6c08bb77"
-		projectID    = "123"
-		mergeRequest = "45"
+		repoUrl         = "https://gitlab.com/example/example"
+		digest          = "12a4a35ccd08194595179815e4646c3a6c08bb77"
+		sourceProjectID = "123"
+		targetProjectID = "456"
+		mergeRequest    = "45"
 	)
 
 	var (
@@ -77,7 +78,8 @@ var _ = Describe("GitLabReporter", func() {
 					"build.appstudio.redhat.com/commit_sha":             digest,
 					"appstudio.redhat.com/updateComponentOnSuccess":     "false",
 					"pac.test.appstudio.openshift.io/repo-url":          repoUrl,
-					"pac.test.appstudio.openshift.io/source-project-id": projectID,
+					"pac.test.appstudio.openshift.io/target-project-id": targetProjectID,
+					"pac.test.appstudio.openshift.io/source-project-id": sourceProjectID,
 					"pac.test.appstudio.openshift.io/pull-request":      mergeRequest,
 				},
 			},
@@ -187,15 +189,16 @@ var _ = Describe("GitLabReporter", func() {
 		},
 			Entry("Missing repo_url", gitops.PipelineAsCodeRepoURLAnnotation, false),
 			Entry("Missing SHA", gitops.PipelineAsCodeSHALabel, true),
-			Entry("Missing project ID", gitops.PipelineAsCodeSourceProjectIDAnnotation, false),
+			Entry("Missing target project ID", gitops.PipelineAsCodeTargetProjectIDAnnotation, false),
+			Entry("Missing source project ID", gitops.PipelineAsCodeSourceProjectIDAnnotation, false),
 		)
 
 		It("creates a commit status for snapshot with correct textual data", func() {
 
 			summary := "Integration test for snapshot snapshot-sample and scenario scenario1 failed"
 
-			muxCommitStatusPost(mux, projectID, digest, summary)
-			muxMergeNotes(mux, projectID, mergeRequest, summary)
+			muxCommitStatusPost(mux, sourceProjectID, digest, summary)
+			muxMergeNotes(mux, targetProjectID, mergeRequest, summary)
 
 			Expect(reporter.ReportStatus(
 				context.TODO(),
@@ -219,7 +222,7 @@ var _ = Describe("GitLabReporter", func() {
 				Text:         "detailed text here",
 			}
 
-			muxCommitStatusesGet(mux, projectID, digest, &report)
+			muxCommitStatusesGet(mux, sourceProjectID, digest, &report)
 
 			Expect(reporter.ReportStatus(context.TODO(), report)).To(Succeed())
 		})


### PR DESCRIPTION
    Bug: When a MR is created from the foked repo, we still try to get/create MR note from
    source target project incorrectly
    
    The fix will:
    * Get source project ID from PAC annotation
      pac.test.appstudio.openshift.io/source-project-id and create/get
      commitStatus from it
    * Get target project id from PAC annotation
      pac.test.appstudio.openshift.io/target-project-id and create/update
      MR note from this project
    
    Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
