### PR TITLE
fix(STONEINTG-885): add https to developmet console links

### DIFF
--- a/status/format.go
+++ b/status/format.go
@@ -222,7 +222,7 @@ func FormatFootnotes(taskRuns []*helpers.TaskRun) (string, error) {
 func FormatPipelineURL(pipelinerun string, namespace string, logger logr.Logger) string {
 	console_url := os.Getenv("CONSOLE_URL")
 	if console_url == "" {
-		return "CONSOLE_URL_NOT_AVAILABLE"
+		return "https://CONSOLE_URL_NOT_AVAILABLE"
 	}
 	buf := bytes.Buffer{}
 	data := SummaryTemplateData{PipelineRunName: pipelinerun, Namespace: namespace}
@@ -237,7 +237,7 @@ func FormatPipelineURL(pipelinerun string, namespace string, logger logr.Logger)
 func FormatTaskLogURL(taskRun *helpers.TaskRun, pipelinerun string, namespace string, logger logr.Logger) string {
 	consoleTaskLogURL := os.Getenv("CONSOLE_URL_TASKLOG")
 	if consoleTaskLogURL == "" {
-		return "CONSOLE_URL_TASKLOG_NOT_AVAILABLE"
+		return "https://CONSOLE_URL_TASKLOG_NOT_AVAILABLE"
 	}
 
 	taskName := taskRun.GetPipelineTaskName()

--- a/status/format_test.go
+++ b/status/format_test.go
@@ -200,13 +200,13 @@ var _ = Describe("Formatters", func() {
 		os.Setenv("CONSOLE_URL", "")
 		text, err := status.FormatTestsSummary(taskRuns, pipelineRun.Name, pipelineRun.Namespace, logr.Discard())
 		Expect(err).To(Succeed())
-		Expect(text).To(ContainSubstring("CONSOLE_URL_NOT_AVAILABLE"))
+		Expect(text).To(ContainSubstring("https://CONSOLE_URL_NOT_AVAILABLE"))
 	})
 
 	It("CONSOLE_URL_TASKLOG env var not set", func() {
 		os.Setenv("CONSOLE_URL_TASKLOG", "")
 		text := status.FormatTaskLogURL(taskRuns[0], pipelineRun.Name, pipelineRun.Namespace, logr.Discard())
-		Expect(text).To(ContainSubstring("CONSOLE_URL_TASKLOG_NOT_AVAILABLE"))
+		Expect(text).To(ContainSubstring("https://CONSOLE_URL_TASKLOG_NOT_AVAILABLE"))
 	})
 
 	It("can construct a comment", func() {


### PR DESCRIPTION
* Solves the error 422 Validation Failed for checkRuns because details_url must use the http or https

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
