### PR TITLE
fix(STONE-841-pm): serve v1alpha1 back

### DIFF
--- a/api/v1alpha1/integrationtestscenario_types.go
+++ b/api/v1alpha1/integrationtestscenario_types.go
@@ -66,7 +66,6 @@ type TestContext struct {
 	Description string `json:"description,omitempty"`
 }
 
-// +kubebuilder:unservedversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Application",type=string,JSONPath=`.spec.application`

--- a/config/crd/bases/appstudio.redhat.com_integrationtestscenarios.yaml
+++ b/config/crd/bases/appstudio.redhat.com_integrationtestscenarios.yaml
@@ -225,7 +225,7 @@ spec:
             - conditions
             type: object
         type: object
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}


### PR DESCRIPTION
* conversion.go is clueless without v1alpha1 version
* even if its not part of the webhook conversion

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)

This change fixes occurence of issue we currently have on staging:
`{"level":"error","ts":"2024-05-03T12:28:50Z","logger":"conversion-webhook","caller":"conversion/conversion.go:74","msg":"failed to convert","request":"e705f104-59f4-470b-b5bb-0599309ed191","error":"no kind \"IntegrationTestScenario\" is registered for version \"appstudio.redhat.com/v1alpha1\" in scheme \"go/pkg/mod/k8s.io/apimachinery@v0.29.4/pkg/runtime/scheme.go:100\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*webhook).ServeHTTP\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/webhook/conversion/conversion.go:74\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1\n\t/opt/app-root/src/go/pkg/mod/github.com/prometheus/client_golang@v1.19.0/prometheus/promhttp/instrument_server.go:60\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/lib/golang/src/net/http/server.go:2122\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1\n\t/opt/app-root/src/go/pkg/mod/github.com/prometheus/client_golang@v1.19.0/prometheus/promhttp/instrument_server.go:147\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/lib/golang/src/net/http/server.go:2122\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2\n\t/opt/app-root/src/go/pkg/mod/github.com/prometheus/client_golang@v1.19.0/prometheus/promhttp/instrument_server.go:109\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/lib/golang/src/net/http/server.go:2122\nnet/http.(*ServeMux).ServeHTTP\n\t/usr/lib/golang/src/net/http/server.go:2500\nnet/http.serverHandler.ServeHTTP\n\t/usr/lib/golang/src/net/http/server.go:2936\nnet/http.(*conn).serve\n\t/usr/lib/golang/src/net/http/server.go:1995"} `