### PR TITLE
refactor(STONEINTG-774): make ctx first param

### DIFF
--- a/controllers/buildpipeline/buildpipeline_adapter.go
+++ b/controllers/buildpipeline/buildpipeline_adapter.go
@@ -19,10 +19,11 @@ package buildpipeline
 import (
 	"context"
 	"fmt"
-	"k8s.io/client-go/util/retry"
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/client-go/util/retry"
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/integration-service/gitops"
@@ -178,7 +179,7 @@ func (a *Adapter) EnsurePipelineIsFinalized() (controller.OperationResult, error
 		return controller.ContinueProcessing()
 	}
 
-	err := h.AddFinalizerToPipelineRun(a.client, a.logger, a.context, a.pipelineRun, h.IntegrationPipelineRunFinalizer)
+	err := h.AddFinalizerToPipelineRun(a.context, a.client, a.logger, a.pipelineRun, h.IntegrationPipelineRunFinalizer)
 	if err != nil {
 		a.logger.Error(err, fmt.Sprintf("Could not add finalizer %s to build pipeline %s", h.IntegrationPipelineRunFinalizer, a.pipelineRun.Name))
 		return controller.RequeueWithError(err)
@@ -295,7 +296,7 @@ func (a *Adapter) updateBuildPipelineRunWithFinalInfo(canRemoveFinalizer bool) e
 		}
 
 		if canRemoveFinalizer {
-			err = h.RemoveFinalizerFromPipelineRun(a.client, a.logger, a.context, a.pipelineRun, h.IntegrationPipelineRunFinalizer)
+			err = h.RemoveFinalizerFromPipelineRun(a.context, a.client, a.logger, a.pipelineRun, h.IntegrationPipelineRunFinalizer)
 			if err != nil {
 				return err
 			}

--- a/controllers/buildpipeline/buildpipeline_adapter.go
+++ b/controllers/buildpipeline/buildpipeline_adapter.go
@@ -107,7 +107,7 @@ func (a *Adapter) EnsureSnapshotExists() (result controller.OperationResult, err
 		return controller.ContinueProcessing()
 	}
 
-	existingSnapshots, err := a.loader.GetAllSnapshotsForBuildPipelineRun(a.client, a.context, a.pipelineRun)
+	existingSnapshots, err := a.loader.GetAllSnapshotsForBuildPipelineRun(a.context, a.client, a.pipelineRun)
 	if err != nil {
 		a.logger.Error(err, "Failed to fetch Snapshots for the build pipelineRun")
 		return controller.RequeueWithError(err)
@@ -236,7 +236,7 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRu
 		return nil, err
 	}
 
-	applicationComponents, err := a.loader.GetAllApplicationComponents(a.client, a.context, application)
+	applicationComponents, err := a.loader.GetAllApplicationComponents(a.context, a.client, application)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRu
 func (a *Adapter) annotateBuildPipelineRunWithSnapshot(snapshot *applicationapiv1alpha1.Snapshot) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var err error
-		a.pipelineRun, err = a.loader.GetPipelineRun(a.client, a.context, a.pipelineRun.Name, a.pipelineRun.Namespace)
+		a.pipelineRun, err = a.loader.GetPipelineRun(a.context, a.client, a.pipelineRun.Name, a.pipelineRun.Namespace)
 		if err != nil {
 			return err
 		}
@@ -280,7 +280,7 @@ func (a *Adapter) annotateBuildPipelineRunWithSnapshot(snapshot *applicationapiv
 func (a *Adapter) updateBuildPipelineRunWithFinalInfo(canRemoveFinalizer bool) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var err error
-		a.pipelineRun, err = a.loader.GetPipelineRun(a.client, a.context, a.pipelineRun.Name, a.pipelineRun.Namespace)
+		a.pipelineRun, err = a.loader.GetPipelineRun(a.context, a.client, a.pipelineRun.Name, a.pipelineRun.Namespace)
 		if err != nil {
 			return err
 		}

--- a/controllers/buildpipeline/buildpipeline_adapter.go
+++ b/controllers/buildpipeline/buildpipeline_adapter.go
@@ -50,8 +50,9 @@ type Adapter struct {
 }
 
 // NewAdapter creates and returns an Adapter instance.
-func NewAdapter(pipelineRun *tektonv1.PipelineRun, component *applicationapiv1alpha1.Component, application *applicationapiv1alpha1.Application, logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
-	context context.Context) *Adapter {
+func NewAdapter(context context.Context, pipelineRun *tektonv1.PipelineRun, component *applicationapiv1alpha1.Component, application *applicationapiv1alpha1.Application,
+	logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
+) *Adapter {
 	return &Adapter{
 		pipelineRun: pipelineRun,
 		component:   component,

--- a/controllers/buildpipeline/buildpipeline_adapter.go
+++ b/controllers/buildpipeline/buildpipeline_adapter.go
@@ -241,7 +241,7 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRu
 		return nil, err
 	}
 
-	snapshot, err := gitops.PrepareSnapshot(a.client, a.context, application, applicationComponents, component, newContainerImage, componentSource)
+	snapshot, err := gitops.PrepareSnapshot(a.context, a.client, application, applicationComponents, component, newContainerImage, componentSource)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/buildpipeline/buildpipeline_adapter_test.go
+++ b/controllers/buildpipeline/buildpipeline_adapter_test.go
@@ -392,7 +392,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(err).To(BeNil())
 			Expect(applicationComponents).NotTo(BeNil())
 
-			snapshot, err := gitops.PrepareSnapshot(adapter.client, adapter.context, hasApp, applicationComponents, hasComp, imagePullSpec, componentSource)
+			snapshot, err := gitops.PrepareSnapshot(adapter.context, adapter.client, hasApp, applicationComponents, hasComp, imagePullSpec, componentSource)
 			Expect(snapshot).NotTo(BeNil())
 			Expect(err).To(BeNil())
 			Expect(snapshot).NotTo(BeNil())

--- a/controllers/buildpipeline/buildpipeline_adapter_test.go
+++ b/controllers/buildpipeline/buildpipeline_adapter_test.go
@@ -388,7 +388,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			componentSource, err := adapter.getComponentSourceFromPipelineRun(buildPipelineRun)
 			Expect(err).To(BeNil())
 
-			applicationComponents, err := adapter.loader.GetAllApplicationComponents(adapter.client, adapter.context, adapter.application)
+			applicationComponents, err := adapter.loader.GetAllApplicationComponents(adapter.context, adapter.client, adapter.application)
 			Expect(err).To(BeNil())
 			Expect(applicationComponents).NotTo(BeNil())
 
@@ -921,7 +921,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 					Resource:   []applicationapiv1alpha1.Snapshot{*hasSnapshot},
 				},
 			})
-			allSnapshots, err := adapter.loader.GetAllSnapshots(adapter.client, adapter.context, adapter.application)
+			allSnapshots, err := adapter.loader.GetAllSnapshots(adapter.context, adapter.client, adapter.application)
 			Expect(err).To(BeNil())
 			Expect(allSnapshots).NotTo(BeNil())
 			existingSnapshot := gitops.FindMatchingSnapshot(hasApp, allSnapshots, hasSnapshot)

--- a/controllers/buildpipeline/buildpipeline_adapter_test.go
+++ b/controllers/buildpipeline/buildpipeline_adapter_test.go
@@ -349,7 +349,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 	When("NewAdapter is called", func() {
 		It("creates and return a new adapter", func() {
-			Expect(reflect.TypeOf(NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
+			Expect(reflect.TypeOf(NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient))).To(Equal(reflect.TypeOf(&Adapter{})))
 		})
 	})
 
@@ -578,7 +578,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				"build.appstudio.openshift.io/repo":             "https://github.com/devfile-samples/devfile-sample-go-basic?rev=c713067b0e65fb3de50d1f7c457eb51c2ab0dbb0",
 				"foo":                                           "bar",
 			}
-			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
 
 			Eventually(func() bool {
 				result, err := adapter.EnsureSnapshotExists()
@@ -669,7 +669,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 
 			// check the behavior when there are multiple Snapshots associated with the build pipelineRun
-			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -866,7 +866,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		})
 
 		It("can annotate the build pipelineRun with the Snapshot name", func() {
-			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient)
 			err := adapter.annotateBuildPipelineRunWithSnapshot(hasSnapshot)
 			Expect(err).To(BeNil())
 			Expect(adapter.pipelineRun.ObjectMeta.Annotations[tekton.SnapshotNameLabel]).To(Equal(hasSnapshot.Name))
@@ -874,7 +874,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 		It("Can annotate the build pipelineRun with the CreateSnapshot annotate", func() {
 			sampleErr := errors.New("this is a sample error")
-			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient)
 			err := tekton.AnnotateBuildPipelineRunWithCreateSnapshotAnnotation(adapter.context, buildPipelineRun, adapter.client, sampleErr)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -906,7 +906,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 		It("can find matching snapshot", func() {
 			// make sure the first pipeline started as first
-			adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -934,7 +934,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 		When("can add and remove finalizers from the pipelineRun", func() {
 			BeforeEach(func() {
-				adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+				adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient)
 			})
 			It("can add and remove finalizers from build pipelineRun", func() {
 				// Mark build PLR as incomplete
@@ -1078,7 +1078,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				}
 				Expect(k8sClient.Status().Update(ctx, runningDeletingBuildPipeline)).Should(Succeed())
 
-				adapter = NewAdapter(runningDeletingBuildPipeline, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+				adapter = NewAdapter(ctx, runningDeletingBuildPipeline, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.GetPipelineRunContextKey,
@@ -1124,7 +1124,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				var buf bytes.Buffer
 				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 				buildPipelineRun.ObjectMeta.Annotations[gitops.SnapshotLabel] = hasSnapshot.Name
-				adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+				adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.GetPipelineRunContextKey,
@@ -1159,7 +1159,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				var buf bytes.Buffer
 				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 				buildPipelineRun.ObjectMeta.Annotations[gitops.SnapshotLabel] = hasSnapshot.Name
-				adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+				adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.GetPipelineRunContextKey,
@@ -1196,7 +1196,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 				var buf bytes.Buffer
 				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-				adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+				adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.GetPipelineRunContextKey,
@@ -1230,7 +1230,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 	})
 
 	createAdapter = func() *Adapter {
-		adapter = NewAdapter(buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+		adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient)
 		return adapter
 	}
 })

--- a/controllers/buildpipeline/buildpipeline_controller.go
+++ b/controllers/buildpipeline/buildpipeline_controller.go
@@ -113,7 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	logger = logger.WithApp(*application)
 
-	adapter := NewAdapter(pipelineRun, component, application, logger, loader, r.Client, ctx)
+	adapter := NewAdapter(ctx, pipelineRun, component, application, logger, loader, r.Client)
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsurePipelineIsFinalized,

--- a/controllers/buildpipeline/buildpipeline_controller.go
+++ b/controllers/buildpipeline/buildpipeline_controller.go
@@ -87,7 +87,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			if err := helpers.RemoveFinalizerFromPipelineRun(r.Client, logger, ctx, pipelineRun, helpers.IntegrationPipelineRunFinalizer); err != nil {
+			if err := helpers.RemoveFinalizerFromPipelineRun(ctx, r.Client, logger, pipelineRun, helpers.IntegrationPipelineRunFinalizer); err != nil {
 				return ctrl.Result{}, err
 			}
 		}

--- a/controllers/buildpipeline/buildpipeline_controller.go
+++ b/controllers/buildpipeline/buildpipeline_controller.go
@@ -82,7 +82,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	var component *applicationapiv1alpha1.Component
 	err = retry.OnError(retry.DefaultRetry, func(_ error) bool { return true }, func() error {
-		component, err = loader.GetComponentFromPipelineRun(r.Client, ctx, pipelineRun)
+		component, err = loader.GetComponentFromPipelineRun(ctx, r.Client, pipelineRun)
 		return err
 	})
 	if err != nil {
@@ -99,7 +99,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	application, err := loader.GetApplicationFromComponent(r.Client, ctx, component)
+	application, err := loader.GetApplicationFromComponent(ctx, r.Client, component)
 	if err != nil {
 		logger.Error(err, "Failed to get Application from Component",
 			"Component.Name ", component.Name, "Component.Namespace ", component.Namespace)

--- a/controllers/component/component_adapter.go
+++ b/controllers/component/component_adapter.go
@@ -43,8 +43,9 @@ type Adapter struct {
 }
 
 // NewAdapter creates and returns an Adapter instance.
-func NewAdapter(component *applicationapiv1alpha1.Component, application *applicationapiv1alpha1.Application, logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
-	context context.Context) *Adapter {
+func NewAdapter(context context.Context, component *applicationapiv1alpha1.Component, application *applicationapiv1alpha1.Application,
+	logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
+) *Adapter {
 	return &Adapter{
 		component:   component,
 		application: application,

--- a/controllers/component/component_adapter.go
+++ b/controllers/component/component_adapter.go
@@ -77,7 +77,7 @@ func (a *Adapter) EnsureComponentIsCleanedUp() (controller.OperationResult, erro
 		return controller.ContinueProcessing()
 	}
 
-	applicationComponents, err := a.loader.GetAllApplicationComponents(a.client, a.context, a.application)
+	applicationComponents, err := a.loader.GetAllApplicationComponents(a.context, a.client, a.application)
 	if err != nil {
 		a.logger.Error(err, "Failed to load application components")
 		return controller.RequeueWithError(err)

--- a/controllers/component/component_adapter.go
+++ b/controllers/component/component_adapter.go
@@ -60,7 +60,7 @@ func NewAdapter(component *applicationapiv1alpha1.Component, application *applic
 func (a *Adapter) EnsureComponentHasFinalizer() (controller.OperationResult, error) {
 	if !isComponentMarkedForDeletion(a.component) {
 		if !controllerutil.ContainsFinalizer(a.component, h.ComponentFinalizer) {
-			err := h.AddFinalizerToComponent(a.client, a.logger, a.context, a.component, h.ComponentFinalizer)
+			err := h.AddFinalizerToComponent(a.context, a.client, a.logger, a.component, h.ComponentFinalizer)
 			if err != nil {
 				return controller.RequeueWithError(fmt.Errorf("failed to add the finalizer: %w", err))
 			}
@@ -105,7 +105,7 @@ func (a *Adapter) EnsureComponentIsCleanedUp() (controller.OperationResult, erro
 			return controller.RequeueWithError(err)
 		}
 	}
-	err = h.RemoveFinalizerFromComponent(a.client, a.logger, a.context, a.component, h.ComponentFinalizer)
+	err = h.RemoveFinalizerFromComponent(a.context, a.client, a.logger, a.component, h.ComponentFinalizer)
 	if err != nil {
 		return controller.RequeueWithError(fmt.Errorf("failed to remove the finalizer: %w", err))
 	}

--- a/controllers/component/component_adapter_test.go
+++ b/controllers/component/component_adapter_test.go
@@ -109,13 +109,13 @@ var _ = Describe("Component Adapter", Ordered, func() {
 	})
 
 	It("can create a new Adapter instance", func() {
-		Expect(reflect.TypeOf(NewAdapter(hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
+		Expect(reflect.TypeOf(NewAdapter(ctx, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient))).To(Equal(reflect.TypeOf(&Adapter{})))
 	})
 	It("ensures removing a component will result in a new snapshot being created", func() {
 		buf := bytes.Buffer{}
 
 		log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-		adapter = NewAdapter(hasComp, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+		adapter = NewAdapter(ctx, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
 		adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 			{
 				ContextKey: loader.ApplicationContextKey,

--- a/controllers/component/component_controller.go
+++ b/controllers/component/component_controller.go
@@ -69,7 +69,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	var application *applicationapiv1alpha1.Application
-	application, err = loader.GetApplicationFromComponent(r.Client, ctx, component)
+	application, err = loader.GetApplicationFromComponent(ctx, r.Client, component)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			if err := helpers.RemoveFinalizerFromComponent(r.Client, logger, ctx, component, helpers.ComponentFinalizer); err != nil {

--- a/controllers/component/component_controller.go
+++ b/controllers/component/component_controller.go
@@ -72,7 +72,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	application, err = loader.GetApplicationFromComponent(ctx, r.Client, component)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			if err := helpers.RemoveFinalizerFromComponent(r.Client, logger, ctx, component, helpers.ComponentFinalizer); err != nil {
+			if err := helpers.RemoveFinalizerFromComponent(ctx, r.Client, logger, component, helpers.ComponentFinalizer); err != nil {
 				return ctrl.Result{}, err
 			}
 		}

--- a/controllers/component/component_controller.go
+++ b/controllers/component/component_controller.go
@@ -86,7 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	logger = logger.WithApp(*application)
 
-	adapter := NewAdapter(component, application, logger, loader, r.Client, ctx)
+	adapter := NewAdapter(ctx, component, application, logger, loader, r.Client)
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureComponentHasFinalizer,

--- a/controllers/integrationpipeline/integrationpipeline_adapter.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter.go
@@ -48,8 +48,9 @@ type Adapter struct {
 }
 
 // NewAdapter creates and returns an Adapter instance.
-func NewAdapter(pipelineRun *tektonv1.PipelineRun, application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot, logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
-	context context.Context) *Adapter {
+func NewAdapter(context context.Context, pipelineRun *tektonv1.PipelineRun, application *applicationapiv1alpha1.Application,
+	snapshot *applicationapiv1alpha1.Snapshot, logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
+) *Adapter {
 	return &Adapter{
 		pipelineRun: pipelineRun,
 		application: application,
@@ -82,7 +83,7 @@ func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, 
 			return err
 		}
 
-		pipelinerunStatus, detail, err = a.GetIntegrationPipelineRunStatus(a.client, a.context, a.pipelineRun)
+		pipelinerunStatus, detail, err = a.GetIntegrationPipelineRunStatus(a.context, a.client, a.pipelineRun)
 		if err != nil {
 			return err
 		}
@@ -155,7 +156,7 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 }
 
 // GetIntegrationPipelineRunStatus checks the Tekton results for a given PipelineRun and returns status of test.
-func (a *Adapter) GetIntegrationPipelineRunStatus(adapterClient client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (intgteststat.IntegrationTestStatus, string, error) {
+func (a *Adapter) GetIntegrationPipelineRunStatus(ctx context.Context, adapterClient client.Client, pipelineRun *tektonv1.PipelineRun) (intgteststat.IntegrationTestStatus, string, error) {
 	// Check if the pipelineRun finished from the condition of status
 	if !h.HasPipelineRunFinished(pipelineRun) {
 		// Mark the pipelineRun's status as "Deleted" if its not finished yet and is marked for deletion (with a non-nil deletionTimestamp)

--- a/controllers/integrationpipeline/integrationpipeline_adapter.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter.go
@@ -103,7 +103,7 @@ func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, 
 	// Remove the finalizer from Integration PLRs only if they are related to Snapshots created by Push event
 	// If they are related, then the statusreport controller removes the finalizers from these PLRs
 	if gitops.IsSnapshotCreatedByPACPushEvent(a.snapshot) && (h.HasPipelineRunFinished(a.pipelineRun) || pipelinerunStatus == intgteststat.IntegrationTestStatusDeleted) {
-		err = h.RemoveFinalizerFromPipelineRun(a.client, a.logger, a.context, a.pipelineRun, h.IntegrationPipelineRunFinalizer)
+		err = h.RemoveFinalizerFromPipelineRun(a.context, a.client, a.logger, a.pipelineRun, h.IntegrationPipelineRunFinalizer)
 		if err != nil {
 			return controller.RequeueWithError(fmt.Errorf("failed to remove the finalizer: %w", err))
 		}
@@ -144,7 +144,7 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 			return controller.RequeueWithError(err)
 		}
 
-		err = h.CleanUpEphemeralEnvironments(a.client, &a.logger, a.context, testEnvironment, dtc)
+		err = h.CleanUpEphemeralEnvironments(a.context, a.client, &a.logger, testEnvironment, dtc)
 		if err != nil {
 			a.logger.Error(err, "Failed to delete the Ephemeral Environment")
 			return controller.RequeueWithError(err)
@@ -180,7 +180,7 @@ func (a *Adapter) GetIntegrationPipelineRunStatus(adapterClient client.Client, c
 			pipelineRun.Name, taskRunsInClusterCount, taskRunsInChildRefCount), nil
 	}
 
-	outcome, err := h.GetIntegrationPipelineRunOutcome(adapterClient, ctx, pipelineRun)
+	outcome, err := h.GetIntegrationPipelineRunOutcome(ctx, adapterClient, pipelineRun)
 	if err != nil {
 		return intgteststat.IntegrationTestStatusTestFail, "", fmt.Errorf("failed to evaluate integration test results: %w", err)
 	}

--- a/controllers/integrationpipeline/integrationpipeline_adapter.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter.go
@@ -72,7 +72,7 @@ func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, 
 	// thus `RetryOnConflict` is easy solution here, given the snapshot must be loaded specifically here
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 
-		a.snapshot, err = a.loader.GetSnapshotFromPipelineRun(a.client, a.context, a.pipelineRun)
+		a.snapshot, err = a.loader.GetSnapshotFromPipelineRun(a.context, a.client, a.pipelineRun)
 		if err != nil {
 			return err
 		}
@@ -119,7 +119,7 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 		return controller.ContinueProcessing()
 	}
 
-	testEnvironment, err := a.loader.GetEnvironmentFromIntegrationPipelineRun(a.client, a.context, a.pipelineRun)
+	testEnvironment, err := a.loader.GetEnvironmentFromIntegrationPipelineRun(a.context, a.client, a.pipelineRun)
 	if err != nil && !errors.IsNotFound(err) {
 		a.logger.Error(err, "Failed to find the environment for the pipelineRun")
 		return controller.RequeueWithError(err)
@@ -132,13 +132,13 @@ func (a *Adapter) EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationRe
 	isEphemeral := h.IsEnvironmentEphemeral(testEnvironment)
 
 	if isEphemeral {
-		dtc, err := a.loader.GetDeploymentTargetClaimForEnvironment(a.client, a.context, testEnvironment)
+		dtc, err := a.loader.GetDeploymentTargetClaimForEnvironment(a.context, a.client, testEnvironment)
 		if err != nil || dtc == nil {
 			a.logger.Error(err, "Failed to find deploymentTargetClaim defined in environment", "environment.Name", testEnvironment.Name)
 			return controller.RequeueWithError(err)
 		}
 
-		binding, err := a.loader.FindExistingSnapshotEnvironmentBinding(a.client, a.context, a.application, testEnvironment)
+		binding, err := a.loader.FindExistingSnapshotEnvironmentBinding(a.context, a.client, a.application, testEnvironment)
 		if err != nil || binding == nil {
 			a.logger.Error(err, "Failed to find snapshotEnvironmentBinding associated with environment", "environment.Name", testEnvironment.Name)
 			return controller.RequeueWithError(err)
@@ -166,7 +166,7 @@ func (a *Adapter) GetIntegrationPipelineRunStatus(adapterClient client.Client, c
 		}
 	}
 
-	taskRuns, err := a.loader.GetAllTaskRunsWithMatchingPipelineRunLabel(adapterClient, ctx, pipelineRun)
+	taskRuns, err := a.loader.GetAllTaskRunsWithMatchingPipelineRunLabel(ctx, adapterClient, pipelineRun)
 	if err != nil {
 		return intgteststat.IntegrationTestStatusTestInvalid, fmt.Sprintf("Unable to get all the TaskRun(s) related to the pipelineRun '%s'", pipelineRun.Name), err
 	}

--- a/controllers/integrationpipeline/integrationpipeline_adapter.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter.go
@@ -92,7 +92,7 @@ func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, 
 		}
 
 		// don't return wrapped err for retries
-		err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.snapshot, statuses, a.client, a.context)
+		err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, statuses, a.client)
 		return err
 	})
 	if err != nil {

--- a/controllers/integrationpipeline/integrationpipeline_adapter_test.go
+++ b/controllers/integrationpipeline/integrationpipeline_adapter_test.go
@@ -435,7 +435,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 					Resource:   []tektonv1.TaskRun{*successfulTaskRun},
 				},
 			})
-			existingSnapshot, err := adapter.loader.GetSnapshotFromPipelineRun(adapter.client, adapter.context, integrationPipelineRunComponent)
+			existingSnapshot, err := adapter.loader.GetSnapshotFromPipelineRun(adapter.context, adapter.client, integrationPipelineRunComponent)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(existingSnapshot).ToNot(BeNil())
 		})
@@ -704,13 +704,13 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				},
 			})
 
-			dtc, _ := adapter.loader.GetDeploymentTargetClaimForEnvironment(k8sClient, adapter.context, hasEnv)
+			dtc, _ := adapter.loader.GetDeploymentTargetClaimForEnvironment(adapter.context, k8sClient, hasEnv)
 			Expect(dtc).NotTo(BeNil())
 
-			dt, _ := adapter.loader.GetDeploymentTargetForDeploymentTargetClaim(k8sClient, adapter.context, dtc)
+			dt, _ := adapter.loader.GetDeploymentTargetForDeploymentTargetClaim(adapter.context, k8sClient, dtc)
 			Expect(dt).NotTo(BeNil())
 
-			binding, _ := adapter.loader.FindExistingSnapshotEnvironmentBinding(k8sClient, adapter.context, hasApp, hasEnv)
+			binding, _ := adapter.loader.FindExistingSnapshotEnvironmentBinding(adapter.context, k8sClient, hasApp, hasEnv)
 			Expect(binding).NotTo(BeNil())
 
 			result, err := adapter.EnsureEphemeralEnvironmentsCleanedUp()

--- a/controllers/integrationpipeline/integrationpipeline_controller.go
+++ b/controllers/integrationpipeline/integrationpipeline_controller.go
@@ -113,7 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	logger = logger.WithApp(*application)
 
-	adapter := NewAdapter(pipelineRun, application, snapshot, logger, loader, r.Client, ctx)
+	adapter := NewAdapter(ctx, pipelineRun, application, snapshot, logger, loader, r.Client)
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureStatusReportedInSnapshot,

--- a/controllers/integrationpipeline/integrationpipeline_controller.go
+++ b/controllers/integrationpipeline/integrationpipeline_controller.go
@@ -87,7 +87,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	var snapshot *applicationapiv1alpha1.Snapshot
 	err = retry.OnError(retry.DefaultRetry, func(_ error) bool { return true }, func() error {
-		snapshot, err = loader.GetSnapshotFromPipelineRun(r.Client, ctx, pipelineRun)
+		snapshot, err = loader.GetSnapshotFromPipelineRun(ctx, r.Client, pipelineRun)
 		return err
 	})
 	if err != nil {
@@ -99,7 +99,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return helpers.HandleLoaderError(logger, err, "Snapshot", "PipelineRun")
 	}
 
-	application, err := loader.GetApplicationFromPipelineRun(r.Client, ctx, pipelineRun)
+	application, err := loader.GetApplicationFromPipelineRun(ctx, r.Client, pipelineRun)
 	if err != nil {
 		logger.Error(err, "Failed to get Application from the integration pipelineRun",
 			"PipelineRun.Name", pipelineRun.Name, "PipelineRun.Namespace", pipelineRun.Namespace)

--- a/controllers/integrationpipeline/integrationpipeline_controller.go
+++ b/controllers/integrationpipeline/integrationpipeline_controller.go
@@ -92,7 +92,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			if err := helpers.RemoveFinalizerFromPipelineRun(r.Client, logger, ctx, pipelineRun, helpers.IntegrationPipelineRunFinalizer); err != nil {
+			if err := helpers.RemoveFinalizerFromPipelineRun(ctx, r.Client, logger, pipelineRun, helpers.IntegrationPipelineRunFinalizer); err != nil {
 				return ctrl.Result{}, err
 			}
 		}

--- a/controllers/scenario/scenario_adapter.go
+++ b/controllers/scenario/scenario_adapter.go
@@ -119,7 +119,7 @@ func (a *Adapter) EnsureDeletedScenarioResourcesAreCleanedUp() (controller.Opera
 		return controller.ContinueProcessing()
 	}
 
-	environmentsForScenario, err := a.loader.GetAllEnvironmentsForScenario(a.client, a.context, a.scenario)
+	environmentsForScenario, err := a.loader.GetAllEnvironmentsForScenario(a.context, a.client, a.scenario)
 	if err != nil {
 		a.logger.Error(err, "Failed to find all Environments for IntegrationTestScenario")
 		return controller.RequeueWithError(err)
@@ -127,7 +127,7 @@ func (a *Adapter) EnsureDeletedScenarioResourcesAreCleanedUp() (controller.Opera
 	for _, testEnvironment := range *environmentsForScenario {
 		testEnvironment := testEnvironment
 		if h.IsEnvironmentEphemeral(&testEnvironment) {
-			dtc, err := a.loader.GetDeploymentTargetClaimForEnvironment(a.client, a.context, &testEnvironment)
+			dtc, err := a.loader.GetDeploymentTargetClaimForEnvironment(a.context, a.client, &testEnvironment)
 			if err != nil || dtc == nil {
 				a.logger.Error(err, "Failed to find deploymentTargetClaim defined in environment", "environment.Name", &testEnvironment.Name)
 				return controller.RequeueWithError(err)

--- a/controllers/scenario/scenario_adapter.go
+++ b/controllers/scenario/scenario_adapter.go
@@ -103,7 +103,7 @@ func (a *Adapter) EnsureCreatedScenarioIsValid() (controller.OperationResult, er
 		a.logger.LogAuditEvent("IntegrationTestScenario marked as Valid", a.scenario, h.LogActionUpdate)
 	}
 
-	err := h.AddFinalizerToScenario(a.client, a.logger, a.context, a.scenario, h.IntegrationTestScenarioFinalizer)
+	err := h.AddFinalizerToScenario(a.context, a.client, a.logger, a.scenario, h.IntegrationTestScenarioFinalizer)
 	if err != nil {
 		a.logger.Error(err, "Failed to add finalizer to IntegrationTestScenario")
 		return controller.RequeueWithError(err)
@@ -133,7 +133,7 @@ func (a *Adapter) EnsureDeletedScenarioResourcesAreCleanedUp() (controller.Opera
 				return controller.RequeueWithError(err)
 			}
 
-			err = h.CleanUpEphemeralEnvironments(a.client, &a.logger, a.context, &testEnvironment, dtc)
+			err = h.CleanUpEphemeralEnvironments(a.context, a.client, &a.logger, &testEnvironment, dtc)
 			if err != nil {
 				a.logger.Error(err, "Failed to delete the Ephemeral Environment")
 				return controller.RequeueWithError(err)
@@ -141,7 +141,7 @@ func (a *Adapter) EnsureDeletedScenarioResourcesAreCleanedUp() (controller.Opera
 		}
 	}
 	// Remove the finalizer from the scenario since the cleanup has been handled
-	err = h.RemoveFinalizerFromScenario(a.client, a.logger, a.context, a.scenario, h.IntegrationTestScenarioFinalizer)
+	err = h.RemoveFinalizerFromScenario(a.context, a.client, a.logger, a.scenario, h.IntegrationTestScenarioFinalizer)
 	if err != nil {
 		a.logger.Error(err, "Failed to remove the finalizer from the Scenario")
 		return controller.RequeueWithError(err)

--- a/controllers/scenario/scenario_adapter.go
+++ b/controllers/scenario/scenario_adapter.go
@@ -41,8 +41,8 @@ type Adapter struct {
 }
 
 // NewAdapter creates and returns an Adapter instance.
-func NewAdapter(application *applicationapiv1alpha1.Application, scenario *v1beta2.IntegrationTestScenario, logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
-	context context.Context) *Adapter {
+func NewAdapter(context context.Context, application *applicationapiv1alpha1.Application, scenario *v1beta2.IntegrationTestScenario, logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
+) *Adapter {
 	return &Adapter{
 		application: application,
 		scenario:    scenario,

--- a/controllers/scenario/scenario_adapter_test.go
+++ b/controllers/scenario/scenario_adapter_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 		}
 		Expect(k8sClient.Create(ctx, &env)).Should(Succeed())
 
-		adapter = NewAdapter(hasApp, integrationTestScenario, logger, loader.NewMockLoader(), k8sClient, ctx)
+		adapter = NewAdapter(ctx, hasApp, integrationTestScenario, logger, loader.NewMockLoader(), k8sClient)
 		Expect(reflect.TypeOf(adapter)).To(Equal(reflect.TypeOf(&Adapter{})))
 	})
 
@@ -182,15 +182,15 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 	})
 
 	It("can create a new Adapter instance", func() {
-		Expect(reflect.TypeOf(NewAdapter(hasApp, integrationTestScenario, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
+		Expect(reflect.TypeOf(NewAdapter(ctx, hasApp, integrationTestScenario, logger, loader.NewMockLoader(), k8sClient))).To(Equal(reflect.TypeOf(&Adapter{})))
 	})
 
 	It("can create a new Adapter instance with invalid scenario", func() {
-		Expect(reflect.TypeOf(NewAdapter(hasApp, invalidScenario, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
+		Expect(reflect.TypeOf(NewAdapter(ctx, hasApp, invalidScenario, logger, loader.NewMockLoader(), k8sClient))).To(Equal(reflect.TypeOf(&Adapter{})))
 	})
 
 	It("EnsureCreatedScenarioIsValid without app", func() {
-		a := NewAdapter(nil, integrationTestScenario, logger, loader.NewMockLoader(), k8sClient, ctx)
+		a := NewAdapter(ctx, nil, integrationTestScenario, logger, loader.NewMockLoader(), k8sClient)
 
 		Eventually(func() bool {
 			result, err := a.EnsureCreatedScenarioIsValid()
@@ -272,7 +272,7 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 			controllerutil.AddFinalizer(deletedIntegrationTestScenario, helpers.IntegrationTestScenarioFinalizer)
 			now := metav1.NewTime(metav1.Now().Add(time.Second * 1))
 			deletedIntegrationTestScenario.SetDeletionTimestamp(&now)
-			adapter = NewAdapter(hasApp, deletedIntegrationTestScenario, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasApp, deletedIntegrationTestScenario, log, loader.NewMockLoader(), k8sClient)
 
 			Eventually(func() bool {
 				result, err := adapter.EnsureDeletedScenarioResourcesAreCleanedUp()

--- a/controllers/scenario/scenario_controller.go
+++ b/controllers/scenario/scenario_controller.go
@@ -78,7 +78,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		logger.Info("Failed to get Application from the IntegrationTestScenario", "error:", err)
 	}
 
-	adapter := NewAdapter(application, scenario, logger, loader, r.Client, ctx)
+	adapter := NewAdapter(ctx, application, scenario, logger, loader, r.Client)
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureCreatedScenarioIsValid,

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -64,8 +64,8 @@ type Adapter struct {
 }
 
 // NewAdapter creates and returns an Adapter instance.
-func NewAdapter(snapshot *applicationapiv1alpha1.Snapshot, application *applicationapiv1alpha1.Application, component *applicationapiv1alpha1.Component, logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
-	context context.Context) *Adapter {
+func NewAdapter(context context.Context, snapshot *applicationapiv1alpha1.Snapshot, application *applicationapiv1alpha1.Application, component *applicationapiv1alpha1.Component, logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
+) *Adapter {
 	return &Adapter{
 		snapshot:    snapshot,
 		application: application,

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -100,7 +100,7 @@ func (a *Adapter) EnsureRerunPipelineRunsExist() (controller.OperationResult, er
 		if clienterrors.IsNotFound(err) {
 			a.logger.Error(err, "scenario for integration test re-run not found", "scenario", scenarioName)
 			// scenario doesn't exist just remove label and continue
-			if err = gitops.RemoveIntegrationTestRerunLabel(a.client, a.context, a.snapshot); err != nil {
+			if err = gitops.RemoveIntegrationTestRerunLabel(a.context, a.client, a.snapshot); err != nil {
 				return controller.RequeueWithError(err)
 			}
 			return controller.ContinueProcessing()
@@ -120,7 +120,7 @@ func (a *Adapter) EnsureRerunPipelineRunsExist() (controller.OperationResult, er
 		integrationTestScenarioStatus.Status == intgteststat.IntegrationTestStatusPending) {
 		a.logger.Info(fmt.Sprintf("Found existing test in %s status, skipping re-run", integrationTestScenarioStatus.Status),
 			"integrationTestScenario.Name", integrationTestScenario.Name)
-		if err = gitops.RemoveIntegrationTestRerunLabel(a.client, a.context, a.snapshot); err != nil {
+		if err = gitops.RemoveIntegrationTestRerunLabel(a.context, a.client, a.snapshot); err != nil {
 			return controller.RequeueWithError(err)
 		}
 		return controller.ContinueProcessing()
@@ -139,16 +139,16 @@ func (a *Adapter) EnsureRerunPipelineRunsExist() (controller.OperationResult, er
 		a.logger.Error(err, "Failed to update pipelinerun name in test status")
 	}
 
-	if err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.snapshot, testStatuses, a.client, a.context); err != nil {
+	if err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client); err != nil {
 		return controller.RequeueWithError(err)
 	}
 
-	if err = gitops.ResetSnapshotStatusConditions(a.client, a.context, a.snapshot, "Integration test is being rerun for snapshot"); err != nil {
+	if err = gitops.ResetSnapshotStatusConditions(a.context, a.client, a.snapshot, "Integration test is being rerun for snapshot"); err != nil {
 		a.logger.Error(err, "Failed to reset snapshot status conditions")
 		return controller.RequeueWithError(err)
 	}
 
-	if err = gitops.RemoveIntegrationTestRerunLabel(a.client, a.context, a.snapshot); err != nil {
+	if err = gitops.RemoveIntegrationTestRerunLabel(a.context, a.client, a.snapshot); err != nil {
 		return controller.RequeueWithError(err)
 	}
 
@@ -182,7 +182,7 @@ func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResu
 			return controller.RequeueWithError(err)
 		}
 		testStatuses.InitStatuses(scenariosNamesToList(integrationTestScenarios))
-		err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.snapshot, testStatuses, a.client, a.context)
+		err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
 		if err != nil {
 			return controller.RequeueWithError(err)
 		}
@@ -192,7 +192,7 @@ func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResu
 			// This is only best effort update
 			//
 			// When update of statuses worked fine at the end of function, this is just a no-op
-			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.snapshot, testStatuses, a.client, a.context)
+			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
 			if err != nil {
 				a.logger.Error(err, "Defer: Updating statuses of tests in snapshot failed")
 			}
@@ -244,7 +244,7 @@ func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResu
 			}
 		}
 
-		err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.snapshot, testStatuses, a.client, a.context)
+		err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
 		if err != nil {
 			a.logger.Error(err, "Failed to update test status in snapshot annotation")
 			errsForPLRCreation = errors.Join(errsForPLRCreation, err)
@@ -265,7 +265,7 @@ func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResu
 		return controller.RequeueOnErrorOrStop(a.client.Status().Patch(a.context, a.snapshot, patch))
 	}
 	if len(*requiredIntegrationTestScenarios) == 0 && !gitops.IsSnapshotMarkedAsPassed(a.snapshot) {
-		err := gitops.MarkSnapshotAsPassed(a.client, a.context, a.snapshot, "No required IntegrationTestScenarios found, skipped testing")
+		err := gitops.MarkSnapshotAsPassed(a.context, a.client, a.snapshot, "No required IntegrationTestScenarios found, skipped testing")
 		if err != nil {
 			a.logger.Error(err, "Failed to update Snapshot status")
 			return controller.RequeueWithError(err)
@@ -326,7 +326,7 @@ func (a *Adapter) EnsureGlobalCandidateImageUpdated() (controller.OperationResul
 
 	// Mark the Snapshot as already added to global candidate list to prevent it from getting added again when the Snapshot
 	// gets reconciled at a later time
-	err := gitops.MarkSnapshotAsAddedToGlobalCandidateList(a.client, a.context, a.snapshot, "The Snapshot's component was added to the global candidate list")
+	err := gitops.MarkSnapshotAsAddedToGlobalCandidateList(a.context, a.client, a.snapshot, "The Snapshot's component was added to the global candidate list")
 	if err != nil {
 		a.logger.Error(err, "Failed to update the Snapshot's status to AddedToGlobalCandidateList")
 		return controller.RequeueWithError(err)
@@ -384,7 +384,7 @@ func (a *Adapter) EnsureAllReleasesExist() (controller.OperationResult, error) {
 
 	// Mark the Snapshot as already auto-released to prevent re-releasing the Snapshot when it gets reconciled
 	// at a later time, especially if new ReleasePlans are introduced or existing ones are renamed
-	err = gitops.MarkSnapshotAsAutoReleased(a.client, a.context, a.snapshot, "The Snapshot was auto-released")
+	err = gitops.MarkSnapshotAsAutoReleased(a.context, a.client, a.snapshot, "The Snapshot was auto-released")
 	if err != nil {
 		a.logger.Error(err, "Failed to update the Snapshot's status to auto-released")
 		return controller.RequeueWithError(err)
@@ -488,7 +488,7 @@ func (a *Adapter) createIntegrationPipelineRun(application *applicationapiv1alph
 	a.logger.LogAuditEvent("IntegrationTestscenario pipeline has been created", pipelineRun, h.LogActionAdd,
 		"integrationTestScenario.Name", integrationTestScenario.Name)
 	if gitops.IsSnapshotNotStarted(a.snapshot) {
-		err := gitops.MarkSnapshotIntegrationStatusAsInProgress(a.client, a.context, a.snapshot, "Snapshot starts being tested by the integrationPipelineRun")
+		err := gitops.MarkSnapshotIntegrationStatusAsInProgress(a.context, a.client, a.snapshot, "Snapshot starts being tested by the integrationPipelineRun")
 		if err != nil {
 			a.logger.Error(err, "Failed to update integration status condition to in progress for snapshot")
 		} else {
@@ -517,7 +517,7 @@ func (a *Adapter) HandlePipelineCreationError(err error, integrationTestScenario
 		testStatuses.UpdateTestStatusIfChanged(
 			integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestInvalid,
 			fmt.Sprintf("Creation of pipelineRun failed during creation due to invalid resource: %s.", err))
-		itsErr := gitops.WriteIntegrationTestStatusesIntoSnapshot(a.snapshot, testStatuses, a.client, a.context)
+		itsErr := gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
 		if itsErr != nil {
 			a.logger.Error(err, "Failed to write Test Status into Snapshot")
 			return controller.RequeueWithError(err)

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -94,7 +94,7 @@ func (a *Adapter) EnsureRerunPipelineRunsExist() (controller.OperationResult, er
 		// no test rerun triggered
 		return controller.ContinueProcessing()
 	}
-	integrationTestScenario, err := a.loader.GetScenario(a.client, a.context, scenarioName, a.application.Namespace)
+	integrationTestScenario, err := a.loader.GetScenario(a.context, a.client, scenarioName, a.application.Namespace)
 
 	if err != nil {
 		if clienterrors.IsNotFound(err) {
@@ -163,7 +163,7 @@ func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResu
 		return controller.ContinueProcessing()
 	}
 
-	integrationTestScenarios, err := a.loader.GetAllIntegrationTestScenariosForApplication(a.client, a.context, a.application)
+	integrationTestScenarios, err := a.loader.GetAllIntegrationTestScenariosForApplication(a.context, a.client, a.application)
 	if err != nil {
 		a.logger.Error(err, "Failed to get Integration test scenarios for the following application",
 			"Application.Namespace", a.application.Namespace)
@@ -255,7 +255,7 @@ func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResu
 		}
 	}
 
-	requiredIntegrationTestScenarios, err := a.loader.GetRequiredIntegrationTestScenariosForApplication(a.client, a.context, a.application)
+	requiredIntegrationTestScenarios, err := a.loader.GetRequiredIntegrationTestScenariosForApplication(a.context, a.client, a.application)
 	if err != nil {
 		a.logger.Error(err, "Failed to get all required IntegrationTestScenarios")
 		patch := client.MergeFrom(a.snapshot.DeepCopy())
@@ -350,7 +350,7 @@ func (a *Adapter) EnsureAllReleasesExist() (controller.OperationResult, error) {
 		return controller.ContinueProcessing()
 	}
 
-	releasePlans, err := a.loader.GetAutoReleasePlansForApplication(a.client, a.context, a.application)
+	releasePlans, err := a.loader.GetAutoReleasePlansForApplication(a.context, a.client, a.application)
 	if err != nil {
 		a.logger.Error(err, "Failed to get all ReleasePlans")
 		patch := client.MergeFrom(a.snapshot.DeepCopy())
@@ -396,7 +396,7 @@ func (a *Adapter) EnsureAllReleasesExist() (controller.OperationResult, error) {
 // createMissingReleasesForReleasePlans checks if there's existing Releases for a given list of ReleasePlans and creates
 // new ones if they are missing. In case the Releases can't be created, an error will be returned.
 func (a *Adapter) createMissingReleasesForReleasePlans(application *applicationapiv1alpha1.Application, releasePlans *[]releasev1alpha1.ReleasePlan, snapshot *applicationapiv1alpha1.Snapshot) error {
-	releases, err := a.loader.GetReleasesWithSnapshot(a.client, a.context, a.snapshot)
+	releases, err := a.loader.GetReleasesWithSnapshot(a.context, a.client, a.snapshot)
 	if err != nil {
 		return err
 	}

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -345,7 +345,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("ensures global Component Image will not be updated in the PR context", func() {
-			err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshotPR, "test passed")
+			err := gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshotPR, "test passed")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshotPR)).To(BeTrue())
 			adapter.snapshot = hasSnapshotPR
@@ -360,7 +360,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("no error from ensuring global Component Image updated when AppStudio Tests failed", func() {
-			err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+			err := gitops.MarkSnapshotAsFailed(ctx, k8sClient, hasSnapshot, "test failed")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 			adapter.snapshot = hasSnapshot
@@ -373,7 +373,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("ensures global Component Image updated when AppStudio Tests succeeded", func() {
-			err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			err := gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "test passed")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 			adapter.snapshot = hasSnapshot
@@ -405,9 +405,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		It("ensures Release created successfully", func() {
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 
-			err := gitops.MarkSnapshotIntegrationStatusAsFinished(k8sClient, ctx, hasSnapshot, "Snapshot integration status condition is finished since all testing pipelines completed")
+			err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Snapshot integration status condition is finished since all testing pipelines completed")
 			Expect(err).ToNot(HaveOccurred())
-			err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			err = gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "test passed")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsFinished(hasSnapshot)).To(BeTrue())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
@@ -489,7 +489,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 			// Set the snapshot up for failure by setting its status as failed and invalid
 			// as well as marking it as PaC pull request event type
-			err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+			err := gitops.MarkSnapshotAsFailed(ctx, k8sClient, hasSnapshot, "test failed")
 			Expect(err).ShouldNot(HaveOccurred())
 			gitops.SetSnapshotIntegrationStatusAsInvalid(hasSnapshot, "snapshot invalid")
 			hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePullRequestType
@@ -609,7 +609,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("Skip integration test for passed Snapshot", func() {
-			err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test pass")
+			err := gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "test pass")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 			var buf bytes.Buffer
@@ -822,7 +822,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 
 		BeforeAll(func() {
-			err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+			err := gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "test passed")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 		})
@@ -1055,7 +1055,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				Expect(err).To(Succeed())
 				statuses.UpdateTestStatusIfChanged(integrationTestScenario.Name, intgteststat.IntegrationTestStatusInProgress, fakeDetails)
 				Expect(statuses.UpdateTestPipelineRunName(integrationTestScenario.Name, fakePLRName)).To(Succeed())
-				Expect(gitops.WriteIntegrationTestStatusesIntoSnapshot(hasSnapshot, statuses, k8sClient, ctx)).Should(Succeed())
+				Expect(gitops.WriteIntegrationTestStatusesIntoSnapshot(ctx, hasSnapshot, statuses, k8sClient)).Should(Succeed())
 
 				// add rerun label
 				// we cannot update it into k8s DB via patch, it would trigger reconciliation in background

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -304,7 +304,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(result.RequeueRequest).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
 
-			requiredIntegrationTestScenarios, err := adapter.loader.GetRequiredIntegrationTestScenariosForApplication(k8sClient, adapter.context, hasApp)
+			requiredIntegrationTestScenarios, err := adapter.loader.GetRequiredIntegrationTestScenariosForApplication(adapter.context, k8sClient, hasApp)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(requiredIntegrationTestScenarios).NotTo(BeNil())
 			expectedLogEntry := "Creating new pipelinerun for integrationTestscenario integrationTestScenario.Name example-pass"

--- a/controllers/snapshot/snapshot_adapter_test.go
+++ b/controllers/snapshot/snapshot_adapter_test.go
@@ -266,12 +266,12 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		var buf bytes.Buffer
 
 		It("can create a new Adapter instance", func() {
-			Expect(reflect.TypeOf(NewAdapter(hasSnapshot, hasApp, hasComp, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
+			Expect(reflect.TypeOf(NewAdapter(ctx, hasSnapshot, hasApp, hasComp, logger, loader.NewMockLoader(), k8sClient))).To(Equal(reflect.TypeOf(&Adapter{})))
 		})
 
 		It("ensures the integrationTestPipelines are created", func() {
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -411,7 +411,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsFinished(hasSnapshot)).To(BeTrue())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
-			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
@@ -496,7 +496,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 			Expect(gitops.IsSnapshotValid(hasSnapshot)).To(BeFalse())
 
-			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 			Eventually(func() bool {
 				result, err := adapter.EnsureAllReleasesExist()
 				return !result.CancelRequest && err == nil
@@ -548,7 +548,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		It("Ensure error is logged when experiencing error when fetching ITS for application", func() {
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -582,7 +582,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		It("Mark snapshot as pass when required ITS is not found", func() {
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -614,7 +614,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -728,7 +728,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			var buf bytes.Buffer
 
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(hasInvalidSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasInvalidSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
@@ -769,7 +769,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			var buf bytes.Buffer
 
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 
 			helpers.SetScenarioIntegrationStatusAsInvalid(integrationTestScenarioForInvalidSnapshot, "invalid")
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
@@ -828,7 +828,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("Cancel request when GetAutoReleasePlansForApplication returns an error", func() {
-			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 			// Mock the context with error for AutoReleasePlansContextKey
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
@@ -845,7 +845,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("Returns RequeueWithError if the snapshot is less than three hours old", func() {
-			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 			testErr := fmt.Errorf("something went wrong with the release")
 
 			result, err := adapter.RequeueIfYoungerThanThreshold(testErr)
@@ -861,7 +861,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			// and returns a time.Time.  Why?  Who knows.  We want the latter, so we add -3 hours here
 			hasSnapshot.CreationTimestamp = metav1.NewTime(time.Now().Add(-1 * SnapshotRetryTimeout))
 
-			adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 			testErr := fmt.Errorf("something went wrong with the release")
 
 			result, err := adapter.RequeueIfYoungerThanThreshold(testErr)
@@ -885,7 +885,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				hasSnapshot.Labels[gitops.SnapshotIntegrationTestRun] = integrationTestScenario.Name
 
 				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-				adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+				adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.ApplicationContextKey,
@@ -979,7 +979,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				hasSnapshot.Labels[gitops.SnapshotIntegrationTestRun] = integrationTestScenario.Name
 
 				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-				adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+				adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.ApplicationContextKey,
@@ -1063,7 +1063,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				hasSnapshot.Labels[gitops.SnapshotIntegrationTestRun] = integrationTestScenario.Name
 
 				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-				adapter = NewAdapter(hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient, ctx)
+				adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.ApplicationContextKey,

--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -132,7 +132,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return helpers.HandleLoaderError(logger, err, fmt.Sprintf("Component or '%s' label", tekton.ComponentNameLabel), "Snapshot")
 	}
 
-	adapter := NewAdapter(snapshot, application, component, logger, loader, r.Client, ctx)
+	adapter := NewAdapter(ctx, snapshot, application, component, logger, loader, r.Client)
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureAllReleasesExist,

--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -101,7 +101,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	var application *applicationapiv1alpha1.Application
 	err = retry.OnError(retry.DefaultRetry, func(_ error) bool { return true }, func() error {
-		application, err = loader.GetApplicationFromSnapshot(r.Client, ctx, snapshot)
+		application, err = loader.GetApplicationFromSnapshot(ctx, r.Client, snapshot)
 		return err
 	})
 	if err != nil {
@@ -125,7 +125,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	var component *applicationapiv1alpha1.Component
 	err = retry.OnError(retry.DefaultRetry, func(_ error) bool { return true }, func() error {
-		component, err = loader.GetComponentFromSnapshot(r.Client, ctx, snapshot)
+		component, err = loader.GetComponentFromSnapshot(ctx, r.Client, snapshot)
 		return err
 	})
 	if err != nil {

--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -107,7 +107,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		if errors.IsNotFound(err) {
 			if !gitops.IsSnapshotMarkedAsInvalid(snapshot) {
-				err := gitops.MarkSnapshotAsInvalid(r.Client, ctx, snapshot,
+				err := gitops.MarkSnapshotAsInvalid(ctx, r.Client, snapshot,
 					fmt.Sprintf("The application %s owning this snapshot doesn't exist, try again after creating application", snapshot.Spec.Application))
 				if err != nil {
 					logger.Error(err, "Failed to update the status to Invalid for the snapshot",

--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -110,7 +110,7 @@ func (a *Adapter) EnsureSnapshotTestStatusReportedToGitProvider() (controller.Op
 				continue
 			}
 
-			err = helpers.RemoveFinalizerFromPipelineRun(a.client, a.logger, a.context, pipelineRun, helpers.IntegrationPipelineRunFinalizer)
+			err = helpers.RemoveFinalizerFromPipelineRun(a.context, a.client, a.logger, pipelineRun, helpers.IntegrationPipelineRunFinalizer)
 			if err != nil {
 				return controller.RequeueWithError(err)
 			}

--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -126,7 +126,7 @@ func (a *Adapter) EnsureSnapshotTestStatusReportedToGitProvider() (controller.Op
 func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, error) {
 	// Get all required integrationTestScenarios for the Application and then use the Snapshot status annotation
 	// to check if all Integration tests were finished for that Snapshot
-	integrationTestScenarios, err := a.loader.GetRequiredIntegrationTestScenariosForApplication(a.client, a.context, a.application)
+	integrationTestScenarios, err := a.loader.GetRequiredIntegrationTestScenariosForApplication(a.context, a.client, a.application)
 	if err != nil {
 		return controller.RequeueWithError(err)
 	}
@@ -181,7 +181,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 	if metadata.HasLabelWithValue(a.snapshot, gitops.SnapshotTypeLabel, gitops.SnapshotComponentType) && gitops.IsSnapshotCreatedByPACPushEvent(a.snapshot) {
 		var component *applicationapiv1alpha1.Component
 		err = retry.OnError(retry.DefaultRetry, func(_ error) bool { return true }, func() error {
-			component, err = a.loader.GetComponentFromSnapshot(a.client, a.context, a.snapshot)
+			component, err = a.loader.GetComponentFromSnapshot(a.context, a.client, a.snapshot)
 			return err
 		})
 		if err != nil {
@@ -264,7 +264,7 @@ func (a *Adapter) determineIfAllIntegrationTestsFinishedAndPassed(integrationTes
 // prepareCompositeSnapshot prepares the Composite Snapshot for a given application,
 // component, containerImage and containerSource. In case the Snapshot can't be created, an error will be returned.
 func (a *Adapter) prepareCompositeSnapshot(application *applicationapiv1alpha1.Application, component *applicationapiv1alpha1.Component, newContainerImage string, newComponentSource *applicationapiv1alpha1.ComponentSource) (*applicationapiv1alpha1.Snapshot, error) {
-	applicationComponents, err := a.loader.GetAllApplicationComponents(a.client, a.context, application)
+	applicationComponents, err := a.loader.GetAllApplicationComponents(a.context, a.client, application)
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +304,7 @@ func (a *Adapter) createCompositeSnapshotsIfConflictExists(application *applicat
 
 	// Create the new composite snapshot if it doesn't exist already
 	if !gitops.CompareSnapshots(compositeSnapshot, testedSnapshot) {
-		allSnapshots, err := a.loader.GetAllSnapshots(a.client, a.context, application)
+		allSnapshots, err := a.loader.GetAllSnapshots(a.context, a.client, application)
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -54,8 +54,9 @@ type Adapter struct {
 }
 
 // NewAdapter creates and returns an Adapter instance.
-func NewAdapter(snapshot *applicationapiv1alpha1.Snapshot, application *applicationapiv1alpha1.Application, logger helpers.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
-	context context.Context) *Adapter {
+func NewAdapter(context context.Context, snapshot *applicationapiv1alpha1.Snapshot, application *applicationapiv1alpha1.Application,
+	logger helpers.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
+) *Adapter {
 	return &Adapter{
 		snapshot:    snapshot,
 		application: application,

--- a/controllers/statusreport/statusreport_adapter.go
+++ b/controllers/statusreport/statusreport_adapter.go
@@ -153,7 +153,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 		if integrationTestScenarioNotTriggered != "" {
 			a.logger.Info("Detected an integrationTestScenario was not triggered, applying snapshot reconcilation",
 				"integrationTestScenario.Name", integrationTestScenarioNotTriggered)
-			if err = gitops.AddIntegrationTestRerunLabel(a.client, a.context, a.snapshot, integrationTestScenarioNotTriggered); err != nil {
+			if err = gitops.AddIntegrationTestRerunLabel(a.context, a.client, a.snapshot, integrationTestScenarioNotTriggered); err != nil {
 				return controller.RequeueWithError(err)
 			}
 
@@ -168,7 +168,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 	}
 
 	if !gitops.IsSnapshotIntegrationStatusMarkedAsFinished(a.snapshot) {
-		err = gitops.MarkSnapshotIntegrationStatusAsFinished(a.client, a.context, a.snapshot, finishedStatusMessage)
+		err = gitops.MarkSnapshotIntegrationStatusAsFinished(a.context, a.client, a.snapshot, finishedStatusMessage)
 		if err != nil {
 			a.logger.Error(err, "Failed to Update Snapshot AppStudioIntegrationStatus status")
 			return controller.RequeueWithError(err)
@@ -202,7 +202,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 			a.logger.Info("The global component list has changed in the meantime, marking snapshot as Invalid",
 				"snapshot.Name", a.snapshot.Name)
 			if !gitops.IsSnapshotMarkedAsInvalid(a.snapshot) {
-				err = gitops.MarkSnapshotAsInvalid(a.client, a.context, a.snapshot,
+				err = gitops.MarkSnapshotAsInvalid(a.context, a.client, a.snapshot,
 					"The global component list has changed in the meantime, superseding with a composite snapshot")
 				if err != nil {
 					a.logger.Error(err, "Failed to update the status to Invalid for the snapshot",
@@ -220,7 +220,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 	// This updates the Snapshot resource on the cluster
 	if allIntegrationTestsPassed {
 		if !gitops.IsSnapshotMarkedAsPassed(a.snapshot) {
-			err = gitops.MarkSnapshotAsPassed(a.client, a.context, a.snapshot, "All Integration Pipeline tests passed")
+			err = gitops.MarkSnapshotAsPassed(a.context, a.client, a.snapshot, "All Integration Pipeline tests passed")
 			if err != nil {
 				a.logger.Error(err, "Failed to Update Snapshot AppStudioTestSucceeded status")
 				return controller.RequeueWithError(err)
@@ -230,7 +230,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 		}
 	} else {
 		if !gitops.IsSnapshotMarkedAsFailed(a.snapshot) {
-			err = gitops.MarkSnapshotAsFailed(a.client, a.context, a.snapshot, "Some Integration pipeline tests failed")
+			err = gitops.MarkSnapshotAsFailed(a.context, a.client, a.snapshot, "Some Integration pipeline tests failed")
 			if err != nil {
 				a.logger.Error(err, "Failed to Update Snapshot AppStudioTestSucceeded status")
 				return controller.RequeueWithError(err)
@@ -269,7 +269,7 @@ func (a *Adapter) prepareCompositeSnapshot(application *applicationapiv1alpha1.A
 		return nil, err
 	}
 
-	snapshot, err := gitops.PrepareSnapshot(a.client, a.context, application, applicationComponents, component, newContainerImage, newComponentSource)
+	snapshot, err := gitops.PrepareSnapshot(a.context, a.client, application, applicationComponents, component, newContainerImage, newComponentSource)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/statusreport/statusreport_adapter_test.go
+++ b/controllers/statusreport/statusreport_adapter_test.go
@@ -285,7 +285,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(hasSnapshot)
 			Expect(err).To(BeNil())
 			statuses.UpdateTestStatusIfChanged(integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestPassed, "testDetails")
-			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(hasSnapshot, statuses, k8sClient, ctx)
+			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(ctx, hasSnapshot, statuses, k8sClient)
 			Expect(err).To(BeNil())
 
 			adapter = NewAdapter(hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
@@ -402,7 +402,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(hasSnapshot)
 			Expect(err).To(BeNil())
 			statuses.UpdateTestStatusIfChanged(integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestFail, "Failed test")
-			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(hasSnapshot, statuses, k8sClient, ctx)
+			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(ctx, hasSnapshot, statuses, k8sClient)
 			Expect(err).To(BeNil())
 
 			adapter = NewAdapter(hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
@@ -456,7 +456,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(hasSnapshot)
 			Expect(err).ToNot(HaveOccurred())
 			statuses.UpdateTestStatusIfChanged(integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestFail, "Failed test")
-			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(hasSnapshot, statuses, k8sClient, ctx)
+			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(ctx, hasSnapshot, statuses, k8sClient)
 			Expect(err).ToNot(HaveOccurred())
 
 			adapter = NewAdapter(hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
@@ -510,7 +510,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(hasSnapshot)
 			Expect(err).To(BeNil())
 			statuses.UpdateTestStatusIfChanged(integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestPassed, "testDetails")
-			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(hasSnapshot, statuses, k8sClient, ctx)
+			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(ctx, hasSnapshot, statuses, k8sClient)
 			Expect(err).To(BeNil())
 
 			adapter = NewAdapter(hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)

--- a/controllers/statusreport/statusreport_adapter_test.go
+++ b/controllers/statusreport/statusreport_adapter_test.go
@@ -238,7 +238,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 	When("adapter is created", func() {
 		It("can create a new Adapter instance", func() {
-			Expect(reflect.TypeOf(NewAdapter(hasSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx))).To(Equal(reflect.TypeOf(&Adapter{})))
+			Expect(reflect.TypeOf(NewAdapter(ctx, hasSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient))).To(Equal(reflect.TypeOf(&Adapter{})))
 		})
 
 		It("ensures the statusReport is called", func() {
@@ -254,7 +254,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			mockStatus.EXPECT().ReportSnapshotStatus(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			mockScenarios := []v1beta2.IntegrationTestScenario{}
-			adapter = NewAdapter(hasPRSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasPRSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient)
 			adapter.status = mockStatus
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
@@ -288,7 +288,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(ctx, hasSnapshot, statuses, k8sClient)
 			Expect(err).To(BeNil())
 
-			adapter = NewAdapter(hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -405,7 +405,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(ctx, hasSnapshot, statuses, k8sClient)
 			Expect(err).To(BeNil())
 
-			adapter = NewAdapter(hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -459,7 +459,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(ctx, hasSnapshot, statuses, k8sClient)
 			Expect(err).ToNot(HaveOccurred())
 
-			adapter = NewAdapter(hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -513,7 +513,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			err = gitops.WriteIntegrationTestStatusesIntoSnapshot(ctx, hasSnapshot, statuses, k8sClient)
 			Expect(err).To(BeNil())
 
-			adapter = NewAdapter(hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient, ctx)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,

--- a/controllers/statusreport/statusreport_adapter_test.go
+++ b/controllers/statusreport/statusreport_adapter_test.go
@@ -372,7 +372,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			// Check when all integrationTestScenarion exist in testStatuses of the snapshot
 			testStatuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(hasSnapshot)
 			Expect(err).To(BeNil())
-			integrationTestScenarios, err := adapter.loader.GetRequiredIntegrationTestScenariosForApplication(adapter.client, adapter.context, adapter.application)
+			integrationTestScenarios, err := adapter.loader.GetRequiredIntegrationTestScenariosForApplication(adapter.context, adapter.client, adapter.application)
 			Expect(err).To(BeNil())
 			result := adapter.findUntriggeredIntegrationTestFromStatus(integrationTestScenarios, testStatuses)
 			Expect(result).To(BeEmpty())

--- a/controllers/statusreport/statusreport_controller.go
+++ b/controllers/statusreport/statusreport_controller.go
@@ -86,7 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	logger = logger.WithApp(*application)
 
-	adapter := NewAdapter(snapshot, application, logger, loader, r.Client, ctx)
+	adapter := NewAdapter(ctx, snapshot, application, logger, loader, r.Client)
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureSnapshotFinishedAllTests,
 		adapter.EnsureSnapshotTestStatusReportedToGitProvider,

--- a/controllers/statusreport/statusreport_controller.go
+++ b/controllers/statusreport/statusreport_controller.go
@@ -79,7 +79,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	application, err := loader.GetApplicationFromSnapshot(r.Client, ctx, snapshot)
+	application, err := loader.GetApplicationFromSnapshot(ctx, r.Client, snapshot)
 	if err != nil {
 		logger.Error(err, "Failed to get Application from the Snapshot")
 		return ctrl.Result{}, err

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -203,7 +203,7 @@ func IsSnapshotMarkedAsPassed(snapshot *applicationapiv1alpha1.Snapshot) bool {
 
 // MarkSnapshotAsPassed updates the AppStudio Test succeeded condition for the Snapshot to passed.
 // If the patch command fails, an error will be returned.
-func MarkSnapshotAsPassed(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
+func MarkSnapshotAsPassed(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	condition := metav1.Condition{
 		Type:    AppStudioTestSucceededCondition,
@@ -230,7 +230,7 @@ func IsSnapshotMarkedAsFailed(snapshot *applicationapiv1alpha1.Snapshot) bool {
 
 // MarkSnapshotAsFailed updates the AppStudio Test succeeded condition for the Snapshot to failed.
 // If the patch command fails, an error will be returned.
-func MarkSnapshotAsFailed(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
+func MarkSnapshotAsFailed(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	condition := metav1.Condition{
 		Type:    AppStudioTestSucceededCondition,
@@ -252,7 +252,7 @@ func MarkSnapshotAsFailed(adapterClient client.Client, ctx context.Context, snap
 
 // MarkSnapshotAsInvalid updates the AppStudio integration status condition for the Snapshot to invalid.
 // If the patch command fails, an error will be returned.
-func MarkSnapshotAsInvalid(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
+func MarkSnapshotAsInvalid(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	SetSnapshotIntegrationStatusAsInvalid(snapshot, message)
 	err := adapterClient.Status().Patch(ctx, snapshot, patch)
@@ -292,7 +292,7 @@ func SetSnapshotIntegrationStatusAsError(snapshot *applicationapiv1alpha1.Snapsh
 }
 
 // MarkSnapshotIntegrationStatusAsInProgress sets the AppStudio integration status condition for the Snapshot to In Progress.
-func MarkSnapshotIntegrationStatusAsInProgress(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
+func MarkSnapshotIntegrationStatusAsInProgress(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	log := log.FromContext(ctx)
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	meta.SetStatusCondition(&snapshot.Status.Conditions, metav1.Condition{
@@ -332,7 +332,7 @@ func PrepareToRegisterIntegrationPipelineRunStarted(snapshot *applicationapiv1al
 }
 
 // MarkSnapshotIntegrationStatusAsFinished sets the AppStudio integration status condition for the Snapshot to Finished.
-func MarkSnapshotIntegrationStatusAsFinished(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
+func MarkSnapshotIntegrationStatusAsFinished(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	condition := metav1.Condition{
 		Type:    AppStudioIntegrationStatusCondition,
@@ -416,7 +416,7 @@ func IsSnapshotMarkedAsAutoReleased(snapshot *applicationapiv1alpha1.Snapshot) b
 
 // MarkSnapshotAsAutoReleased updates the SnapshotAutoReleasedCondition for the Snapshot to 'AutoReleased'.
 // If the patch command fails, an error will be returned.
-func MarkSnapshotAsAutoReleased(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
+func MarkSnapshotAsAutoReleased(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	condition := metav1.Condition{
 		Type:    SnapshotAutoReleasedCondition,
@@ -441,7 +441,7 @@ func IsSnapshotMarkedAsAddedToGlobalCandidateList(snapshot *applicationapiv1alph
 
 // MarkSnapshotAsAddedToGlobalCandidateList updates the SnapshotAddedToGlobalCandidateListCondition for the Snapshot to true with reason 'Added'.
 // If the patch command fails, an error will be returned.
-func MarkSnapshotAsAddedToGlobalCandidateList(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
+func MarkSnapshotAsAddedToGlobalCandidateList(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	condition := metav1.Condition{
 		Type:    SnapshotAddedToGlobalCandidateListCondition,
@@ -649,7 +649,7 @@ func HasSnapshotRerunLabelChanged(objectOld, objectNew client.Object) bool {
 
 // PrepareSnapshot prepares the Snapshot for a given application, components and the updated component (if any).
 // In case the Snapshot can't be created, an error will be returned.
-func PrepareSnapshot(adapterClient client.Client, ctx context.Context, application *applicationapiv1alpha1.Application, applicationComponents *[]applicationapiv1alpha1.Component, component *applicationapiv1alpha1.Component, newContainerImage string, newComponentSource *applicationapiv1alpha1.ComponentSource) (*applicationapiv1alpha1.Snapshot, error) {
+func PrepareSnapshot(ctx context.Context, adapterClient client.Client, application *applicationapiv1alpha1.Application, applicationComponents *[]applicationapiv1alpha1.Component, component *applicationapiv1alpha1.Component, newContainerImage string, newComponentSource *applicationapiv1alpha1.ComponentSource) (*applicationapiv1alpha1.Snapshot, error) {
 	log := log.FromContext(ctx)
 	var snapshotComponents []applicationapiv1alpha1.SnapshotComponent
 	for _, applicationComponent := range *applicationComponents {
@@ -730,7 +730,7 @@ func GetIntegrationTestRunLabelValue(obj metav1.Object) (string, bool) {
 }
 
 // RemoveIntegrationTestRerunLabel removes re-run label from snapshot
-func RemoveIntegrationTestRerunLabel(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) error {
+func RemoveIntegrationTestRerunLabel(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	err := metadata.DeleteLabel(snapshot, SnapshotIntegrationTestRun)
 	if err != nil {
@@ -745,7 +745,7 @@ func RemoveIntegrationTestRerunLabel(adapterClient client.Client, ctx context.Co
 }
 
 // AddIntegrationTestRerunLabel adding re-run label to snapshot
-func AddIntegrationTestRerunLabel(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, integrationTestScenarioName string) error {
+func AddIntegrationTestRerunLabel(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot, integrationTestScenarioName string) error {
 	patch := client.MergeFrom(snapshot.DeepCopy())
 	newLabel := map[string]string{}
 	newLabel[SnapshotIntegrationTestRun] = integrationTestScenarioName
@@ -775,7 +775,7 @@ func GetLatestUpdateTime(snapshot *applicationapiv1alpha1.Snapshot) (time.Time, 
 	return t, nil
 }
 
-func ResetSnapshotStatusConditions(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
+func ResetSnapshotStatusConditions(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
 	if HaveAppStudioTestsFinished(snapshot) {
 		patch := client.MergeFrom(snapshot.DeepCopy())
 		meta.SetStatusCondition(&snapshot.Status.Conditions, metav1.Condition{

--- a/gitops/snapshot_integration_tests_status.go
+++ b/gitops/snapshot_integration_tests_status.go
@@ -47,7 +47,7 @@ func NewSnapshotIntegrationTestStatusesFromSnapshot(s *applicationapiv1alpha1.Sn
 
 // WriteIntegrationTestStatusesIntoSnapshot writes data to snapshot by updating CR
 // Data are written only when new changes are detected
-func WriteIntegrationTestStatusesIntoSnapshot(s *applicationapiv1alpha1.Snapshot, sts *intgteststat.SnapshotIntegrationTestStatuses, c client.Client, ctx context.Context) error {
+func WriteIntegrationTestStatusesIntoSnapshot(ctx context.Context, s *applicationapiv1alpha1.Snapshot, sts *intgteststat.SnapshotIntegrationTestStatuses, c client.Client) error {
 	if !sts.IsDirty() {
 		// No updates were done, we don't need to update snapshot
 		return nil

--- a/gitops/snapshot_integration_tests_status_test.go
+++ b/gitops/snapshot_integration_tests_status_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Snapshot integration test statuses", func() {
 			It("Test results are written into snapshot", func() {
 				sits.UpdateTestStatusIfChanged(testScenarioName, intgteststat.IntegrationTestStatusInProgress, testDetails)
 
-				err := gitops.WriteIntegrationTestStatusesIntoSnapshot(snapshot, sits, k8sClient, ctx)
+				err := gitops.WriteIntegrationTestStatusesIntoSnapshot(ctx, snapshot, sits, k8sClient)
 				Expect(err).To(BeNil())
 				Expect(sits.IsDirty()).To(BeFalse())
 

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures the Snapshots status can be marked as passed", func() {
-		err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.AppStudioTestSucceededCondition)).To(BeTrue())
@@ -189,7 +189,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures the Snapshots status can be marked as failed", func() {
-		err := gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsFailed(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.AppStudioTestSucceededCondition)).To(BeFalse())
@@ -204,14 +204,14 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures the Snapshots status can be marked as finished", func() {
-		err := gitops.MarkSnapshotIntegrationStatusAsFinished(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(gitops.IsSnapshotIntegrationStatusMarkedAsFinished(hasSnapshot)).To(BeTrue())
 	})
 
 	It("ensures the Snapshots status can be marked as in progress", func() {
-		err := gitops.MarkSnapshotIntegrationStatusAsInProgress(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotIntegrationStatusAsInProgress(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		foundStatusCondition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.AppStudioIntegrationStatusCondition)
@@ -219,7 +219,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures the Snapshots status can be marked as invalid", func() {
-		err := gitops.MarkSnapshotAsInvalid(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsInvalid(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		Expect(meta.IsStatusConditionTrue(hasSnapshot.Status.Conditions, gitops.AppStudioIntegrationStatusCondition)).To(BeFalse())
@@ -229,7 +229,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	It("ensures the Snapshots status can be marked as auto released", func() {
 		Expect(gitops.IsSnapshotMarkedAsAutoReleased(hasSnapshot)).To(BeFalse())
 
-		err := gitops.MarkSnapshotAsAutoReleased(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsAutoReleased(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		foundStatusCondition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.SnapshotAutoReleasedCondition)
@@ -242,7 +242,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	It("ensures the Snapshots status can be marked as component added to global candidate list", func() {
 		Expect(gitops.IsSnapshotMarkedAsAddedToGlobalCandidateList(hasSnapshot)).To(BeFalse())
 
-		err := gitops.MarkSnapshotAsAddedToGlobalCandidateList(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotAsAddedToGlobalCandidateList(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 		foundStatusCondition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.SnapshotAddedToGlobalCandidateListCondition)
@@ -366,7 +366,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures the Snapshots status can be detected to be valid", func() {
-		err := gitops.MarkSnapshotIntegrationStatusAsFinished(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hasSnapshot).NotTo(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
@@ -374,25 +374,25 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures the Snapshots status can be reset", func() {
-		err := gitops.MarkSnapshotIntegrationStatusAsFinished(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).ToNot(HaveOccurred())
-		err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		err = gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "test passed")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(gitops.HaveAppStudioTestsFinished(hasSnapshot)).To(BeTrue())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
-		Expect(gitops.ResetSnapshotStatusConditions(k8sClient, ctx, hasSnapshot, "in progress")).To(Succeed())
+		Expect(gitops.ResetSnapshotStatusConditions(ctx, k8sClient, hasSnapshot, "in progress")).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 		Expect(gitops.HaveAppStudioTestsFinished(hasSnapshot)).To(BeFalse())
 	})
 
 	It("ensures the a decision can be made to promote the Snapshot based on its status", func() {
-		err := gitops.MarkSnapshotIntegrationStatusAsFinished(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hasSnapshot).NotTo(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 
-		err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "Test message")
+		err = gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 
@@ -402,12 +402,12 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	})
 
 	It("ensures the a decision can be made to NOT promote the Snapshot based on its status", func() {
-		err := gitops.MarkSnapshotIntegrationStatusAsFinished(k8sClient, ctx, hasSnapshot, "Test message")
+		err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hasSnapshot).NotTo(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 
-		err = gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "Test message")
+		err = gitops.MarkSnapshotAsFailed(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
 		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
 
@@ -448,7 +448,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 			},
 		}
 		allApplicationComponents := &[]applicationapiv1alpha1.Component{*hasComp}
-		snapshot, err := gitops.PrepareSnapshot(k8sClient, ctx, hasApp, allApplicationComponents, hasComp, imagePullSpec, componentSource)
+		snapshot, err := gitops.PrepareSnapshot(ctx, k8sClient, hasApp, allApplicationComponents, hasComp, imagePullSpec, componentSource)
 		Expect(snapshot).NotTo(BeNil())
 		Expect(err).To(BeNil())
 		Expect(snapshot.Spec.Components).To(HaveLen(1), "One component should have been added to snapshot.  Other component should have been omited due to empty ContainerImage field or missing valid digest")
@@ -466,7 +466,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 			},
 		}
 		allApplicationComponents := &[]applicationapiv1alpha1.Component{*hasComp}
-		snapshot, err := gitops.PrepareSnapshot(k8sClient, ctx, hasApp, allApplicationComponents, hasComp, imagePullSpec, componentSource)
+		snapshot, err := gitops.PrepareSnapshot(ctx, k8sClient, hasApp, allApplicationComponents, hasComp, imagePullSpec, componentSource)
 		Expect(snapshot).To(BeNil())
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).Should(ContainSubstring("quay.io/redhat-appstudio/sample-image@invaliDigest is invalid container image digest from component component-sample"))
@@ -515,7 +515,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 		It("add run label to snapshot", func() {
 			testScenario := "test-scenario"
-			err := gitops.AddIntegrationTestRerunLabel(k8sClient, ctx, hasSnapshot, testScenario)
+			err := gitops.AddIntegrationTestRerunLabel(ctx, k8sClient, hasSnapshot, testScenario)
 			Expect(err).To(BeNil())
 			val, ok := gitops.GetIntegrationTestRunLabelValue(hasSnapshot)
 			Expect(ok).To(BeTrue())
@@ -527,7 +527,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 	Context("RemoveIntegrationTestRerunLabel tests", func() {
 
 		It("won't fail if re-run label is not present", func() {
-			err := gitops.RemoveIntegrationTestRerunLabel(k8sClient, ctx, hasSnapshot)
+			err := gitops.RemoveIntegrationTestRerunLabel(ctx, k8sClient, hasSnapshot)
 			Expect(err).To(Succeed())
 		})
 
@@ -549,7 +549,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 					gitops.SnapshotIntegrationTestRun: Equal(testScenario),
 				})
 				Expect(snapshotRerun.GetLabels()).Should(m, "have re-run label")
-				err := gitops.RemoveIntegrationTestRerunLabel(k8sClient, ctx, snapshotRerun)
+				err := gitops.RemoveIntegrationTestRerunLabel(ctx, k8sClient, snapshotRerun)
 				Expect(err).To(Succeed())
 				Expect(snapshotRerun.GetLabels()).ShouldNot(m, "shouldn't have re-run label")
 			})

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -702,7 +702,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		}
 		Expect(k8sClient.Status().Update(ctx, integrationPipelineRun)).Should(Succeed())
 
-		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(k8sClient, ctx, integrationPipelineRun)
+		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(ctx, k8sClient, integrationPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(pipelineRunOutcome.HasPipelineRunPassedTesting()).To(BeTrue())
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
@@ -739,7 +739,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		}
 		Expect(k8sClient.Status().Update(ctx, integrationPipelineRun)).Should(Succeed())
 
-		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(k8sClient, ctx, integrationPipelineRun)
+		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(ctx, k8sClient, integrationPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(pipelineRunOutcome.HasPipelineRunPassedTesting()).To(BeTrue())
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
@@ -761,7 +761,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		})
 		Expect(k8sClient.Status().Update(ctx, integrationPipelineRun)).Should(Succeed())
 
-		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(k8sClient, ctx, integrationPipelineRun)
+		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(ctx, k8sClient, integrationPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(pipelineRunOutcome.HasPipelineRunPassedTesting()).To(BeFalse())
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
@@ -798,7 +798,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		}
 		Expect(k8sClient.Status().Update(ctx, integrationPipelineRun)).Should(Succeed())
 
-		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(k8sClient, ctx, integrationPipelineRun)
+		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(ctx, k8sClient, integrationPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(pipelineRunOutcome.HasPipelineRunPassedTesting()).To(BeFalse())
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
@@ -839,7 +839,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		}
 		Expect(k8sClient.Status().Update(ctx, integrationPipelineRun)).Should(Succeed())
 
-		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(k8sClient, ctx, integrationPipelineRun)
+		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(ctx, k8sClient, integrationPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(pipelineRunOutcome.HasPipelineRunPassedTesting()).To(BeFalse())
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
@@ -878,7 +878,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		}
 		Expect(k8sClient.Status().Update(ctx, integrationPipelineRun)).Should(Succeed())
 
-		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(k8sClient, ctx, integrationPipelineRun)
+		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(ctx, k8sClient, integrationPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(pipelineRunOutcome.HasPipelineRunPassedTesting()).To(BeFalse())
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
@@ -915,7 +915,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		}
 
 		Expect(k8sClient.Status().Update(ctx, integrationPipelineRun)).Should(Succeed())
-		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(k8sClient, ctx, integrationPipelineRun)
+		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(ctx, k8sClient, integrationPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(pipelineRunOutcome).NotTo(BeNil())
 		Expect(pipelineRunOutcome.HasPipelineRunPassedTesting()).To(BeFalse())
@@ -954,7 +954,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		}
 
 		Expect(k8sClient.Status().Update(ctx, integrationPipelineRun)).Should(Succeed())
-		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(k8sClient, ctx, integrationPipelineRun)
+		pipelineRunOutcome, err := helpers.GetIntegrationPipelineRunOutcome(ctx, k8sClient, integrationPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(pipelineRunOutcome).NotTo(BeNil())
 
@@ -991,7 +991,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			},
 		}
 
-		taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(k8sClient, ctx, integrationPipelineRun)
+		taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(ctx, k8sClient, integrationPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(taskRuns).To(HaveLen(2))
 
@@ -1027,7 +1027,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{},
 		}
 
-		taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(k8sClient, ctx, integrationPipelineRun)
+		taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(ctx, k8sClient, integrationPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(taskRuns).To(BeNil())
 	})
@@ -1037,13 +1037,13 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 		// calling AddFinalizerToScenario() when the IntegrationTestScenario doesn't contain the finalizer
 		log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-		Expect(helpers.AddFinalizerToScenario(k8sClient, log, ctx, integrationTestScenario, helpers.IntegrationTestScenarioFinalizer)).To(Succeed())
+		Expect(helpers.AddFinalizerToScenario(ctx, k8sClient, log, integrationTestScenario, helpers.IntegrationTestScenarioFinalizer)).To(Succeed())
 		Expect(integrationTestScenario.Finalizers).To(ContainElement(ContainSubstring(helpers.IntegrationTestScenarioFinalizer)))
 		logEntry := "Added Finalizer to the IntegrationTestScenario"
 		Expect(buf.String()).Should(ContainSubstring(logEntry))
 
 		// calling RemoveFinalizerFromScenario() when the IntegrationTestScenario contains the finalizer
-		Expect(helpers.RemoveFinalizerFromScenario(k8sClient, log, ctx, integrationTestScenario, helpers.IntegrationTestScenarioFinalizer)).To(Succeed())
+		Expect(helpers.RemoveFinalizerFromScenario(ctx, k8sClient, log, integrationTestScenario, helpers.IntegrationTestScenarioFinalizer)).To(Succeed())
 		Expect(integrationTestScenario.Finalizers).NotTo(ContainElement(ContainSubstring(helpers.IntegrationTestScenarioFinalizer)))
 		logEntry = "Removed Finalizer from the IntegrationTestScenario"
 		Expect(buf.String()).Should(ContainSubstring(logEntry))
@@ -1054,13 +1054,13 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 		// calling AddFinalizerToComponent() when the Component doesn't contain the finalizer
 		log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-		Expect(helpers.AddFinalizerToComponent(k8sClient, log, ctx, hasComp, helpers.ComponentFinalizer)).To(Succeed())
+		Expect(helpers.AddFinalizerToComponent(ctx, k8sClient, log, hasComp, helpers.ComponentFinalizer)).To(Succeed())
 		Expect(hasComp.Finalizers).To(ContainElement(ContainSubstring(helpers.ComponentFinalizer)))
 		logEntry := "Added Finalizer to the Component"
 		Expect(buf.String()).Should(ContainSubstring(logEntry))
 
 		// calling RemoveFinalizerFromComponent() when the Component contains the finalizer
-		Expect(helpers.RemoveFinalizerFromComponent(k8sClient, log, ctx, hasComp, helpers.ComponentFinalizer)).To(Succeed())
+		Expect(helpers.RemoveFinalizerFromComponent(ctx, k8sClient, log, hasComp, helpers.ComponentFinalizer)).To(Succeed())
 		Expect(hasComp.Finalizers).NotTo(ContainElement(ContainSubstring(helpers.ComponentFinalizer)))
 		logEntry = "Removed Finalizer from the Component"
 		Expect(buf.String()).Should(ContainSubstring(logEntry))

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -708,7 +708,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		err = gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "test passed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 	})
@@ -745,7 +745,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		err = gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "test passed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 	})
@@ -767,7 +767,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		err = gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+		err = gitops.MarkSnapshotAsFailed(ctx, k8sClient, hasSnapshot, "test failed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 	})
@@ -804,7 +804,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		err = gitops.MarkSnapshotAsFailed(k8sClient, ctx, hasSnapshot, "test failed")
+		err = gitops.MarkSnapshotAsFailed(ctx, k8sClient, hasSnapshot, "test failed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 	})
@@ -884,7 +884,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(pipelineRunOutcome.HasPipelineRunValidTestOutputs()).To(BeTrue())
 		Expect(pipelineRunOutcome.GetValidationErrorsList()).Should(BeEmpty())
 
-		err = gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		err = gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "test passed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 	})

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -38,29 +38,29 @@ import (
 )
 
 type ObjectLoader interface {
-	GetAllEnvironments(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Environment, error)
-	GetReleasesWithSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.Release, error)
-	GetAllApplicationComponents(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Component, error)
-	GetApplicationFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Application, error)
-	GetComponentFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Component, error)
-	GetComponentFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Component, error)
-	GetApplicationFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Application, error)
-	GetApplicationFromComponent(c client.Client, ctx context.Context, component *applicationapiv1alpha1.Component) (*applicationapiv1alpha1.Application, error)
-	GetEnvironmentFromIntegrationPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Environment, error)
-	GetSnapshotFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Snapshot, error)
-	GetAllIntegrationTestScenariosForApplication(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error)
-	GetRequiredIntegrationTestScenariosForApplication(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error)
-	GetDeploymentTargetClaimForEnvironment(c client.Client, ctx context.Context, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.DeploymentTargetClaim, error)
-	GetDeploymentTargetForDeploymentTargetClaim(c client.Client, ctx context.Context, dtc *applicationapiv1alpha1.DeploymentTargetClaim) (*applicationapiv1alpha1.DeploymentTarget, error)
-	FindExistingSnapshotEnvironmentBinding(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error)
-	GetAllPipelineRunsForSnapshotAndScenario(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]tektonv1.PipelineRun, error)
-	GetAllSnapshots(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Snapshot, error)
-	GetAutoReleasePlansForApplication(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]releasev1alpha1.ReleasePlan, error)
-	GetScenario(c client.Client, ctx context.Context, name, namespace string) (*v1beta2.IntegrationTestScenario, error)
-	GetAllEnvironmentsForScenario(c client.Client, ctx context.Context, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]applicationapiv1alpha1.Environment, error)
-	GetAllSnapshotsForBuildPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*[]applicationapiv1alpha1.Snapshot, error)
-	GetAllTaskRunsWithMatchingPipelineRunLabel(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*[]tektonv1.TaskRun, error)
-	GetPipelineRun(c client.Client, ctx context.Context, name, namespace string) (*tektonv1.PipelineRun, error)
+	GetAllEnvironments(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Environment, error)
+	GetReleasesWithSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.Release, error)
+	GetAllApplicationComponents(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Component, error)
+	GetApplicationFromSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Application, error)
+	GetComponentFromSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Component, error)
+	GetComponentFromPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Component, error)
+	GetApplicationFromPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Application, error)
+	GetApplicationFromComponent(ctx context.Context, c client.Client, component *applicationapiv1alpha1.Component) (*applicationapiv1alpha1.Application, error)
+	GetEnvironmentFromIntegrationPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Environment, error)
+	GetSnapshotFromPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Snapshot, error)
+	GetAllIntegrationTestScenariosForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error)
+	GetRequiredIntegrationTestScenariosForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error)
+	GetDeploymentTargetClaimForEnvironment(ctx context.Context, c client.Client, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.DeploymentTargetClaim, error)
+	GetDeploymentTargetForDeploymentTargetClaim(ctx context.Context, c client.Client, dtc *applicationapiv1alpha1.DeploymentTargetClaim) (*applicationapiv1alpha1.DeploymentTarget, error)
+	FindExistingSnapshotEnvironmentBinding(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error)
+	GetAllPipelineRunsForSnapshotAndScenario(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]tektonv1.PipelineRun, error)
+	GetAllSnapshots(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Snapshot, error)
+	GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]releasev1alpha1.ReleasePlan, error)
+	GetScenario(ctx context.Context, c client.Client, name, namespace string) (*v1beta2.IntegrationTestScenario, error)
+	GetAllEnvironmentsForScenario(ctx context.Context, c client.Client, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]applicationapiv1alpha1.Environment, error)
+	GetAllSnapshotsForBuildPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]applicationapiv1alpha1.Snapshot, error)
+	GetAllTaskRunsWithMatchingPipelineRunLabel(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]tektonv1.TaskRun, error)
+	GetPipelineRun(ctx context.Context, c client.Client, name, namespace string) (*tektonv1.PipelineRun, error)
 }
 
 type loader struct{}
@@ -70,7 +70,7 @@ func NewLoader() ObjectLoader {
 }
 
 // GetAllEnvironments gets all environments in the namespace
-func (l *loader) GetAllEnvironments(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Environment, error) {
+func (l *loader) GetAllEnvironments(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Environment, error) {
 
 	environmentList := &applicationapiv1alpha1.EnvironmentList{}
 	opts := []client.ListOption{
@@ -85,7 +85,7 @@ func (l *loader) GetAllEnvironments(c client.Client, ctx context.Context, applic
 
 // GetReleasesWithSnapshot returns all Releases associated with the given snapshot.
 // In the case the List operation fails, an error will be returned.
-func (l *loader) GetReleasesWithSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.Release, error) {
+func (l *loader) GetReleasesWithSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.Release, error) {
 	releases := &releasev1alpha1.ReleaseList{}
 	opts := []client.ListOption{
 		client.InNamespace(snapshot.Namespace),
@@ -102,7 +102,7 @@ func (l *loader) GetReleasesWithSnapshot(c client.Client, ctx context.Context, s
 
 // GetAllApplicationComponents loads from the cluster all Components associated with the given Application.
 // If the Application doesn't have any Components or this is not found in the cluster, an error will be returned.
-func (l *loader) GetAllApplicationComponents(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Component, error) {
+func (l *loader) GetAllApplicationComponents(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Component, error) {
 	applicationComponents := &applicationapiv1alpha1.ComponentList{}
 	opts := []client.ListOption{
 		client.InNamespace(application.Namespace),
@@ -119,14 +119,14 @@ func (l *loader) GetAllApplicationComponents(c client.Client, ctx context.Contex
 
 // GetApplicationFromSnapshot loads from the cluster the Application referenced in the given Snapshot.
 // If the Snapshot doesn't specify an Component or this is not found in the cluster, an error will be returned.
-func (l *loader) GetApplicationFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Application, error) {
+func (l *loader) GetApplicationFromSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Application, error) {
 	application := &applicationapiv1alpha1.Application{}
 	return application, toolkit.GetObject(snapshot.Spec.Application, snapshot.Namespace, c, ctx, application)
 }
 
 // GetComponentFromSnapshot loads from the cluster the Component referenced in the given Snapshot.
 // If the Snapshot doesn't specify an Application or this is not found in the cluster, an error will be returned.
-func (l *loader) GetComponentFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Component, error) {
+func (l *loader) GetComponentFromSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Component, error) {
 	if componentLabel, ok := snapshot.Labels[gitops.SnapshotComponentLabel]; ok {
 		component := &applicationapiv1alpha1.Component{}
 		err := c.Get(ctx, types.NamespacedName{
@@ -147,7 +147,7 @@ func (l *loader) GetComponentFromSnapshot(c client.Client, ctx context.Context, 
 
 // GetComponentFromPipelineRun loads from the cluster the Component referenced in the given PipelineRun. If the PipelineRun doesn't
 // specify a Component or this is not found in the cluster, an error will be returned.
-func (l *loader) GetComponentFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Component, error) {
+func (l *loader) GetComponentFromPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Component, error) {
 	if componentName, found := pipelineRun.Labels[tekton.PipelineRunComponentLabel]; found {
 		component := &applicationapiv1alpha1.Component{}
 		err := c.Get(ctx, types.NamespacedName{
@@ -167,7 +167,7 @@ func (l *loader) GetComponentFromPipelineRun(c client.Client, ctx context.Contex
 
 // GetApplicationFromPipelineRun loads from the cluster the Application referenced in the given PipelineRun. If the PipelineRun doesn't
 // specify an Application or this is not found in the cluster, an error will be returned.
-func (l *loader) GetApplicationFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Application, error) {
+func (l *loader) GetApplicationFromPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Application, error) {
 	if applicationName, found := pipelineRun.Labels[tekton.PipelineRunApplicationLabel]; found {
 		application := &applicationapiv1alpha1.Application{}
 		err := c.Get(ctx, types.NamespacedName{
@@ -187,7 +187,7 @@ func (l *loader) GetApplicationFromPipelineRun(c client.Client, ctx context.Cont
 
 // GetApplicationFromComponent loads from the cluster the Application referenced in the given Component. If the Component doesn't
 // specify an Application or this is not found in the cluster, an error will be returned.
-func (l *loader) GetApplicationFromComponent(c client.Client, ctx context.Context, component *applicationapiv1alpha1.Component) (*applicationapiv1alpha1.Application, error) {
+func (l *loader) GetApplicationFromComponent(ctx context.Context, c client.Client, component *applicationapiv1alpha1.Component) (*applicationapiv1alpha1.Application, error) {
 	application := &applicationapiv1alpha1.Application{}
 	err := c.Get(ctx, types.NamespacedName{
 		Namespace: component.Namespace,
@@ -203,7 +203,7 @@ func (l *loader) GetApplicationFromComponent(c client.Client, ctx context.Contex
 
 // GetEnvironmentFromIntegrationPipelineRun loads from the cluster the Environment referenced in the given PipelineRun.
 // If the PipelineRun doesn't specify an Environment or this is not found in the cluster, an error will be returned.
-func (l *loader) GetEnvironmentFromIntegrationPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Environment, error) {
+func (l *loader) GetEnvironmentFromIntegrationPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Environment, error) {
 	if environmentLabel, ok := pipelineRun.Labels[tekton.EnvironmentNameLabel]; ok {
 		environment := &applicationapiv1alpha1.Environment{}
 		err := c.Get(ctx, types.NamespacedName{
@@ -223,7 +223,7 @@ func (l *loader) GetEnvironmentFromIntegrationPipelineRun(c client.Client, ctx c
 
 // GetSnapshotFromPipelineRun loads from the cluster the Snapshot referenced in the given PipelineRun.
 // If the PipelineRun doesn't specify an Snapshot or this is not found in the cluster, an error will be returned.
-func (l *loader) GetSnapshotFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Snapshot, error) {
+func (l *loader) GetSnapshotFromPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Snapshot, error) {
 	if snapshotName, found := pipelineRun.Labels[tekton.SnapshotNameLabel]; found {
 		snapshot := &applicationapiv1alpha1.Snapshot{}
 		err := c.Get(ctx, types.NamespacedName{
@@ -242,7 +242,7 @@ func (l *loader) GetSnapshotFromPipelineRun(c client.Client, ctx context.Context
 }
 
 // GetAllIntegrationTestScenariosForApplication returns all IntegrationTestScenarios used by the application being processed.
-func (l *loader) GetAllIntegrationTestScenariosForApplication(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error) {
+func (l *loader) GetAllIntegrationTestScenariosForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error) {
 	integrationList := &v1beta2.IntegrationTestScenarioList{}
 
 	opts := &client.ListOptions{
@@ -261,7 +261,7 @@ func (l *loader) GetAllIntegrationTestScenariosForApplication(c client.Client, c
 // GetRequiredIntegrationTestScenariosForApplication returns the IntegrationTestScenarios used by the application being processed.
 // An IntegrationTestScenarios will only be returned if it has the test.appstudio.openshift.io/optional
 // label not set to true or if it is missing the label entirely.
-func (l *loader) GetRequiredIntegrationTestScenariosForApplication(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error) {
+func (l *loader) GetRequiredIntegrationTestScenariosForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error) {
 	integrationList := &v1beta2.IntegrationTestScenarioList{}
 	labelRequirement, err := labels.NewRequirement("test.appstudio.openshift.io/optional", selection.NotIn, []string{"true"})
 	if err != nil {
@@ -285,7 +285,7 @@ func (l *loader) GetRequiredIntegrationTestScenariosForApplication(c client.Clie
 
 // GetDeploymentTargetClaimForEnvironment try to find the DeploymentTargetClaim whose name is defined in Environment
 // if not found, an error is returned
-func (l *loader) GetDeploymentTargetClaimForEnvironment(c client.Client, ctx context.Context, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.DeploymentTargetClaim, error) {
+func (l *loader) GetDeploymentTargetClaimForEnvironment(ctx context.Context, c client.Client, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.DeploymentTargetClaim, error) {
 	if (environment.Spec.Configuration.Target != applicationapiv1alpha1.EnvironmentTarget{}) {
 		dtcName := environment.Spec.Configuration.Target.DeploymentTargetClaim.ClaimName
 		if dtcName != "" {
@@ -308,7 +308,7 @@ func (l *loader) GetDeploymentTargetClaimForEnvironment(c client.Client, ctx con
 
 // GetDeploymentTargetForDeploymentTargetClaim try to find the DeploymentTarget whose name is defined in DeploymentTargetClaim
 // if not found, an error is returned
-func (l *loader) GetDeploymentTargetForDeploymentTargetClaim(c client.Client, ctx context.Context, dtc *applicationapiv1alpha1.DeploymentTargetClaim) (*applicationapiv1alpha1.DeploymentTarget, error) {
+func (l *loader) GetDeploymentTargetForDeploymentTargetClaim(ctx context.Context, c client.Client, dtc *applicationapiv1alpha1.DeploymentTargetClaim) (*applicationapiv1alpha1.DeploymentTarget, error) {
 	dtName := dtc.Spec.TargetName
 	if dtName == "" {
 		return nil, fmt.Errorf("deploymentTarget is not defined in .Spec.TargetName for deploymentTargetClaim: %s/%s", dtc.Namespace, dtc.Name)
@@ -329,7 +329,7 @@ func (l *loader) GetDeploymentTargetForDeploymentTargetClaim(c client.Client, ct
 
 // FindExistingSnapshotEnvironmentBinding attempts to find a SnapshotEnvironmentBinding that's
 // associated with the provided environment.
-func (l *loader) FindExistingSnapshotEnvironmentBinding(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error) {
+func (l *loader) FindExistingSnapshotEnvironmentBinding(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error) {
 	snapshotEnvironmentBindingList := &applicationapiv1alpha1.SnapshotEnvironmentBindingList{}
 	opts := []client.ListOption{
 		client.InNamespace(application.Namespace),
@@ -353,7 +353,7 @@ func (l *loader) FindExistingSnapshotEnvironmentBinding(c client.Client, ctx con
 // GetAllPipelineRunsForSnapshotAndScenario returns all Integration PipelineRun for the
 // associated Snapshot and IntegrationTestScenario. In the case the List operation fails,
 // an error will be returned.
-func (l *loader) GetAllPipelineRunsForSnapshotAndScenario(adapterClient client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]tektonv1.PipelineRun, error) {
+func (l *loader) GetAllPipelineRunsForSnapshotAndScenario(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]tektonv1.PipelineRun, error) {
 	integrationPipelineRuns := &tektonv1.PipelineRunList{}
 	opts := []client.ListOption{
 		client.InNamespace(snapshot.Namespace),
@@ -373,7 +373,7 @@ func (l *loader) GetAllPipelineRunsForSnapshotAndScenario(adapterClient client.C
 
 // GetAllSnapshots returns all Snapshots in the Application's namespace nil if it's not found.
 // In the case the List operation fails, an error will be returned.
-func (l *loader) GetAllSnapshots(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *loader) GetAllSnapshots(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Snapshot, error) {
 	snapshots := &applicationapiv1alpha1.SnapshotList{}
 	opts := []client.ListOption{
 		client.InNamespace(application.Namespace),
@@ -391,7 +391,7 @@ func (l *loader) GetAllSnapshots(c client.Client, ctx context.Context, applicati
 // GetAutoReleasePlansForApplication returns the ReleasePlans used by the application being processed. If matching
 // ReleasePlans are not found, an error will be returned. A ReleasePlan will only be returned if it has the
 // release.appstudio.openshift.io/auto-release label set to true or if it is missing the label entirely.
-func (l *loader) GetAutoReleasePlansForApplication(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]releasev1alpha1.ReleasePlan, error) {
+func (l *loader) GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]releasev1alpha1.ReleasePlan, error) {
 	releasePlans := &releasev1alpha1.ReleasePlanList{}
 	labelRequirement, err := labels.NewRequirement("release.appstudio.openshift.io/auto-release", selection.NotIn, []string{"false"})
 	if err != nil {
@@ -414,14 +414,14 @@ func (l *loader) GetAutoReleasePlansForApplication(c client.Client, ctx context.
 }
 
 // GetScenario returns integration test scenario requested by name and namespace
-func (l *loader) GetScenario(c client.Client, ctx context.Context, name, namespace string) (*v1beta2.IntegrationTestScenario, error) {
+func (l *loader) GetScenario(ctx context.Context, c client.Client, name, namespace string) (*v1beta2.IntegrationTestScenario, error) {
 	scenario := &v1beta2.IntegrationTestScenario{}
 	return scenario, toolkit.GetObject(name, namespace, c, ctx, scenario)
 }
 
 // GetAllEnvironmentsForScenario returns all Environments for the associated integrationTestScenario.
 // In the case the List operation fails, an error will be returned.
-func (l *loader) GetAllEnvironmentsForScenario(c client.Client, ctx context.Context, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]applicationapiv1alpha1.Environment, error) {
+func (l *loader) GetAllEnvironmentsForScenario(ctx context.Context, c client.Client, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]applicationapiv1alpha1.Environment, error) {
 	environments := &applicationapiv1alpha1.EnvironmentList{}
 	opts := []client.ListOption{
 		client.InNamespace(integrationTestScenario.Namespace),
@@ -439,7 +439,7 @@ func (l *loader) GetAllEnvironmentsForScenario(c client.Client, ctx context.Cont
 
 // GetAllSnapshotsForBuildPipelineRun returns all Snapshots for the associated build pipelineRun.
 // In the case the List operation fails, an error will be returned.
-func (l *loader) GetAllSnapshotsForBuildPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *loader) GetAllSnapshotsForBuildPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]applicationapiv1alpha1.Snapshot, error) {
 	snapshots := &applicationapiv1alpha1.SnapshotList{}
 	opts := []client.ListOption{
 		client.InNamespace(pipelineRun.Namespace),
@@ -457,7 +457,7 @@ func (l *loader) GetAllSnapshotsForBuildPipelineRun(c client.Client, ctx context
 
 // GetAllTaskRunsWithMatchingPipelineRunLabel finds all Child TaskRuns
 // whose "tekton.dev/pipeline" label points to the given PipelineRun
-func (l *loader) GetAllTaskRunsWithMatchingPipelineRunLabel(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*[]tektonv1.TaskRun, error) {
+func (l *loader) GetAllTaskRunsWithMatchingPipelineRunLabel(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]tektonv1.TaskRun, error) {
 	taskRuns := &tektonv1.TaskRunList{}
 	opts := []client.ListOption{
 		client.InNamespace(pipelineRun.Namespace),
@@ -475,7 +475,7 @@ func (l *loader) GetAllTaskRunsWithMatchingPipelineRunLabel(c client.Client, ctx
 }
 
 // GetPipelineRun returns Tekton pipelineRun requested by name and namespace
-func (l *loader) GetPipelineRun(c client.Client, ctx context.Context, name, namespace string) (*tektonv1.PipelineRun, error) {
+func (l *loader) GetPipelineRun(ctx context.Context, c client.Client, name, namespace string) (*tektonv1.PipelineRun, error) {
 	pipelineRun := &tektonv1.PipelineRun{}
 	return pipelineRun, toolkit.GetObject(name, namespace, c, ctx, pipelineRun)
 }

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -63,193 +63,193 @@ func NewMockLoader() ObjectLoader {
 }
 
 // GetAllEnvironments returns the resource and error passed as values of the context.
-func (l *mockLoader) GetAllEnvironments(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Environment, error) {
+func (l *mockLoader) GetAllEnvironments(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Environment, error) {
 	if ctx.Value(EnvironmentContextKey) == nil {
-		return l.loader.GetAllEnvironments(c, ctx, application)
+		return l.loader.GetAllEnvironments(ctx, c, application)
 	}
 	environment, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, EnvironmentContextKey, &applicationapiv1alpha1.Environment{})
 	return &[]applicationapiv1alpha1.Environment{*environment}, err
 }
 
 // GetReleasesWithSnapshot returns the resource and error passed as values of the context.
-func (l *mockLoader) GetReleasesWithSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.Release, error) {
+func (l *mockLoader) GetReleasesWithSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.Release, error) {
 	if ctx.Value(ReleaseContextKey) == nil {
-		return l.loader.GetReleasesWithSnapshot(c, ctx, snapshot)
+		return l.loader.GetReleasesWithSnapshot(ctx, c, snapshot)
 	}
 	release, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, ReleaseContextKey, &releasev1alpha1.Release{})
 	return &[]releasev1alpha1.Release{*release}, err
 }
 
 // GetAllApplicationComponents returns the resource and error passed as values of the context.
-func (l *mockLoader) GetAllApplicationComponents(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Component, error) {
+func (l *mockLoader) GetAllApplicationComponents(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Component, error) {
 	if ctx.Value(ApplicationComponentsContextKey) == nil {
-		return l.loader.GetAllApplicationComponents(c, ctx, application)
+		return l.loader.GetAllApplicationComponents(ctx, c, application)
 	}
 	components, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, ApplicationComponentsContextKey, []applicationapiv1alpha1.Component{})
 	return &components, err
 }
 
 // GetApplicationFromSnapshot returns the resource and error passed as values of the context.
-func (l *mockLoader) GetApplicationFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Application, error) {
+func (l *mockLoader) GetApplicationFromSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Application, error) {
 	if ctx.Value(ApplicationContextKey) == nil {
-		return l.loader.GetApplicationFromSnapshot(c, ctx, snapshot)
+		return l.loader.GetApplicationFromSnapshot(ctx, c, snapshot)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ApplicationContextKey, &applicationapiv1alpha1.Application{})
 }
 
 // GetComponentFromSnapshot returns the resource and error passed as values of the context.
-func (l *mockLoader) GetComponentFromSnapshot(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Component, error) {
+func (l *mockLoader) GetComponentFromSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Component, error) {
 	if ctx.Value(ComponentContextKey) == nil {
-		return l.loader.GetComponentFromSnapshot(c, ctx, snapshot)
+		return l.loader.GetComponentFromSnapshot(ctx, c, snapshot)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ComponentContextKey, &applicationapiv1alpha1.Component{})
 }
 
 // GetComponentFromPipelineRun returns the resource and error passed as values of the context.
-func (l *mockLoader) GetComponentFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Component, error) {
+func (l *mockLoader) GetComponentFromPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Component, error) {
 	if ctx.Value(ComponentContextKey) == nil {
-		return l.loader.GetComponentFromPipelineRun(c, ctx, pipelineRun)
+		return l.loader.GetComponentFromPipelineRun(ctx, c, pipelineRun)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ComponentContextKey, &applicationapiv1alpha1.Component{})
 }
 
 // GetApplicationFromPipelineRun returns the resource and error passed as values of the context.
-func (l *mockLoader) GetApplicationFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Application, error) {
+func (l *mockLoader) GetApplicationFromPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Application, error) {
 	if ctx.Value(ApplicationContextKey) == nil {
-		return l.loader.GetApplicationFromPipelineRun(c, ctx, pipelineRun)
+		return l.loader.GetApplicationFromPipelineRun(ctx, c, pipelineRun)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ApplicationContextKey, &applicationapiv1alpha1.Application{})
 }
 
 // GetApplicationFromComponent returns the resource and error passed as values of the context.
-func (l *mockLoader) GetApplicationFromComponent(c client.Client, ctx context.Context, component *applicationapiv1alpha1.Component) (*applicationapiv1alpha1.Application, error) {
+func (l *mockLoader) GetApplicationFromComponent(ctx context.Context, c client.Client, component *applicationapiv1alpha1.Component) (*applicationapiv1alpha1.Application, error) {
 	if ctx.Value(ApplicationContextKey) == nil {
-		return l.loader.GetApplicationFromComponent(c, ctx, component)
+		return l.loader.GetApplicationFromComponent(ctx, c, component)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ApplicationContextKey, &applicationapiv1alpha1.Application{})
 }
 
 // GetEnvironmentFromIntegrationPipelineRun returns the resource and error passed as values of the context.
-func (l *mockLoader) GetEnvironmentFromIntegrationPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Environment, error) {
+func (l *mockLoader) GetEnvironmentFromIntegrationPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Environment, error) {
 	if ctx.Value(EnvironmentContextKey) == nil {
-		return l.loader.GetEnvironmentFromIntegrationPipelineRun(c, ctx, pipelineRun)
+		return l.loader.GetEnvironmentFromIntegrationPipelineRun(ctx, c, pipelineRun)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, EnvironmentContextKey, &applicationapiv1alpha1.Environment{})
 }
 
 // GetSnapshotFromPipelineRun returns the resource and error passed as values of the context.
-func (l *mockLoader) GetSnapshotFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Snapshot, error) {
+func (l *mockLoader) GetSnapshotFromPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*applicationapiv1alpha1.Snapshot, error) {
 	if ctx.Value(SnapshotContextKey) == nil {
-		return l.loader.GetSnapshotFromPipelineRun(c, ctx, pipelineRun)
+		return l.loader.GetSnapshotFromPipelineRun(ctx, c, pipelineRun)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, SnapshotContextKey, &applicationapiv1alpha1.Snapshot{})
 }
 
 // GetAllIntegrationTestScenariosForApplication returns the resource and error passed as values of the context.
-func (l *mockLoader) GetAllIntegrationTestScenariosForApplication(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error) {
+func (l *mockLoader) GetAllIntegrationTestScenariosForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error) {
 	if ctx.Value(AllIntegrationTestScenariosContextKey) == nil {
-		return l.loader.GetAllIntegrationTestScenariosForApplication(c, ctx, application)
+		return l.loader.GetAllIntegrationTestScenariosForApplication(ctx, c, application)
 	}
 	integrationTestScenarios, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllIntegrationTestScenariosContextKey, []v1beta2.IntegrationTestScenario{})
 	return &integrationTestScenarios, err
 }
 
 // GetRequiredIntegrationTestScenariosForApplication returns the resource and error passed as values of the context.
-func (l *mockLoader) GetRequiredIntegrationTestScenariosForApplication(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error) {
+func (l *mockLoader) GetRequiredIntegrationTestScenariosForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]v1beta2.IntegrationTestScenario, error) {
 	if ctx.Value(RequiredIntegrationTestScenariosContextKey) == nil {
-		return l.loader.GetRequiredIntegrationTestScenariosForApplication(c, ctx, application)
+		return l.loader.GetRequiredIntegrationTestScenariosForApplication(ctx, c, application)
 	}
 	integrationTestScenarios, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, RequiredIntegrationTestScenariosContextKey, []v1beta2.IntegrationTestScenario{})
 	return &integrationTestScenarios, err
 }
 
 // GetDeploymentTargetClaimForEnvironment returns the resource and error passed as values of the context.
-func (l *mockLoader) GetDeploymentTargetClaimForEnvironment(c client.Client, ctx context.Context, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.DeploymentTargetClaim, error) {
+func (l *mockLoader) GetDeploymentTargetClaimForEnvironment(ctx context.Context, c client.Client, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.DeploymentTargetClaim, error) {
 	if ctx.Value(DeploymentTargetClaimContextKey) == nil {
-		return l.loader.GetDeploymentTargetClaimForEnvironment(c, ctx, environment)
+		return l.loader.GetDeploymentTargetClaimForEnvironment(ctx, c, environment)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, DeploymentTargetClaimContextKey, &applicationapiv1alpha1.DeploymentTargetClaim{})
 }
 
 // GetDeploymentTargetForDeploymentTargetClaim returns the resource and error passed as values of the context.
-func (l *mockLoader) GetDeploymentTargetForDeploymentTargetClaim(c client.Client, ctx context.Context, dtc *applicationapiv1alpha1.DeploymentTargetClaim) (*applicationapiv1alpha1.DeploymentTarget, error) {
+func (l *mockLoader) GetDeploymentTargetForDeploymentTargetClaim(ctx context.Context, c client.Client, dtc *applicationapiv1alpha1.DeploymentTargetClaim) (*applicationapiv1alpha1.DeploymentTarget, error) {
 	if ctx.Value(DeploymentTargetContextKey) == nil {
-		return l.loader.GetDeploymentTargetForDeploymentTargetClaim(c, ctx, dtc)
+		return l.loader.GetDeploymentTargetForDeploymentTargetClaim(ctx, c, dtc)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, DeploymentTargetContextKey, &applicationapiv1alpha1.DeploymentTarget{})
 }
 
 // FindExistingSnapshotEnvironmentBinding returns the resource and error passed as values of the context.
-func (l *mockLoader) FindExistingSnapshotEnvironmentBinding(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error) {
+func (l *mockLoader) FindExistingSnapshotEnvironmentBinding(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, environment *applicationapiv1alpha1.Environment) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error) {
 	if ctx.Value(SnapshotEnvironmentBindingContextKey) == nil {
-		return l.loader.FindExistingSnapshotEnvironmentBinding(c, ctx, application, environment)
+		return l.loader.FindExistingSnapshotEnvironmentBinding(ctx, c, application, environment)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, SnapshotEnvironmentBindingContextKey, &applicationapiv1alpha1.SnapshotEnvironmentBinding{})
 }
 
 // GetAllPipelineRunsForSnapshotAndScenario returns the resource and error passed as values of the context.
-func (l *mockLoader) GetAllPipelineRunsForSnapshotAndScenario(c client.Client, ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]tektonv1.PipelineRun, error) {
+func (l *mockLoader) GetAllPipelineRunsForSnapshotAndScenario(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]tektonv1.PipelineRun, error) {
 	if ctx.Value(PipelineRunsContextKey) == nil {
-		return l.loader.GetAllPipelineRunsForSnapshotAndScenario(c, ctx, snapshot, integrationTestScenario)
+		return l.loader.GetAllPipelineRunsForSnapshotAndScenario(ctx, c, snapshot, integrationTestScenario)
 	}
 	pipelineRuns, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, PipelineRunsContextKey, []tektonv1.PipelineRun{})
 	return &pipelineRuns, err
 }
 
 // GetAllSnapshots returns the resource and error passed as values of the context.
-func (l *mockLoader) GetAllSnapshots(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *mockLoader) GetAllSnapshots(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Snapshot, error) {
 	if ctx.Value(AllSnapshotsContextKey) == nil {
-		return l.loader.GetAllSnapshots(c, ctx, application)
+		return l.loader.GetAllSnapshots(ctx, c, application)
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllSnapshotsContextKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
 }
 
 // GetAutoReleasePlansForApplication returns the resource and error passed as values of the context.
-func (l *mockLoader) GetAutoReleasePlansForApplication(c client.Client, ctx context.Context, application *applicationapiv1alpha1.Application) (*[]releasev1alpha1.ReleasePlan, error) {
+func (l *mockLoader) GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]releasev1alpha1.ReleasePlan, error) {
 	if ctx.Value(AutoReleasePlansContextKey) == nil {
-		return l.loader.GetAutoReleasePlansForApplication(c, ctx, application)
+		return l.loader.GetAutoReleasePlansForApplication(ctx, c, application)
 	}
 	autoReleasePlans, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AutoReleasePlansContextKey, []releasev1alpha1.ReleasePlan{})
 	return &autoReleasePlans, err
 }
 
 // GetScenario returns the resource and error passed as values of the context.
-func (l *mockLoader) GetScenario(c client.Client, ctx context.Context, name, namespace string) (*v1beta2.IntegrationTestScenario, error) {
+func (l *mockLoader) GetScenario(ctx context.Context, c client.Client, name, namespace string) (*v1beta2.IntegrationTestScenario, error) {
 	if ctx.Value(GetScenarioContextKey) == nil {
-		return l.loader.GetScenario(c, ctx, name, namespace)
+		return l.loader.GetScenario(ctx, c, name, namespace)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, GetScenarioContextKey, &v1beta2.IntegrationTestScenario{})
 }
 
-func (l *mockLoader) GetAllEnvironmentsForScenario(c client.Client, ctx context.Context, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]applicationapiv1alpha1.Environment, error) {
+func (l *mockLoader) GetAllEnvironmentsForScenario(ctx context.Context, c client.Client, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]applicationapiv1alpha1.Environment, error) {
 	if ctx.Value(AllEnvironmentsForScenarioContextKey) == nil {
-		return l.loader.GetAllEnvironmentsForScenario(c, ctx, integrationTestScenario)
+		return l.loader.GetAllEnvironmentsForScenario(ctx, c, integrationTestScenario)
 	}
 	environments, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllEnvironmentsForScenarioContextKey, []applicationapiv1alpha1.Environment{})
 	return &environments, err
 }
 
-func (l *mockLoader) GetAllSnapshotsForBuildPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *mockLoader) GetAllSnapshotsForBuildPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]applicationapiv1alpha1.Snapshot, error) {
 	if ctx.Value(AllSnapshotsForBuildPipelineRunContextKey) == nil {
-		return l.loader.GetAllSnapshotsForBuildPipelineRun(c, ctx, pipelineRun)
+		return l.loader.GetAllSnapshotsForBuildPipelineRun(ctx, c, pipelineRun)
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllSnapshotsForBuildPipelineRunContextKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
 }
 
-func (l *mockLoader) GetAllTaskRunsWithMatchingPipelineRunLabel(c client.Client, ctx context.Context, pipelineRun *tektonv1.PipelineRun) (*[]tektonv1.TaskRun, error) {
+func (l *mockLoader) GetAllTaskRunsWithMatchingPipelineRunLabel(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]tektonv1.TaskRun, error) {
 	if ctx.Value(AllTaskRunsWithMatchingPipelineRunLabelContextKey) == nil {
-		return l.loader.GetAllTaskRunsWithMatchingPipelineRunLabel(c, ctx, pipelineRun)
+		return l.loader.GetAllTaskRunsWithMatchingPipelineRunLabel(ctx, c, pipelineRun)
 	}
 	taskRuns, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllTaskRunsWithMatchingPipelineRunLabelContextKey, []tektonv1.TaskRun{})
 	return &taskRuns, err
 }
 
 // GetPipelineRun returns the resource and error passed as values of the context.
-func (l *mockLoader) GetPipelineRun(c client.Client, ctx context.Context, name, namespace string) (*tektonv1.PipelineRun, error) {
+func (l *mockLoader) GetPipelineRun(ctx context.Context, c client.Client, name, namespace string) (*tektonv1.PipelineRun, error) {
 	if ctx.Value(GetPipelineRunContextKey) == nil {
-		return l.loader.GetPipelineRun(c, ctx, name, namespace)
+		return l.loader.GetPipelineRun(ctx, c, name, namespace)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, GetPipelineRunContextKey, &tektonv1.PipelineRun{})
 }

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   environment,
 				},
 			})
-			resource, err := loader.GetAllEnvironments(nil, mockContext, nil)
+			resource, err := loader.GetAllEnvironments(mockContext, nil, nil)
 			Expect(resource).To(Equal(&[]applicationapiv1alpha1.Environment{*environment}))
 			Expect(err).To(BeNil())
 		})
@@ -60,7 +60,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   release,
 				},
 			})
-			resource, err := loader.GetReleasesWithSnapshot(nil, mockContext, nil)
+			resource, err := loader.GetReleasesWithSnapshot(mockContext, nil, nil)
 			Expect(resource).To(Equal(&[]releasev1alpha1.Release{*release}))
 			Expect(err).To(BeNil())
 		})
@@ -75,7 +75,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   applicationComponents,
 				},
 			})
-			resource, err := loader.GetAllApplicationComponents(nil, mockContext, nil)
+			resource, err := loader.GetAllApplicationComponents(mockContext, nil, nil)
 			Expect(resource).To(Equal(&applicationComponents))
 			Expect(err).To(BeNil())
 		})
@@ -90,7 +90,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   application,
 				},
 			})
-			resource, err := loader.GetApplicationFromSnapshot(nil, mockContext, nil)
+			resource, err := loader.GetApplicationFromSnapshot(mockContext, nil, nil)
 			Expect(resource).To(Equal(application))
 			Expect(err).To(BeNil())
 		})
@@ -105,7 +105,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   component,
 				},
 			})
-			resource, err := loader.GetComponentFromSnapshot(nil, mockContext, nil)
+			resource, err := loader.GetComponentFromSnapshot(mockContext, nil, nil)
 			Expect(resource).To(Equal(component))
 			Expect(err).To(BeNil())
 		})
@@ -120,7 +120,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   component,
 				},
 			})
-			resource, err := loader.GetComponentFromPipelineRun(nil, mockContext, nil)
+			resource, err := loader.GetComponentFromPipelineRun(mockContext, nil, nil)
 			Expect(resource).To(Equal(component))
 			Expect(err).To(BeNil())
 		})
@@ -135,7 +135,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   application,
 				},
 			})
-			resource, err := loader.GetApplicationFromPipelineRun(nil, mockContext, nil)
+			resource, err := loader.GetApplicationFromPipelineRun(mockContext, nil, nil)
 			Expect(resource).To(Equal(application))
 			Expect(err).To(BeNil())
 		})
@@ -150,7 +150,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   application,
 				},
 			})
-			resource, err := loader.GetApplicationFromComponent(nil, mockContext, nil)
+			resource, err := loader.GetApplicationFromComponent(mockContext, nil, nil)
 			Expect(resource).To(Equal(application))
 			Expect(err).To(BeNil())
 		})
@@ -165,7 +165,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   environment,
 				},
 			})
-			resource, err := loader.GetEnvironmentFromIntegrationPipelineRun(nil, mockContext, nil)
+			resource, err := loader.GetEnvironmentFromIntegrationPipelineRun(mockContext, nil, nil)
 			Expect(resource).To(Equal(environment))
 			Expect(err).To(BeNil())
 		})
@@ -180,7 +180,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   snapshot,
 				},
 			})
-			resource, err := loader.GetSnapshotFromPipelineRun(nil, mockContext, nil)
+			resource, err := loader.GetSnapshotFromPipelineRun(mockContext, nil, nil)
 			Expect(resource).To(Equal(snapshot))
 			Expect(err).To(BeNil())
 		})
@@ -195,7 +195,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   snapshots,
 				},
 			})
-			resource, err := loader.GetAllSnapshotsForBuildPipelineRun(nil, mockContext, nil)
+			resource, err := loader.GetAllSnapshotsForBuildPipelineRun(mockContext, nil, nil)
 			Expect(resource).To(Equal(&snapshots))
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -210,7 +210,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   scenarios,
 				},
 			})
-			resource, err := loader.GetAllIntegrationTestScenariosForApplication(nil, mockContext, nil)
+			resource, err := loader.GetAllIntegrationTestScenariosForApplication(mockContext, nil, nil)
 			Expect(resource).To(Equal(&scenarios))
 			Expect(err).To(BeNil())
 		})
@@ -225,7 +225,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   scenarios,
 				},
 			})
-			resource, err := loader.GetRequiredIntegrationTestScenariosForApplication(nil, mockContext, nil)
+			resource, err := loader.GetRequiredIntegrationTestScenariosForApplication(mockContext, nil, nil)
 			Expect(resource).To(Equal(&scenarios))
 			Expect(err).To(BeNil())
 		})
@@ -240,7 +240,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   dtc,
 				},
 			})
-			resource, err := loader.GetDeploymentTargetClaimForEnvironment(nil, mockContext, nil)
+			resource, err := loader.GetDeploymentTargetClaimForEnvironment(mockContext, nil, nil)
 			Expect(resource).To(Equal(dtc))
 			Expect(err).To(BeNil())
 		})
@@ -255,7 +255,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   dt,
 				},
 			})
-			resource, err := loader.GetDeploymentTargetForDeploymentTargetClaim(nil, mockContext, nil)
+			resource, err := loader.GetDeploymentTargetForDeploymentTargetClaim(mockContext, nil, nil)
 			Expect(resource).To(Equal(dt))
 			Expect(err).To(BeNil())
 		})
@@ -270,7 +270,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   binding,
 				},
 			})
-			resource, err := loader.FindExistingSnapshotEnvironmentBinding(nil, mockContext, nil, nil)
+			resource, err := loader.FindExistingSnapshotEnvironmentBinding(mockContext, nil, nil, nil)
 			Expect(resource).To(Equal(binding))
 			Expect(err).To(BeNil())
 		})
@@ -285,7 +285,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   prs,
 				},
 			})
-			resource, err := loader.GetAllPipelineRunsForSnapshotAndScenario(nil, mockContext, nil, nil)
+			resource, err := loader.GetAllPipelineRunsForSnapshotAndScenario(mockContext, nil, nil, nil)
 			Expect(resource).To(Equal(&prs))
 			Expect(err).To(BeNil())
 		})
@@ -300,7 +300,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   snapshots,
 				},
 			})
-			resource, err := loader.GetAllSnapshots(nil, mockContext, nil)
+			resource, err := loader.GetAllSnapshots(mockContext, nil, nil)
 			Expect(resource).To(Equal(&snapshots))
 			Expect(err).To(BeNil())
 		})
@@ -315,7 +315,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   releasePlans,
 				},
 			})
-			resource, err := loader.GetAutoReleasePlansForApplication(nil, mockContext, nil)
+			resource, err := loader.GetAutoReleasePlansForApplication(mockContext, nil, nil)
 			Expect(resource).To(Equal(&releasePlans))
 			Expect(err).To(BeNil())
 		})
@@ -330,7 +330,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   environments,
 				},
 			})
-			resource, err := loader.GetAllEnvironmentsForScenario(nil, mockContext, nil)
+			resource, err := loader.GetAllEnvironmentsForScenario(mockContext, nil, nil)
 			Expect(resource).To(Equal(&environments))
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -345,7 +345,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   taskRuns,
 				},
 			})
-			resource, err := loader.GetAllTaskRunsWithMatchingPipelineRunLabel(nil, mockContext, nil)
+			resource, err := loader.GetAllTaskRunsWithMatchingPipelineRunLabel(mockContext, nil, nil)
 			Expect(resource).To(Equal(&taskRuns))
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -360,7 +360,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   pipelineRun,
 				},
 			})
-			resource, err := loader.GetPipelineRun(nil, mockContext, "", "")
+			resource, err := loader.GetPipelineRun(mockContext, nil, "", "")
 			Expect(resource).To(Equal(pipelineRun))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -470,7 +470,7 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(k8sClient).NotTo(BeNil())
 		Expect(ctx).NotTo(BeNil())
 		Expect(hasSnapshot).NotTo(BeNil())
-		err := gitops.MarkSnapshotAsPassed(k8sClient, ctx, hasSnapshot, "test passed")
+		err := gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "test passed")
 		Expect(err).To(Succeed())
 		Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -461,7 +461,7 @@ var _ = Describe("Loader", Ordered, func() {
 	}
 
 	It("ensures environments can be found", func() {
-		environments, err := loader.GetAllEnvironments(k8sClient, ctx, hasApp)
+		environments, err := loader.GetAllEnvironments(ctx, k8sClient, hasApp)
 		Expect(err).To(BeNil())
 		Expect(environments).NotTo(BeNil())
 	})
@@ -477,7 +477,7 @@ var _ = Describe("Loader", Ordered, func() {
 		// Normally we would Ensure that releases exist here, but that requires
 		// importing the snapshot package which causes an import cycle
 
-		releases, err := loader.GetReleasesWithSnapshot(k8sClient, ctx, hasSnapshot)
+		releases, err := loader.GetReleasesWithSnapshot(ctx, k8sClient, hasSnapshot)
 		Expect(err).To(BeNil())
 		Expect(releases).NotTo(BeNil())
 		for _, release := range *releases {
@@ -486,20 +486,20 @@ var _ = Describe("Loader", Ordered, func() {
 	})
 
 	It("ensures the Application Components can be found ", func() {
-		applicationComponents, err := loader.GetAllApplicationComponents(k8sClient, ctx, hasApp)
+		applicationComponents, err := loader.GetAllApplicationComponents(ctx, k8sClient, hasApp)
 		Expect(err).To(BeNil())
 		Expect(applicationComponents).NotTo(BeNil())
 	})
 
 	It("ensures we can get an Application from a Snapshot ", func() {
-		app, err := loader.GetApplicationFromSnapshot(k8sClient, ctx, hasSnapshot)
+		app, err := loader.GetApplicationFromSnapshot(ctx, k8sClient, hasSnapshot)
 		Expect(err).To(BeNil())
 		Expect(app).NotTo(BeNil())
 		Expect(app.ObjectMeta).To(Equal(hasApp.ObjectMeta))
 	})
 
 	It("ensures we can get a Component from a Snapshot ", func() {
-		comp, err := loader.GetComponentFromSnapshot(k8sClient, ctx, hasSnapshot)
+		comp, err := loader.GetComponentFromSnapshot(ctx, k8sClient, hasSnapshot)
 		Expect(err).To(BeNil())
 		Expect(comp).NotTo(BeNil())
 		Expect(comp.ObjectMeta).To(Equal(hasComp.ObjectMeta))
@@ -509,7 +509,7 @@ var _ = Describe("Loader", Ordered, func() {
 		// Temporarily remove the component label from Snapshot
 		delete(hasSnapshot.Labels, gitops.SnapshotComponentLabel)
 
-		comp, err := loader.GetComponentFromSnapshot(k8sClient, ctx, hasSnapshot)
+		comp, err := loader.GetComponentFromSnapshot(ctx, k8sClient, hasSnapshot)
 		Expect(err).To(HaveOccurred())
 		Expect(comp).To(BeNil())
 
@@ -518,41 +518,41 @@ var _ = Describe("Loader", Ordered, func() {
 	})
 
 	It("ensures we can get a Component from a Pipeline Run ", func() {
-		comp, err := loader.GetComponentFromPipelineRun(k8sClient, ctx, buildPipelineRun)
+		comp, err := loader.GetComponentFromPipelineRun(ctx, k8sClient, buildPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(comp).NotTo(BeNil())
 		Expect(comp.ObjectMeta).To(Equal(hasComp.ObjectMeta))
 	})
 
 	It("ensures we can get the application from the Pipeline Run", func() {
-		app, err := loader.GetApplicationFromPipelineRun(k8sClient, ctx, buildPipelineRun)
+		app, err := loader.GetApplicationFromPipelineRun(ctx, k8sClient, buildPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(app).NotTo(BeNil())
 		Expect(app.ObjectMeta).To(Equal(hasApp.ObjectMeta))
 	})
 
 	It("ensures we can get the environment from the Pipeline Run", func() {
-		env, err := loader.GetApplicationFromPipelineRun(k8sClient, ctx, buildPipelineRun)
+		env, err := loader.GetApplicationFromPipelineRun(ctx, k8sClient, buildPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(env).NotTo(BeNil())
 	})
 
 	It("ensures we can get the Application from a Component", func() {
-		app, err := loader.GetApplicationFromComponent(k8sClient, ctx, hasComp)
+		app, err := loader.GetApplicationFromComponent(ctx, k8sClient, hasComp)
 		Expect(err).To(BeNil())
 		Expect(app).NotTo(BeNil())
 		Expect(app.ObjectMeta).To(Equal(hasApp.ObjectMeta))
 	})
 
 	It("ensures we can get the Snapshot from a Pipeline Run", func() {
-		snapshot, err := loader.GetSnapshotFromPipelineRun(k8sClient, ctx, buildPipelineRun)
+		snapshot, err := loader.GetSnapshotFromPipelineRun(ctx, k8sClient, buildPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(snapshot).NotTo(BeNil())
 		Expect(snapshot.ObjectMeta).To(Equal(hasSnapshot.ObjectMeta))
 	})
 
 	It("ensures we can get the Snapshot from a Pipeline Run", func() {
-		snapshots, err := loader.GetAllSnapshotsForBuildPipelineRun(k8sClient, ctx, buildPipelineRun)
+		snapshots, err := loader.GetAllSnapshotsForBuildPipelineRun(ctx, k8sClient, buildPipelineRun)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 		Expect(*snapshots).To(HaveLen(1))
@@ -560,14 +560,14 @@ var _ = Describe("Loader", Ordered, func() {
 	})
 
 	It("ensures we can get the Environment from a Pipeline Run", func() {
-		env, err := loader.GetEnvironmentFromIntegrationPipelineRun(k8sClient, ctx, buildPipelineRun)
+		env, err := loader.GetEnvironmentFromIntegrationPipelineRun(ctx, k8sClient, buildPipelineRun)
 		Expect(err).To(BeNil())
 		Expect(env).NotTo(BeNil())
 		Expect(env.ObjectMeta).To(Equal(hasEnv.ObjectMeta))
 	})
 
 	It("can fetch all pipelineRuns for snapshot and scenario", func() {
-		pipelineRuns, err := loader.GetAllPipelineRunsForSnapshotAndScenario(k8sClient, ctx, hasSnapshot, integrationTestScenario)
+		pipelineRuns, err := loader.GetAllPipelineRunsForSnapshotAndScenario(ctx, k8sClient, hasSnapshot, integrationTestScenario)
 		Expect(err).To(BeNil())
 		Expect(pipelineRuns).NotTo(BeNil())
 		Expect(*pipelineRuns).To(HaveLen(1))
@@ -575,7 +575,7 @@ var _ = Describe("Loader", Ordered, func() {
 	})
 
 	It("can fetch all integrationTestScenario for application", func() {
-		integrationTestScenarios, err := loader.GetAllIntegrationTestScenariosForApplication(k8sClient, ctx, hasApp)
+		integrationTestScenarios, err := loader.GetAllIntegrationTestScenariosForApplication(ctx, k8sClient, hasApp)
 		Expect(err).To(BeNil())
 		Expect(integrationTestScenarios).NotTo(BeNil())
 		Expect(*integrationTestScenarios).To(HaveLen(1))
@@ -583,7 +583,7 @@ var _ = Describe("Loader", Ordered, func() {
 	})
 
 	It("can fetch required integrationTestScenario for application", func() {
-		integrationTestScenarios, err := loader.GetRequiredIntegrationTestScenariosForApplication(k8sClient, ctx, hasApp)
+		integrationTestScenarios, err := loader.GetRequiredIntegrationTestScenariosForApplication(ctx, k8sClient, hasApp)
 		Expect(err).To(BeNil())
 		Expect(integrationTestScenarios).NotTo(BeNil())
 		Expect(*integrationTestScenarios).To(HaveLen(1))
@@ -591,52 +591,52 @@ var _ = Describe("Loader", Ordered, func() {
 	})
 
 	It("can fetch DeploymentTargetClaim for environment", func() {
-		dtcls, err := loader.GetDeploymentTargetClaimForEnvironment(k8sClient, ctx, hasEnv)
+		dtcls, err := loader.GetDeploymentTargetClaimForEnvironment(ctx, k8sClient, hasEnv)
 		Expect(err).To(BeNil())
 		Expect(dtcls.Name).To(Equal(deploymentTargetClaim.Name))
 	})
 
 	It("can fetch DeploymentTarget for DeploymentTargetClaim", func() {
-		dt, err := loader.GetDeploymentTargetForDeploymentTargetClaim(k8sClient, ctx, deploymentTargetClaim)
+		dt, err := loader.GetDeploymentTargetForDeploymentTargetClaim(ctx, k8sClient, deploymentTargetClaim)
 		Expect(err).To(BeNil())
 		Expect(dt.Name).To(Equal(deploymentTarget.Name))
 	})
 
 	It("can snapshotEnvironmentBinding for application and environment", func() {
-		binding, err := loader.FindExistingSnapshotEnvironmentBinding(k8sClient, ctx, hasApp, hasEnv)
+		binding, err := loader.FindExistingSnapshotEnvironmentBinding(ctx, k8sClient, hasApp, hasEnv)
 		Expect(err).To(BeNil())
 		Expect(binding.Name).To(Equal(hasBinding.Name))
 	})
 
 	It("ensures that all Snapshots for a given application can be found", func() {
-		snapshots, err := loader.GetAllSnapshots(k8sClient, ctx, hasApp)
+		snapshots, err := loader.GetAllSnapshots(ctx, k8sClient, hasApp)
 		Expect(err).To(BeNil())
 		Expect(*snapshots).To(HaveLen(1))
 	})
 
 	It("ensures the ReleasePlan can be gotten for Application", func() {
-		gottenReleasePlanItems, err := loader.GetAutoReleasePlansForApplication(k8sClient, ctx, hasApp)
+		gottenReleasePlanItems, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp)
 		Expect(err).To(BeNil())
 		Expect(gottenReleasePlanItems).NotTo(BeNil())
 
 	})
 
 	It("can get all environments for integrationTestScenario", func() {
-		environments, err := loader.GetAllEnvironmentsForScenario(k8sClient, ctx, integrationTestScenario)
+		environments, err := loader.GetAllEnvironmentsForScenario(ctx, k8sClient, integrationTestScenario)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(*environments).To(HaveLen(1))
 		Expect((*environments)[0].Name).To(Equal(hasEnv.Name))
 	})
 
 	It("can get all environments for integrationTestScenario", func() {
-		environments, err := loader.GetAllEnvironmentsForScenario(k8sClient, ctx, integrationTestScenario)
+		environments, err := loader.GetAllEnvironmentsForScenario(ctx, k8sClient, integrationTestScenario)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(*environments).To(HaveLen(1))
 		Expect((*environments)[0].Name).To(Equal(hasEnv.Name))
 	})
 
 	It("can get all TaskRuns present in the cluster that are associated with the given pipelineRun", func() {
-		taskRuns, err := loader.GetAllTaskRunsWithMatchingPipelineRunLabel(k8sClient, ctx, buildPipelineRun)
+		taskRuns, err := loader.GetAllTaskRunsWithMatchingPipelineRunLabel(ctx, k8sClient, buildPipelineRun)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(*taskRuns).To(HaveLen(1))
 		Expect((*taskRuns)[0].Name).To(Equal(taskRunSample.Name))
@@ -676,7 +676,7 @@ var _ = Describe("Loader", Ordered, func() {
 
 		It("ensures the auto-release plans for application are returned correctly when the auto-release label is set to true", func() {
 			// Get auto-release plans for application
-			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(k8sClient, ctx, hasApp)
+			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp)
 			Expect(err).To(BeNil())
 			Expect(autoReleasePlans).ToNot(BeNil())
 			Expect(*autoReleasePlans).To(HaveLen(1))
@@ -716,7 +716,7 @@ var _ = Describe("Loader", Ordered, func() {
 
 		It("ensures the auto-release plans for application are returned correctly when the auto-release label is missing", func() {
 			// Get auto-release plans for application
-			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(k8sClient, ctx, hasApp)
+			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp)
 			Expect(err).To(BeNil())
 			Expect(autoReleasePlans).ToNot(BeNil())
 			Expect(*autoReleasePlans).To(HaveLen(1))
@@ -759,14 +759,14 @@ var _ = Describe("Loader", Ordered, func() {
 
 		It("ensures the auto-release plans for application are returned correctly when the auto-release label is set to false", func() {
 			// Get auto-release plans for application
-			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(k8sClient, ctx, hasApp)
+			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp)
 			Expect(err).To(BeNil())
 			Expect(autoReleasePlans).ToNot(BeNil())
 			Expect(*autoReleasePlans).To(BeEmpty())
 		})
 
 		It("Can fetch integration test scenario", func() {
-			fetchedScenario, err := loader.GetScenario(k8sClient, ctx, integrationTestScenario.Name, integrationTestScenario.Namespace)
+			fetchedScenario, err := loader.GetScenario(ctx, k8sClient, integrationTestScenario.Name, integrationTestScenario.Namespace)
 			Expect(err).To(Succeed())
 			Expect(fetchedScenario.Name).To(Equal(integrationTestScenario.Name))
 			Expect(fetchedScenario.Namespace).To(Equal(integrationTestScenario.Namespace))
@@ -774,7 +774,7 @@ var _ = Describe("Loader", Ordered, func() {
 		})
 
 		It("Can fetch pipelineRun", func() {
-			fetchedBuildPipelineRun, err := loader.GetPipelineRun(k8sClient, ctx, buildPipelineRun.Name, buildPipelineRun.Namespace)
+			fetchedBuildPipelineRun, err := loader.GetPipelineRun(ctx, k8sClient, buildPipelineRun.Name, buildPipelineRun.Namespace)
 			Expect(err).To(Succeed())
 			Expect(fetchedBuildPipelineRun.Name).To(Equal(buildPipelineRun.Name))
 			Expect(fetchedBuildPipelineRun.Namespace).To(Equal(buildPipelineRun.Namespace))

--- a/status/status.go
+++ b/status/status.go
@@ -326,7 +326,7 @@ func (s *Status) generateText(ctx context.Context, integrationTestStatusDetail i
 			return "", fmt.Errorf("error while getting the pipelineRun %s: %w", pipelineRunName, err)
 		}
 
-		taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(s.client, ctx, pipelineRun)
+		taskRuns, err := helpers.GetAllChildTaskRunsForPipelineRun(ctx, s.client, pipelineRun)
 		if err != nil {
 			return "", fmt.Errorf("error while getting all child taskRuns from pipelineRun %s: %w", pipelineRunName, err)
 		}

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -339,14 +339,14 @@ var _ = Describe("Integration pipeline", func() {
 
 			// calling RemoveFinalizerFromPipelineRun() when the PipelineRun contains the finalizer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			Expect(helpers.RemoveFinalizerFromPipelineRun(k8sClient, log, ctx, &newIntegrationPipelineRun.PipelineRun, helpers.IntegrationPipelineRunFinalizer)).To(BeNil())
+			Expect(helpers.RemoveFinalizerFromPipelineRun(ctx, k8sClient, log, &newIntegrationPipelineRun.PipelineRun, helpers.IntegrationPipelineRunFinalizer)).To(BeNil())
 			Expect(newIntegrationPipelineRun.Finalizers).To(BeNil())
 			Expect(buf.String()).Should(ContainSubstring(logEntry))
 
 			// calling RemoveFinalizerFromPipelineRun() when the PipelineRun doesn't contain the finalizer
 			buf = bytes.Buffer{}
 			log = helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			Expect(helpers.RemoveFinalizerFromPipelineRun(k8sClient, log, ctx, &newIntegrationPipelineRun.PipelineRun, helpers.IntegrationPipelineRunFinalizer)).To(BeNil())
+			Expect(helpers.RemoveFinalizerFromPipelineRun(ctx, k8sClient, log, &newIntegrationPipelineRun.PipelineRun, helpers.IntegrationPipelineRunFinalizer)).To(BeNil())
 			Expect(newIntegrationPipelineRun.Finalizers).To(BeNil())
 			Expect(buf.String()).ShouldNot(ContainSubstring(logEntry))
 		})

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -339,14 +339,14 @@ var _ = Describe("Integration pipeline", func() {
 
 			// calling RemoveFinalizerFromPipelineRun() when the PipelineRun contains the finalizer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			Expect(helpers.RemoveFinalizerFromPipelineRun(ctx, k8sClient, log, &newIntegrationPipelineRun.PipelineRun, helpers.IntegrationPipelineRunFinalizer)).To(BeNil())
+			Expect(helpers.RemoveFinalizerFromPipelineRun(ctx, k8sClient, log, &newIntegrationPipelineRun.PipelineRun, helpers.IntegrationPipelineRunFinalizer)).To(Succeed())
 			Expect(newIntegrationPipelineRun.Finalizers).To(BeNil())
 			Expect(buf.String()).Should(ContainSubstring(logEntry))
 
 			// calling RemoveFinalizerFromPipelineRun() when the PipelineRun doesn't contain the finalizer
 			buf = bytes.Buffer{}
 			log = helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			Expect(helpers.RemoveFinalizerFromPipelineRun(ctx, k8sClient, log, &newIntegrationPipelineRun.PipelineRun, helpers.IntegrationPipelineRunFinalizer)).To(BeNil())
+			Expect(helpers.RemoveFinalizerFromPipelineRun(ctx, k8sClient, log, &newIntegrationPipelineRun.PipelineRun, helpers.IntegrationPipelineRunFinalizer)).To(Succeed())
 			Expect(newIntegrationPipelineRun.Finalizers).To(BeNil())
 			Expect(buf.String()).ShouldNot(ContainSubstring(logEntry))
 		})


### PR DESCRIPTION
Refactor params in a way that context is first param

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
