### PR TITLE
fix: glibc CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1161
 COPY --from=builder /opt/app-root/src/manager /
 COPY --from=builder /opt/app-root/src/snapshotgc /
 
+# workaround, fixing glibc CVE which prevents us to release; remove this when new parent image is released
+RUN microdnf upgrade -y glibc && microdnf clean all
+
 # It is mandatory to set these labels
 LABEL name="integration-service"
 LABEL com.redhat.component="konflux-integration-service"


### PR DESCRIPTION
Upgrading glibc manually because parent image doesn't contain fix yet

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
