### PR TITLE
fix(STONEINTG-872) add group_left() to fix many-to-one matching issue

### DIFF
--- a/config/grafana/dashboards/integration-service-health.json
+++ b/config/grafana/dashboards/integration-service-health.json
@@ -104,7 +104,7 @@
         {
           "datasource": "$datasource",
           "editorMode": "builder",
-          "expr": "100 * rate(container_cpu_usage_seconds_total{namespace=\"integration-service\",pod=~\"integration-service-controller-manager-.*\", container=\"manager\"}[5m]) / on (container, pod) kube_pod_container_resource_limits{resource=\"cpu\", namespace=\"integration-service\",pod=~\"integration-service-controller-manager-.*\", container=\"manager\"}",
+          "expr": "100 * rate(container_cpu_usage_seconds_total{namespace=\"integration-service\",pod=~\"integration-service-controller-manager-.*\", container=\"manager\"}[5m]) / on (container, pod) group_left() kube_pod_container_resource_limits{resource=\"cpu\", namespace=\"integration-service\",pod=~\"integration-service-controller-manager-.*\", container=\"manager\"}",
           "interval": "",
           "legendFormat": "% of integration service manager CPU utilization {{pod}}",
           "range": true,
@@ -194,7 +194,7 @@
         {
           "datasource": "$datasource",
           "editorMode": "builder",
-          "expr": "100 * container_memory_working_set_bytes{namespace=\"integration-service\",pod=~\"integration-service-controller-manager-.*\", container=\"manager\"}  / on (pod) kube_pod_container_resource_limits{resource=\"memory\",namespace=\"integration-service\",pod=~\"integration-service-controller-manager-.*\", container=\"manager\"}",
+          "expr": "100 * container_memory_working_set_bytes{namespace=\"integration-service\",pod=~\"integration-service-controller-manager-.*\", container=\"manager\"}  / on (pod) group_left() kube_pod_container_resource_limits{resource=\"memory\",namespace=\"integration-service\",pod=~\"integration-service-controller-manager-.*\", container=\"manager\"}",
           "interval": "",
           "legendFormat": "% of integration service manager memory utilization {{pod}}",
           "range": true,


### PR DESCRIPTION
Issue:
*There is error message in health dashboard CPU metric https://grafana-access-appstudio-grafana.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/d/b18e4904-b2c7-4942-8df6-60ffeeb04dde/integration-service-health?orgId=1&from=now-24h&to=now&inspect=7&inspectTab=error:
 Status: 500. Message: execution: multiple matches for labels:
 many-to-one matching must be explicit (group_left/group_right)

Fix:
* add group_left to fix  the error Errorexecuting query:multiple matchesforlabels:many-to-one matching must beexplicit(group_left/group_right). Refer to https://iximiuz.com/en/posts/prometheus-vector-matching/

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
