### PR TITLE
fix: missing CRDs due to vendoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,15 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+.PHONY: download-crds
+download-crds: ## Vendoring doesn't fetch CRDs yaml files due pruning of dependencies, for testing we need to download full content of these modules with CRDs
+	# Ugly hack to download CRDs for tests, better solution is welcome
+	go mod download github.com/redhat-appstudio/application-api
+	go mod download github.com/redhat-appstudio/release-service
+	go mod download github.com/tektoncd/pipeline
+
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
+test: manifests generate fmt vet envtest download-crds ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build


### PR DESCRIPTION
In tests we need CRDs from other projects, however go mod vendor has aggresive pruning and vendor module doesn't contain CRDs.

Thus as a workaround, we have to manually fetch some modules to have all content available in tests.

https://github.com/golang/go/issues/26366

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
