### PR TITLE
fix(STONE-828): get component before add finalizer

### DIFF
--- a/internal/controller/component/component_controller.go
+++ b/internal/controller/component/component_controller.go
@@ -72,7 +72,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	application, err = loader.GetApplicationFromComponent(ctx, r.Client, component)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			if err := helpers.RemoveFinalizerFromComponent(ctx, r.Client, logger, component, helpers.ComponentFinalizer); err != nil {
+			if isComponentMarkedForDeletion(component) {
+				component, err = loader.GetComponent(ctx, r.Client, component.Name, component.Namespace)
+				if err := helpers.RemoveFinalizerFromComponent(ctx, r.Client, logger, component, helpers.ComponentFinalizer); err != nil {
+					return ctrl.Result{}, err
+				}
+			} else {
 				return ctrl.Result{}, err
 			}
 		}


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)

Since the issue is still happening (less but still), I think it could help to get the component even before we try to add finalizer to the component itself.