### PR TITLE
fix: clarify error messages in gitlab reporter initialization

### DIFF
--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -98,7 +98,7 @@ func (r *GitLabReporter) Initialize(ctx context.Context, snapshot *applicationap
 
 	targetProjectIDstr, found := annotations[gitops.PipelineAsCodeTargetProjectIDAnnotation]
 	if !found {
-		return fmt.Errorf("project ID label not found %q", gitops.PipelineAsCodeTargetProjectIDAnnotation)
+		return fmt.Errorf("target project ID annotation not found %q", gitops.PipelineAsCodeTargetProjectIDAnnotation)
 	}
 
 	r.targetProjectID, err = strconv.Atoi(targetProjectIDstr)
@@ -108,7 +108,7 @@ func (r *GitLabReporter) Initialize(ctx context.Context, snapshot *applicationap
 
 	sourceProjectIDstr, found := annotations[gitops.PipelineAsCodeSourceProjectIDAnnotation]
 	if !found {
-		return fmt.Errorf("project ID label not found %q", gitops.PipelineAsCodeSourceProjectIDAnnotation)
+		return fmt.Errorf("source project ID annotation not found %q", gitops.PipelineAsCodeSourceProjectIDAnnotation)
 	}
 
 	r.sourceProjectID, err = strconv.Atoi(sourceProjectIDstr)


### PR DESCRIPTION
Make some error messages in the gitlab reporter initialization correctly report "annotation" rather than "label."  Also differentiate betwen missing source project id and target project id annotations

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
