### PR TITLE
feat(STONEINTG-697): Stop deploying successful snapshot to root envs

### DIFF
--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -138,7 +138,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		adapter.EnsureAllReleasesExist,
 		adapter.EnsureGlobalCandidateImageUpdated,
 		adapter.EnsureRerunPipelineRunsExist,
-		adapter.EnsureSnapshotEnvironmentBindingExist,
 		adapter.EnsureIntegrationPipelineRunsExist,
 	})
 }
@@ -149,7 +148,6 @@ type AdapterInterface interface {
 	EnsureRerunPipelineRunsExist() (controller.OperationResult, error)
 	EnsureIntegrationPipelineRunsExist() (controller.OperationResult, error)
 	EnsureGlobalCandidateImageUpdated() (controller.OperationResult, error)
-	EnsureSnapshotEnvironmentBindingExist() (controller.OperationResult, error)
 }
 
 // SetupController creates a new Integration controller and adds it to the Manager.

--- a/docs/snapshot-controller.md
+++ b/docs/snapshot-controller.md
@@ -79,32 +79,6 @@ flowchart TD
   mark_snapshot_autoreleased -->  continue_processing3
   encountered_error32    --Yes--> mark_snapshot_Invalid3
 
-  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureSnapshotEnvironmentBindingExists() function
-
-  %% Node definitions
-  ensure5(Process further if: Snapshot is valid & <br>Snapshot testing succeeded & <br>Snapshot was not created by <br>PAC Pull Request Event & <br> Snapshot wasn't deployed to root environments)
-  any_existing_non_eph_env{Any existing root <br>and non-ephemeral <br>environment?}
-  any_existing_SEB{Any existing-SEB <br>containing the current <br>environment and <br>application?}
-  update_existing_SEB(<b>Update</b> the existing-SEB <br>with the given Snapshot's name)
-  create_SEB_for_non_eph_env("<b>Create a new <br>SnapshotEnvironmentBinding</b> (SEB) <br>with the current env and given Snapshot")
-  encountered_error5{Encountered error?}
-  mark_snapshot_Invalid5(<b>Mark</b> the Snapshot as Invalid)
-  mark_snapshot_deployed(<b>Mark</b> the Snapshot as DeployedToRootEnvironments)
-  continue_processing5(Controller continues processing...)
-
-  %% Node connections
-  predicate                  ---->    |"EnsureSnapshotEnvironmentBindingExists()"|ensure5
-  ensure5                    -->      any_existing_non_eph_env
-  any_existing_non_eph_env   --Yes--> any_existing_SEB
-  any_existing_non_eph_env   --No-->  mark_snapshot_deployed
-  any_existing_SEB           --Yes--> update_existing_SEB
-  any_existing_SEB           --No-->  create_SEB_for_non_eph_env
-  update_existing_SEB        -->      encountered_error5
-  create_SEB_for_non_eph_env -->      encountered_error5
-  encountered_error5         --Yes--> mark_snapshot_Invalid5
-  encountered_error5         --No-->  mark_snapshot_deployed
-  mark_snapshot_deployed     -->      continue_processing5
-
 
   %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureRerunPipelineRunsExist() function
 

--- a/gitops/binding.go
+++ b/gitops/binding.go
@@ -33,26 +33,6 @@ const (
 	BindingErrorOccurredStatusConditionType string = "ErrorOccurred"
 )
 
-// NewSnapshotEnvironmentBinding creates a new SnapshotEnvironmentBinding using the provided info.
-func NewSnapshotEnvironmentBinding(bindingName string, namespace string, applicationName string, environmentName string, snapshot *applicationapiv1alpha1.Snapshot) *applicationapiv1alpha1.SnapshotEnvironmentBinding {
-	bindingComponents := NewBindingComponents(snapshot)
-
-	snapshotEnvironmentBinding := &applicationapiv1alpha1.SnapshotEnvironmentBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: bindingName + "-",
-			Namespace:    namespace,
-		},
-		Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
-			Application: applicationName,
-			Environment: environmentName,
-			Snapshot:    snapshot.Name,
-			Components:  *bindingComponents,
-		},
-	}
-
-	return snapshotEnvironmentBinding
-}
-
 // NewBindingComponents gets all components from the Snapshot and formats them to be used in the
 // SnapshotEnvironmentBinding as BindingComponents.
 func NewBindingComponents(snapshot *applicationapiv1alpha1.Snapshot) *[]applicationapiv1alpha1.BindingComponent {

--- a/gitops/binding_test.go
+++ b/gitops/binding_test.go
@@ -174,25 +174,6 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 	})
 
-	It("ensures Binding Component is created", func() {
-		err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
-		Expect(err).To(Succeed())
-		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
-		bindingComponents := gitops.NewBindingComponents(hasSnapshot)
-		Expect(bindingComponents).NotTo(BeNil())
-	})
-
-	It("ensures a new SnapshotEnvironmentBinding is created", func() {
-		newSnapshotEnvironmentBinding := gitops.NewSnapshotEnvironmentBinding("sample", namespace, hasApp.Name, env.Name, hasSnapshot)
-		Expect(newSnapshotEnvironmentBinding).NotTo(BeNil())
-		Expect(newSnapshotEnvironmentBinding.Spec.Snapshot).To(Equal(hasSnapshot.Name))
-		Expect(newSnapshotEnvironmentBinding.Spec.Environment).To(Equal(env.Name))
-		Expect(newSnapshotEnvironmentBinding.Spec.Components).To(HaveLen(1))
-
-		Expect(gitops.IsBindingDeployed(newSnapshotEnvironmentBinding)).NotTo(BeTrue())
-		Expect(gitops.HaveBindingsFailed(newSnapshotEnvironmentBinding)).NotTo(BeTrue())
-	})
-
 	It("ensures an existing deployed SnapshotEnvironmentBinding conditions are recognized", func() {
 		Expect(gitops.IsBindingDeployed(hasBinding)).To(BeTrue())
 		Expect(gitops.HaveBindingsFailed(hasBinding)).NotTo(BeTrue())

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -409,30 +409,6 @@ func IsSnapshotStatusConditionSet(snapshot *applicationapiv1alpha1.Snapshot, con
 	return true
 }
 
-// IsSnapshotMarkedAsDeployedToRootEnvironments returns true if snapshot is marked as deployed to root environments
-func IsSnapshotMarkedAsDeployedToRootEnvironments(snapshot *applicationapiv1alpha1.Snapshot) bool {
-	return IsSnapshotStatusConditionSet(snapshot, SnapshotDeployedToRootEnvironmentsCondition, metav1.ConditionTrue, "")
-}
-
-// MarkSnapshotAsDeployedToRootEnvironments updates the SnapshotDeployedToRootEnvironmentsCondition for the Snapshot to 'Deployed'.
-// If the patch command fails, an error will be returned.
-func MarkSnapshotAsDeployedToRootEnvironments(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
-	patch := client.MergeFrom(snapshot.DeepCopy())
-	condition := metav1.Condition{
-		Type:    SnapshotDeployedToRootEnvironmentsCondition,
-		Status:  metav1.ConditionTrue,
-		Reason:  "Deployed",
-		Message: message,
-	}
-	meta.SetStatusCondition(&snapshot.Status.Conditions, condition)
-
-	err := adapterClient.Status().Patch(ctx, snapshot, patch)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // IsSnapshotMarkedAsAutoReleased returns true if snapshot is marked as deployed to root environments
 func IsSnapshotMarkedAsAutoReleased(snapshot *applicationapiv1alpha1.Snapshot) bool {
 	return IsSnapshotStatusConditionSet(snapshot, SnapshotAutoReleasedCondition, metav1.ConditionTrue, "")

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -239,19 +239,6 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(gitops.IsSnapshotMarkedAsAutoReleased(hasSnapshot)).To(BeTrue())
 	})
 
-	It("ensures the Snapshots status can be marked as deployed to root environments", func() {
-		Expect(gitops.IsSnapshotMarkedAsDeployedToRootEnvironments(hasSnapshot)).To(BeFalse())
-
-		err := gitops.MarkSnapshotAsDeployedToRootEnvironments(k8sClient, ctx, hasSnapshot, "Test message")
-		Expect(err).To(BeNil())
-		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
-		foundStatusCondition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.SnapshotDeployedToRootEnvironmentsCondition)
-		Expect(foundStatusCondition.Status).To(Equal(metav1.ConditionTrue))
-		Expect(foundStatusCondition.Message).To(Equal("Test message"))
-
-		Expect(gitops.IsSnapshotMarkedAsDeployedToRootEnvironments(hasSnapshot)).To(BeTrue())
-	})
-
 	It("ensures the Snapshots status can be marked as component added to global candidate list", func() {
 		Expect(gitops.IsSnapshotMarkedAsAddedToGlobalCandidateList(hasSnapshot)).To(BeFalse())
 


### PR DESCRIPTION
To stop deploying successful snapshot to root envs, integration need to:
* Remove EnsureSnapshotEnvironmentBindingExist() and all associated (unused) functions and related unit tests
* Update controller diagram

This PR need to wait for [e2e PR](https://github.com/redhat-appstudio/e2e-tests/pull/1125) to pass integration-service-e2e
This PR might be merged after PR https://github.com/redhat-appstudio/integration-service/pull/572/files, then the shared SEB functions should be re-checked and removed.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
