### PR TITLE
fix: overwrite missing inherited labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,13 @@ COPY --from=builder /opt/app-root/src/manager /
 COPY --from=builder /opt/app-root/src/snapshotgc /
 
 # It is mandatory to set these labels
-LABEL description="RHTAP Integration Service"
-LABEL io.k8s.description="RHTAP Integration Service"
+LABEL name="integration-service"
+LABEL com.redhat.component="konflux-integration-service"
+LABEL description="Konflux Integration Service"
+LABEL io.k8s.description="Konflux Integration Service"
 LABEL io.k8s.display-name="Integration-service"
-LABEL summary="RHTAP Integration Service"
-LABEL io.openshift.tags="rhtap"
+LABEL summary="Konflux Integration Service"
+LABEL io.openshift.tags="konflux"
 
 USER 65532:65532
 


### PR DESCRIPTION
* Add name and com.redhat.component labels
* Replace RHTAP with Konflux in each image label

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
