### PR TITLE
fix(STONEINTG-928): conversion of v1beta1 params

### DIFF
--- a/api/v1beta1/integrationtestscenario_conversion.go
+++ b/api/v1beta1/integrationtestscenario_conversion.go
@@ -58,9 +58,13 @@ func (src *IntegrationTestScenario) ConvertTo(dstRaw conversion.Hub) error {
 
 	if src.Spec.ResolverRef.Params != nil {
 		for _, par := range src.Spec.ResolverRef.Params {
-			dst.Spec.ResolverRef.Params = append(dst.Spec.ResolverRef.Params, v1beta2.ResolverParameter(par))
+			dst.Spec.ResolverRef.Params = append(dst.Spec.ResolverRef.Params, v1beta2.ResolverParameter{
+				Name:  par.Name,
+				Value: par.Value,
+			})
 		}
 	}
+
 	return nil
 }
 
@@ -83,12 +87,15 @@ func (dst *IntegrationTestScenario) ConvertFrom(srcRaw conversion.Hub) error {
 	if src.Status.Conditions != nil {
 		dst.Status.Conditions = append(dst.Status.Conditions, src.Status.Conditions...)
 	}
-	src.Spec.ResolverRef = v1beta2.ResolverRef{
-		Resolver: dst.Spec.ResolverRef.Resolver,
+	dst.Spec.ResolverRef = ResolverRef{
+		Resolver: src.Spec.ResolverRef.Resolver,
 	}
 	if src.Spec.ResolverRef.Params != nil {
 		for _, par := range src.Spec.ResolverRef.Params {
-			dst.Spec.ResolverRef.Params = append(dst.Spec.ResolverRef.Params, ResolverParameter(par))
+			dst.Spec.ResolverRef.Params = append(dst.Spec.ResolverRef.Params, ResolverParameter{
+				Name:  par.Name,
+				Value: par.Value,
+			})
 		}
 	}
 


### PR DESCRIPTION
* The conversion was copying the empty destination resolver
  info instead of the source data

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
