### PR TITLE
fix(STONEINTG-828): dont' add finalizer to deleted component

### DIFF
--- a/controllers/component/component_controller_test.go
+++ b/controllers/component/component_controller_test.go
@@ -1,8 +1,9 @@
 package component
 
 import (
-	"k8s.io/apimachinery/pkg/api/errors"
 	"reflect"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -22,7 +23,7 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
-var _ = Describe("ComponentController", func() {
+var _ = Describe("ComponentController", Ordered, func() {
 	var (
 		manager             ctrl.Manager
 		componentReconciler *Reconciler
@@ -35,7 +36,7 @@ var _ = Describe("ComponentController", func() {
 		SampleRepoLink = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
 	)
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 
 		applicationName := "application-sample"
 
@@ -102,7 +103,7 @@ var _ = Describe("ComponentController", func() {
 
 		componentReconciler = NewComponentReconciler(k8sClient, &logf.Log, &scheme)
 	})
-	AfterEach(func() {
+	AfterAll(func() {
 		err := k8sClient.Delete(ctx, hasApp)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasComp)

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -61,6 +61,7 @@ type ObjectLoader interface {
 	GetAllSnapshotsForBuildPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]applicationapiv1alpha1.Snapshot, error)
 	GetAllTaskRunsWithMatchingPipelineRunLabel(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]tektonv1.TaskRun, error)
 	GetPipelineRun(ctx context.Context, c client.Client, name, namespace string) (*tektonv1.PipelineRun, error)
+	GetComponent(ctx context.Context, c client.Client, name, namespace string) (*applicationapiv1alpha1.Component, error)
 }
 
 type loader struct{}
@@ -478,4 +479,10 @@ func (l *loader) GetAllTaskRunsWithMatchingPipelineRunLabel(ctx context.Context,
 func (l *loader) GetPipelineRun(ctx context.Context, c client.Client, name, namespace string) (*tektonv1.PipelineRun, error) {
 	pipelineRun := &tektonv1.PipelineRun{}
 	return pipelineRun, toolkit.GetObject(name, namespace, c, ctx, pipelineRun)
+}
+
+// GetComponent returns application component requested by name and namespace
+func (l *loader) GetComponent(ctx context.Context, c client.Client, name, namespace string) (*applicationapiv1alpha1.Component, error) {
+	component := &applicationapiv1alpha1.Component{}
+	return component, toolkit.GetObject(name, namespace, c, ctx, component)
 }

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -54,6 +54,7 @@ const (
 	AllSnapshotsForBuildPipelineRunContextKey
 	AllTaskRunsWithMatchingPipelineRunLabelContextKey
 	GetPipelineRunContextKey
+	GetComponentContextKey
 )
 
 func NewMockLoader() ObjectLoader {
@@ -252,4 +253,12 @@ func (l *mockLoader) GetPipelineRun(ctx context.Context, c client.Client, name, 
 		return l.loader.GetPipelineRun(ctx, c, name, namespace)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, GetPipelineRunContextKey, &tektonv1.PipelineRun{})
+}
+
+// GetComponent returns the resource and error passed as values of the context.
+func (l *mockLoader) GetComponent(ctx context.Context, c client.Client, name, namespace string) (*applicationapiv1alpha1.Component, error) {
+	if ctx.Value(GetComponentContextKey) == nil {
+		return l.loader.GetComponent(ctx, c, name, namespace)
+	}
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, GetComponentContextKey, &applicationapiv1alpha1.Component{})
 }

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -365,4 +365,19 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Context("When calling GetComponent", func() {
+		It("returns resource and error from the context", func() {
+			component := &applicationapiv1alpha1.Component{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: GetComponentContextKey,
+					Resource:   component,
+				},
+			})
+			resource, err := loader.GetComponent(mockContext, nil, "", "")
+			Expect(resource).To(Equal(component))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -780,5 +780,13 @@ var _ = Describe("Loader", Ordered, func() {
 			Expect(fetchedBuildPipelineRun.Namespace).To(Equal(buildPipelineRun.Namespace))
 			Expect(fetchedBuildPipelineRun.Spec).To(Equal(buildPipelineRun.Spec))
 		})
+
+		It("Can fetch component", func() {
+			fetchedBuildComponent, err := loader.GetComponent(ctx, k8sClient, hasComp.Spec.ComponentName, hasComp.Namespace)
+			Expect(err).To(Succeed())
+			Expect(fetchedBuildComponent.Name).To(Equal(hasComp.Spec.ComponentName))
+			Expect(fetchedBuildComponent.Namespace).To(Equal(hasComp.Namespace))
+			Expect(fetchedBuildComponent.Spec).To(Equal(hasComp.Spec))
+		})
 	})
 })


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)

We have been running into the issue that finalizers are being add to objects that are being deleted - components.
This changes should prevent that from happening by getting the object before such action.